### PR TITLE
iOS LazyImage + SVG

### DIFF
--- a/iosHyperskillApp/Podfile
+++ b/iosHyperskillApp/Podfile
@@ -29,6 +29,10 @@ target 'iosHyperskillApp' do
 
   # CodeEditor
   pod 'Highlightr', :git => 'https://github.com/raspu/Highlightr.git', :branch => 'master'
+
+  # LazyImage with SVG support
+  pod 'NukeUI', :git => 'https://github.com/kean/NukeUI.git', :tag => '0.8.3'
+  pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :branch => '3.x'
 end
 
 post_install do |installer|

--- a/iosHyperskillApp/Podfile.lock
+++ b/iosHyperskillApp/Podfile.lock
@@ -6,6 +6,10 @@ PODS:
   - AppAuth/ExternalUserAgent (1.5.0):
     - AppAuth/Core
   - Atributika (4.10.1)
+  - CocoaLumberjack (3.7.4):
+    - CocoaLumberjack/Core (= 3.7.4)
+  - CocoaLumberjack/Core (3.7.4)
+  - Gifu (3.3.1)
   - GoogleSignIn (6.1.0):
     - AppAuth (~> 1.4)
     - GTMAppAuth (~> 1.0)
@@ -17,6 +21,10 @@ PODS:
   - Highlightr (2.1.0)
   - IQKeyboardManagerSwift (6.5.9)
   - Kanna (5.2.7)
+  - Nuke (10.7.1)
+  - NukeUI (0.8.1):
+    - Gifu (~> 3.0)
+    - Nuke (~> 10.5)
   - PanModal (1.2.7)
   - Sentry (7.13.0):
     - Sentry/Core (= 7.13.0)
@@ -25,6 +33,8 @@ PODS:
   - SkeletonUI (1.0.7)
   - SnapKit (5.6.0)
   - STRegex (2.1.1)
+  - SVGKit (3.1.0):
+    - CocoaLumberjack (~> 3.0)
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.47.0)
 
@@ -34,12 +44,14 @@ DEPENDENCIES:
   - Highlightr (from `https://github.com/raspu/Highlightr.git`, branch `master`)
   - IQKeyboardManagerSwift (= 6.5.9)
   - Kanna (= 5.2.7)
+  - NukeUI (from `https://github.com/kean/NukeUI.git`, tag `0.8.3`)
   - PanModal (from `https://github.com/ivan-magda/PanModal.git`, branch `remove-presenting-appearance-transitions`)
   - Sentry (= 7.13.0)
   - shared (from `../shared`)
   - SkeletonUI (= 1.0.7)
   - SnapKit (= 5.6.0)
   - STRegex (= 2.1.1)
+  - SVGKit (from `https://github.com/SVGKit/SVGKit.git`, branch `3.x`)
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (= 0.47.0)
 
@@ -47,11 +59,14 @@ SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - AppAuth
     - Atributika
+    - CocoaLumberjack
+    - Gifu
     - GoogleSignIn
     - GTMAppAuth
     - GTMSessionFetcher
     - IQKeyboardManagerSwift
     - Kanna
+    - Nuke
     - Sentry
     - SkeletonUI
     - SnapKit
@@ -63,38 +78,55 @@ EXTERNAL SOURCES:
   Highlightr:
     :branch: master
     :git: https://github.com/raspu/Highlightr.git
+  NukeUI:
+    :git: https://github.com/kean/NukeUI.git
+    :tag: 0.8.3
   PanModal:
     :branch: remove-presenting-appearance-transitions
     :git: https://github.com/ivan-magda/PanModal.git
   shared:
     :path: "../shared"
+  SVGKit:
+    :branch: 3.x
+    :git: https://github.com/SVGKit/SVGKit.git
 
 CHECKOUT OPTIONS:
   Highlightr:
     :commit: 048188df13e145657554a53a24882df5461fc96a
     :git: https://github.com/raspu/Highlightr.git
+  NukeUI:
+    :git: https://github.com/kean/NukeUI.git
+    :tag: 0.8.3
   PanModal:
     :commit: 32fc8b5868b0254a2025c9c01b24c0e4b3fe537d
     :git: https://github.com/ivan-magda/PanModal.git
+  SVGKit:
+    :commit: 451e057db1a6b4166a3a75f8e25fa67f05a044b5
+    :git: https://github.com/SVGKit/SVGKit.git
 
 SPEC CHECKSUMS:
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
   Atributika: 47e778507cfb3cd2c996278b0285221a62e97d71
+  CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
+  Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
   GoogleSignIn: c90b5bec45e780f54c6a8e1e3c182a86e3dda69d
   GTMAppAuth: 987526d41b07efb1bedda5e936fe0cb718a03113
   GTMSessionFetcher: 4577a4cc914a5a07c40a8a0ad0acc22080418c2d
   Highlightr: 683f05d5223cade533a78528a35c9f06e4caddf8
   IQKeyboardManagerSwift: 6e839c575c4aa1078d58a596e41244e77abe918f
   Kanna: 01cfbddc127f5ff0963692f285fcbc8a9d62d234
+  Nuke: 279f17a599fd1c83cf51de5e0e1f2db143a287b0
+  NukeUI: 3c7ec7b299dd99707afdc783b436f39768b4493b
   PanModal: 3e16ead1a907fb06f4df3f13492fd00149fa4974
   Sentry: c55b9f69091e58cc48adc3c25bbca908a480e08d
   shared: 57c23201ce62604481c21dfbabc812accac99edd
   SkeletonUI: 18fbcd8698480432852d7e30a65b8d5e138266f0
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
   STRegex: d49e88d0fe58538d3175fdd989bc1243b9be2a07
+  SVGKit: 3c8468aab0026048532a3b27a0c81cdd939f0649
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: d41cc46a2ae58ac6d9f26954bc89f1d72e71fdef
 
-PODFILE CHECKSUM: 168d4a65012d10058022447e154950869ed6ffb5
+PODFILE CHECKSUM: 49fd79088d9440b64e69ea2d37067ff93269d314
 
 COCOAPODS: 1.11.3

--- a/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
+++ b/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		2C225E48281A5B6800E8ABD2 /* SourcelessRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C225E47281A5B6800E8ABD2 /* SourcelessRouter.swift */; };
 		2C2452492847C27C00226702 /* Images+SystemNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2452482847C27C00226702 /* Images+SystemNames.swift */; };
 		2C25BFD52851F8F00036C689 /* UIColor+DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C25BFD42851F8F00036C689 /* UIColor+DesignSystem.swift */; };
+		2C27C77C28772F8A006A641A /* ImageDecoders+SVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C27C77B28772F8A006A641A /* ImageDecoders+SVG.swift */; };
+		2C27C77E28773042006A641A /* NukeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C27C77D28773042006A641A /* NukeManager.swift */; };
 		2C2D492E281151E100753F16 /* AuthCredentialsAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2D492D281151E100753F16 /* AuthCredentialsAssembly.swift */; };
 		2C2D4930281151EB00753F16 /* AuthCredentialsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2D492F281151EB00753F16 /* AuthCredentialsViewModel.swift */; };
 		2C2D4932281154CB00753F16 /* Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2D4931281154CB00753F16 /* Injection.swift */; };
@@ -308,6 +310,8 @@
 		2C225E47281A5B6800E8ABD2 /* SourcelessRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourcelessRouter.swift; sourceTree = "<group>"; };
 		2C2452482847C27C00226702 /* Images+SystemNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Images+SystemNames.swift"; sourceTree = "<group>"; };
 		2C25BFD42851F8F00036C689 /* UIColor+DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+DesignSystem.swift"; sourceTree = "<group>"; };
+		2C27C77B28772F8A006A641A /* ImageDecoders+SVG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageDecoders+SVG.swift"; sourceTree = "<group>"; };
+		2C27C77D28773042006A641A /* NukeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NukeManager.swift; sourceTree = "<group>"; };
 		2C2D492D281151E100753F16 /* AuthCredentialsAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCredentialsAssembly.swift; sourceTree = "<group>"; };
 		2C2D492F281151EB00753F16 /* AuthCredentialsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCredentialsViewModel.swift; sourceTree = "<group>"; };
 		2C2D4931281154CB00753F16 /* Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Injection.swift; sourceTree = "<group>"; };
@@ -795,6 +799,14 @@
 			path = Images;
 			sourceTree = "<group>";
 		};
+		2C27C77A28772F79006A641A /* Nuke */ = {
+			isa = PBXGroup;
+			children = (
+				2C27C77B28772F8A006A641A /* ImageDecoders+SVG.swift */,
+			);
+			path = Nuke;
+			sourceTree = "<group>";
+		};
 		2C2FF9CA285073340069C092 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
@@ -899,6 +911,7 @@
 			isa = PBXGroup;
 			children = (
 				2C42EFB127F2EA5000B4648B /* MokoResources */,
+				2C27C77A28772F79006A641A /* Nuke */,
 			);
 			path = ThirdParty;
 			sourceTree = "<group>";
@@ -1043,6 +1056,7 @@
 			children = (
 				E99D4CEC2826A37400B49D52 /* AppAppearance.swift */,
 				2C9CC1BC280920B5006604D7 /* KeyboardManager.swift */,
+				2C27C77D28773042006A641A /* NukeManager.swift */,
 				2C906CBD280E5D9C0079C594 /* ProgressHUD.swift */,
 				2C2FD61D28191EC0004E7AF6 /* SentryManager.swift */,
 			);
@@ -1745,6 +1759,7 @@
 				2CC4AAF1280DB513002276A0 /* WebOAuthService.swift in Sources */,
 				2CF43410281268A1002893CD /* String+Whitespaces.swift in Sources */,
 				2CF2DA3A27EC5B2D0055426D /* Assembly.swift in Sources */,
+				2C27C77C28772F8A006A641A /* ImageDecoders+SVG.swift in Sources */,
 				2C8E4FB42848CB980011ADFA /* StepQuizTableSelectColumnsColumnView.swift in Sources */,
 				2C863D932804279E0021EFED /* Require.swift in Sources */,
 				2C177EC32837B65500D841DB /* View+Frame.swift in Sources */,
@@ -1752,6 +1767,7 @@
 				2C2FD62428192123004E7AF6 /* BundlePropertyListDeserializer.swift in Sources */,
 				2C1F5879280D2D1300372A37 /* WebOAuthURLParser.swift in Sources */,
 				2C5B2A1D286595960097B270 /* CodeCompletionTableViewCell.swift in Sources */,
+				2C27C77E28773042006A641A /* NukeManager.swift in Sources */,
 				2C0DB91028645332001EA35E /* CodeEditorTheme.swift in Sources */,
 				2CCF3B5828004FC40075D12C /* UserAgentBuilder.swift in Sources */,
 				2C963BC52812D1A70036DD53 /* HomeView.swift in Sources */,

--- a/iosHyperskillApp/iosHyperskillApp/Sources/AppDelegate.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/AppDelegate.swift
@@ -24,6 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         SentryManager.configure()
         ProgressHUD.configure()
         KeyboardManager.configure()
+        NukeManager.registerCustomDecoders()
 
         return true
     }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Extensions/ThirdParty/Nuke/ImageDecoders+SVG.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Extensions/ThirdParty/Nuke/ImageDecoders+SVG.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Nuke
+import SVGKit
+
+extension ImageDecoders {
+    final class SVG: ImageDecoding {
+        var isAsynchronous: Bool { true }
+
+        func decode(_ data: Data) -> ImageContainer? {
+            guard let svgImage = SVGKImage(data: data) else {
+                return nil
+            }
+
+            return ImageContainer(image: svgImage.uiImage, type: .svg, data: data, userInfo: [:])
+        }
+
+        func decodePartiallyDownloadedData(_ data: Data) -> ImageContainer? { nil }
+    }
+}
+
+extension AssetType {
+    static let svg: AssetType = "org.hyperskill.svg"
+}

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Systems/NukeManager.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Systems/NukeManager.swift
@@ -1,0 +1,11 @@
+import Foundation
+import Nuke
+
+enum NukeManager {
+    static func registerCustomDecoders() {
+        ImageDecoderRegistry.shared.register { context in
+            let isSVG = context.urlResponse?.url?.absoluteString.hasSuffix(".svg") ?? false
+            return isSVG ? ImageDecoders.SVG() : nil
+        }
+    }
+}


### PR DESCRIPTION
**Reviewers**
- [x] @vladkash 

**Description**
- Adds support for lazy image loading via [NukeUI](https://github.com/kean/NukeUI)
- Supports SVG image rendering via [SVGKit](https://github.com/SVGKit/SVGKit)

Example usage:
```swift
LazyImage(source: "https://hyperskill.org/media/tracks/0580353297be4214ab9ed7be8ce75d3d/Kotlin.svg")
    .frame(width: 64, height: 64)
    .addBorder(color: Color(ColorPalette.onSurfaceAlpha12), cornerRadius: 128)
```
