### PR TITLE
ALTAPPS-258: iOS change global tintColor to primaryColor

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/AppDelegate.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
 
-        //AppAppearance.themeApplication()
+        AppAppearance.themeApplication(window: window.require())
         ApplicationThemeService.default.applyDefaultTheme()
 
         SentryManager.configure()

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Systems/AppAppearance.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Systems/AppAppearance.swift
@@ -1,23 +1,14 @@
 import UIKit
 
 enum AppAppearance {
-    static func themeApplication() {
-        self.themeNavigationBar()
+    static func themeApplication(window: UIWindow) {
+        window.tintColor = ColorPalette.primary
+        themeNavigationBar()
     }
 
     private static func themeNavigationBar() {
-        let coloredAppearance = UINavigationBarAppearance()
-        coloredAppearance.configureWithOpaqueBackground()
-
-        coloredAppearance.backgroundColor = ColorPalette.background
-
-        coloredAppearance.titleTextAttributes = [.foregroundColor: UIColor.primaryText]
-        coloredAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.primaryText]
-
-        UINavigationBar.appearance().standardAppearance = coloredAppearance
-        UINavigationBar.appearance().compactAppearance = coloredAppearance
-        UINavigationBar.appearance().scrollEdgeAppearance = coloredAppearance
-
-        UIBarButtonItem.appearance().tintColor = ColorPalette.onSurface.withAlphaComponent(0.6)
+        let textAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.primaryText]
+        UINavigationBar.appearance().titleTextAttributes = textAttributes
+        UINavigationBar.appearance().largeTitleTextAttributes = textAttributes
     }
 }


### PR DESCRIPTION
Task: [#ALTAPPS-258](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-258)

**Dependencies**
- !

**Reviewers**
- [ ] @

**Description**
- Changes global `tintColor` to `primaryColor` and themes navigation bar
