### PR TITLE
ALTAPPS-255: iOS reload home screen after entering app from background

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
@@ -1,13 +1,48 @@
 import Foundation
 import shared
+import UIKit
 
 final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage, HomeFeatureActionViewAction> {
+    private var wasInBackground = false
+
+    override init(feature: Presentation_reduxFeature) {
+        super.init(feature: feature)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleApplicationDidBecomeActive(_:)),
+            name: UIApplication.didBecomeActiveNotification,
+            object: UIApplication.shared
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleApplicationDidEnterBackground(_:)),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: UIApplication.shared
+        )
+    }
+
     func loadContent(forceUpdate: Bool = false) {
         onNewMessage(HomeFeatureMessageInit(forceUpdate: forceUpdate))
     }
 
     func logViewedEvent() {
         onNewMessage(HomeFeatureMessageHomeViewedEventMessage())
+    }
+
+    // MARK: Private API
+
+    @objc
+    private func handleApplicationDidBecomeActive(_: NSNotification) {
+        if wasInBackground {
+            wasInBackground = false
+            onNewMessage(HomeFeatureMessageInit(forceUpdate: true))
+        }
+    }
+
+    @objc
+    private func handleApplicationDidEnterBackground(_: NSNotification) {
+        wasInBackground = true
     }
 }
 

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
@@ -1,4 +1,3 @@
-import Foundation
 import shared
 import UIKit
 
@@ -10,13 +9,13 @@ final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage
 
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(handleApplicationDidBecomeActive(_:)),
+            selector: #selector(handleApplicationDidBecomeActive),
             name: UIApplication.didBecomeActiveNotification,
             object: UIApplication.shared
         )
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(handleApplicationDidEnterBackground(_:)),
+            selector: #selector(handleApplicationDidEnterBackground),
             name: UIApplication.didEnterBackgroundNotification,
             object: UIApplication.shared
         )
@@ -33,7 +32,7 @@ final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage
     // MARK: Private API
 
     @objc
-    private func handleApplicationDidBecomeActive(_: NSNotification) {
+    private func handleApplicationDidBecomeActive() {
         if wasInBackground {
             wasInBackground = false
             onNewMessage(HomeFeatureMessageInit(forceUpdate: true))
@@ -41,7 +40,7 @@ final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage
     }
 
     @objc
-    private func handleApplicationDidEnterBackground(_: NSNotification) {
+    private func handleApplicationDidEnterBackground() {
         wasInBackground = true
     }
 }


### PR DESCRIPTION
Task: [#ALTAPPS-255](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-255)

**Dependencies**
- !

**Reviewers**
- [x] @ivan-magda 

**Description**
- Add observing active and background notifications in HomeViewModel
