### PR TITLE
ALTAPPS-260: iOS add Confirm button for table single choice

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizTableSelectColumns/StepQuizTableSelectColumnsViewController.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizTableSelectColumns/StepQuizTableSelectColumnsViewController.swift
@@ -80,10 +80,6 @@ final class StepQuizTableSelectColumnsViewController: PanModalPresentableViewCon
 
     private func handleColumnsChanged(_ newColumns: Set<Int>) {
         self.selectedColumnsIDs = newColumns
-
-        if !self.isMultipleChoice {
-            self.finishColumnsSelection()
-        }
     }
 
     private func finishColumnsSelection() {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizTableSelectColumns/Views/StepQuizTableSelectColumnsColumnView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizTableSelectColumns/Views/StepQuizTableSelectColumnsColumnView.swift
@@ -36,11 +36,19 @@ struct StepQuizTableSelectColumnsColumnView: View {
     @ViewBuilder
     private func buildIndicator(isSelected: Binding<Bool>, onTap: @escaping () -> Void) -> some View {
         if isMultipleChoice {
-            CheckboxButton(isSelected: isSelected, onClick: onTap)
-                .frame(widthHeight: appearance.checkboxIndicatorWidthHeight)
+            CheckboxButton(
+                appearance: .init(backgroundUnselectedColor: .clear),
+                isSelected: isSelected,
+                onClick: onTap
+            )
+            .frame(widthHeight: appearance.checkboxIndicatorWidthHeight)
         } else {
-            RadioButton(isSelected: isSelected, onClick: onTap)
-                .frame(widthHeight: appearance.radioIndicatorWidthHeight)
+            RadioButton(
+                appearance: .init(indicatorUnselectedColor: .clear, backgroundColor: .clear),
+                isSelected: isSelected,
+                onClick: onTap
+            )
+            .frame(widthHeight: appearance.radioIndicatorWidthHeight)
         }
     }
 }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizTableSelectColumns/Views/StepQuizTableSelectColumnsView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizTableSelectColumns/Views/StepQuizTableSelectColumnsView.swift
@@ -70,11 +70,9 @@ struct StepQuizTableSelectColumnsView: View {
                     }
                 }
 
-                if isMultipleChoice {
-                    Button(Strings.StepQuizTable.confirmButton, action: onConfirmTapped)
-                        .buttonStyle(RoundedRectangleButtonStyle(style: .violet))
-                        .padding(.vertical)
-                }
+                Button(Strings.StepQuizTable.confirmButton, action: onConfirmTapped)
+                    .buttonStyle(RoundedRectangleButtonStyle(style: .violet))
+                    .padding(.vertical)
 
                 Spacer()
             }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Views/CheckboxButton.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Views/CheckboxButton.swift
@@ -46,6 +46,7 @@ struct CheckboxButton: View {
                             width: proxy.size.width * appearance.checkmarkSizeRatio,
                             height: proxy.size.height * appearance.checkmarkSizeRatio
                         )
+                        .opacity(isSelected ? 1 : 0)
                 )
                 .addBorder(
                     color: isSelected ? appearance.borderSelectedColor : appearance.borderUnselectedColor,


### PR DESCRIPTION
Task: [#ALTAPPS-260](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-260)

**Dependencies**
- !

**Reviewers**
- [x] @vladkash 

**Description**
- Adds `Confirm` button for table single choice
- Fixes indicators colors in dark mode
