### PR TITLE
ALTAPPS-321: iOS add App Uses Non-Exempt Encryption key for AppStore build uploads

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Info.plist
+++ b/iosHyperskillApp/iosHyperskillApp/Info.plist
@@ -61,5 +61,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Task: [#ALTAPPS-321](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-321)

**Reviewers**
- [ ] @

**Description**
- Adds `ITSAppUsesNonExemptEncryption` key