### PR TITLE
ALTAPPS-294: iOS logout infinite loading fix

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile_settings/injection/ProfileSettingsComponentImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile_settings/injection/ProfileSettingsComponentImpl.kt
@@ -26,6 +26,7 @@ class ProfileSettingsComponentImpl(private val appGraph: AppGraph) : ProfileSett
             appGraph.buildProfileDataComponent().profileInteractor,
             appGraph.analyticComponent.analyticInteractor,
             appGraph.networkComponent.authorizationFlow,
+            appGraph.authComponent.authInteractor,
             appGraph.commonComponent.platform,
             appGraph.commonComponent.userAgentInfo
         )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile_settings/injection/ProfileSettingsFeatureBuilder.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile_settings/injection/ProfileSettingsFeatureBuilder.kt
@@ -3,6 +3,7 @@ package org.hyperskill.app.profile_settings.injection
 import kotlinx.coroutines.flow.MutableSharedFlow
 import org.hyperskill.app.Platform
 import org.hyperskill.app.analytic.domain.interactor.AnalyticInteractor
+import org.hyperskill.app.auth.domain.interactor.AuthInteractor
 import org.hyperskill.app.auth.domain.model.UserDeauthorized
 import org.hyperskill.app.core.presentation.ActionDispatcherOptions
 import org.hyperskill.app.core.remote.UserAgentInfo
@@ -23,6 +24,7 @@ object ProfileSettingsFeatureBuilder {
         profileInteractor: ProfileInteractor,
         analyticInteractor: AnalyticInteractor,
         authorizationFlow: MutableSharedFlow<UserDeauthorized>,
+        authInteractor: AuthInteractor,
         platform: Platform,
         userAgentInfo: UserAgentInfo
     ): Feature<State, Message, Action> {
@@ -33,6 +35,7 @@ object ProfileSettingsFeatureBuilder {
             profileInteractor,
             analyticInteractor,
             authorizationFlow,
+            authInteractor,
             platform,
             userAgentInfo
         )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile_settings/presentation/ProfileSettingsActionDispatcher.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile_settings/presentation/ProfileSettingsActionDispatcher.kt
@@ -3,6 +3,7 @@ package org.hyperskill.app.profile_settings.presentation
 import kotlinx.coroutines.flow.MutableSharedFlow
 import org.hyperskill.app.Platform
 import org.hyperskill.app.analytic.domain.interactor.AnalyticInteractor
+import org.hyperskill.app.auth.domain.interactor.AuthInteractor
 import org.hyperskill.app.auth.domain.model.UserDeauthorized
 import org.hyperskill.app.config.BuildKonfig
 import org.hyperskill.app.core.presentation.ActionDispatcherOptions
@@ -20,6 +21,7 @@ class ProfileSettingsActionDispatcher(
     private val profileInteractor: ProfileInteractor,
     private val analyticInteractor: AnalyticInteractor,
     private val authorizationFlow: MutableSharedFlow<UserDeauthorized>,
+    private val authInteractor: AuthInteractor,
     private val platform: Platform,
     private val userAgentInfo: UserAgentInfo
 ) : CoroutineActionDispatcher<Action, Message>(config.createConfig()) {
@@ -32,6 +34,7 @@ class ProfileSettingsActionDispatcher(
             is Action.ChangeTheme ->
                 profileSettingsInteractor.changeTheme(action.theme)
             is Action.Logout -> {
+                authInteractor.clearCache()
                 profileInteractor.clearCache()
                 authorizationFlow.tryEmit(UserDeauthorized)
             }


### PR DESCRIPTION
Task: [#ALTAPPS-294](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-294)

**Dependencies**
- !

**Reviewers**
- [ ] @ivan-magda 

**Description**
- Add clearing auth cache before emiting UserDeauthorized
