### PR TITLE
ALTAPPS-392: Shared, iOS setup moko-kswift

### DIFF
--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -25,14 +25,6 @@ runs:
       uses: maxim-lobanov/setup-xcode@v1.5.1
       with:
         xcode-version: '14.0.1'
-    
-    - name: Generate Hyperskill-Mobile_shared.swift
-      run: |
-        echo "$(pwd)"
-        ls iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift
-        touch iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Hyperskill-Mobile_shared.swift
-        ls iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift
-      shell: bash
 
     - name: Homebrew install git-crypt
       run: brew install git-crypt
@@ -98,7 +90,12 @@ runs:
         key: ${{ runner.os }}-kotlin-native-compiler-${{ hashFiles('gradle/libs.versions.toml') }}
         restore-keys: |
           ${{ runner.os }}-kotlin-native-compiler-
-    
+
+    - name: Generate Hyperskill-Mobile_shared.swift
+      run: |
+        touch iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Hyperskill-Mobile_shared.swift
+      shell: bash
+
     # Fix Cocoapods not being able to access the shared framework file
     - name: Fix Cocoapods generateDummyFramework
       run: ./gradlew generateDummyFramework

--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -25,7 +25,15 @@ runs:
       uses: maxim-lobanov/setup-xcode@v1.5.1
       with:
         xcode-version: '14.0.1'
-        
+    
+    - name: Generate Hyperskill-Mobile_shared.swift
+      run: |
+        echo "$(pwd)"
+        ls iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift
+        touch iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Hyperskill-Mobile_shared.swift
+        ls iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift
+      shell: bash
+
     - name: Homebrew install git-crypt
       run: brew install git-crypt
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ iosHyperskillApp/.build/
 
 iosHyperskillApp/.idea/
 
+## moko-kswift
+iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Hyperskill-Mobile_shared.swift
+
 ## CocoaPods
 iosHyperskillApp/Pods/
 

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/home/view/ui/fragment/HomeFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/home/view/ui/fragment/HomeFragment.kt
@@ -46,7 +46,7 @@ class HomeFragment :
         object : DefaultLifecycleObserver {
             override fun onResume(owner: LifecycleOwner) {
                 super.onResume(owner)
-                homeViewModel.onNewMessage(HomeFeature.Message.Init(forceUpdate = true))
+                homeViewModel.onNewMessage(HomeFeature.Message.Initialize(forceUpdate = true))
             }
         }
 
@@ -61,7 +61,7 @@ class HomeFragment :
         initViewStateDelegate()
 
         viewBinding.homeScreenError.tryAgain.setOnClickListener {
-            homeViewModel.onNewMessage(HomeFeature.Message.Init(forceUpdate = false))
+            homeViewModel.onNewMessage(HomeFeature.Message.Initialize(forceUpdate = false))
         }
 
         viewBinding.homeScreenKeepLearningInWebButton.setOnClickListener {
@@ -83,7 +83,7 @@ class HomeFragment :
 //            }
 //        }
 
-        homeViewModel.onNewMessage(HomeFeature.Message.Init(forceUpdate = false))
+        homeViewModel.onNewMessage(HomeFeature.Message.Initialize(forceUpdate = false))
         homeViewModel.onNewMessage(HomeFeature.Message.ViewedEventMessage)
     }
 

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/main/view/ui/activity/MainActivity.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/main/view/ui/activity/MainActivity.kt
@@ -71,10 +71,10 @@ class MainActivity :
         viewBinding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(viewBinding.root)
         initViewStateDelegate()
-        mainViewModelProvider.onNewMessage(AppFeature.Message.Init(forceUpdate = false))
+        mainViewModelProvider.onNewMessage(AppFeature.Message.Initialize(forceUpdate = false))
 
         viewBinding.mainError.tryAgain.setOnClickListener {
-            mainViewModelProvider.onNewMessage(AppFeature.Message.Init(forceUpdate = true))
+            mainViewModelProvider.onNewMessage(AppFeature.Message.Initialize(forceUpdate = true))
         }
 
         lifecycleScope.launch {

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/onboarding/fragment/OnboardingFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/onboarding/fragment/OnboardingFragment.kt
@@ -54,7 +54,7 @@ class OnboardingFragment :
             requireRouter().navigateTo(PlaceholderNewUserScreen)
         }
 
-        onboardingViewModel.onNewMessage(OnboardingFeature.Message.Init)
+        onboardingViewModel.onNewMessage(OnboardingFeature.Message.Initialize)
         onboardingViewModel.onNewMessage(OnboardingFeature.Message.ViewedEventMessage)
     }
 

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/profile/view/fragment/ProfileFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/profile/view/fragment/ProfileFragment.kt
@@ -76,7 +76,7 @@ class ProfileFragment :
         super.onViewCreated(view, savedInstanceState)
         initViewStateDelegate()
         viewBinding.profileError.tryAgain.setOnClickListener {
-            profileViewModel.onNewMessage(ProfileFeature.Message.Init(profileId = profileId, forceUpdate = true, isInitCurrent = isInitCurrent))
+            profileViewModel.onNewMessage(ProfileFeature.Message.Initialize(profileId = profileId, forceUpdate = true, isInitCurrent = isInitCurrent))
         }
 
         viewBinding.profileSettingsButton.setOnClickListener {
@@ -86,7 +86,7 @@ class ProfileFragment :
                 .showIfNotExists(childFragmentManager, ProfileSettingsDialogFragment.TAG)
         }
 
-        profileViewModel.onNewMessage(ProfileFeature.Message.Init(profileId = profileId, isInitCurrent = isInitCurrent))
+        profileViewModel.onNewMessage(ProfileFeature.Message.Initialize(profileId = profileId, isInitCurrent = isInitCurrent))
         profileViewModel.onNewMessage(ProfileFeature.Message.ViewedEventMessage)
     }
 

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step/view/fragment/StepFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step/view/fragment/StepFragment.kt
@@ -46,9 +46,9 @@ class StepFragment : Fragment(R.layout.fragment_step), ReduxView<StepFeature.Sta
         super.onViewCreated(view, savedInstanceState)
         initViewStateDelegate()
         viewBinding.stepError.tryAgain.setOnClickListener {
-            stepViewModel.onNewMessage(StepFeature.Message.Init(stepId, forceUpdate = true))
+            stepViewModel.onNewMessage(StepFeature.Message.Initialize(stepId, forceUpdate = true))
         }
-        stepViewModel.onNewMessage(StepFeature.Message.Init(stepId))
+        stepViewModel.onNewMessage(StepFeature.Message.Initialize(stepId))
     }
 
     private fun injectComponent() {

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/track/view/fragment/TrackFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/track/view/fragment/TrackFragment.kt
@@ -55,10 +55,10 @@ class TrackFragment :
         super.onViewCreated(view, savedInstanceState)
         initViewStateDelegate()
         viewBinding.trackError.tryAgain.setOnClickListener {
-            trackViewModel.onNewMessage(TrackFeature.Message.Init(forceUpdate = true))
+            trackViewModel.onNewMessage(TrackFeature.Message.Initialize(forceUpdate = true))
         }
 
-        trackViewModel.onNewMessage(TrackFeature.Message.Init())
+        trackViewModel.onNewMessage(TrackFeature.Message.Initialize())
         trackViewModel.onNewMessage(TrackFeature.Message.ViewedEventMessage)
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ buildscript {
         classpath(libs.plugin.gradleVersionUpdates)
         classpath(libs.plugin.buildKonfig)
         classpath(libs.plugin.mokoResources)
+        classpath(libs.plugin.mokoKswift)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ kotlin = '1.6.21'
 kotlinCoroutines = { strictly = '1.6.0-native-mt' }
 ktor = '2.0.0'
 mokoResources = "0.20.1"
+mokoKswift = "0.6.1"
 ktlintRules = '1.0.0'
 adapters = '1.1.1'
 sentry = '5.7.3'
@@ -20,6 +21,7 @@ plugin-ktlint = { module = "org.jlleitschuh.gradle:ktlint-gradle", version = "10
 plugin-gradleVersionUpdates = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.39.0" }
 plugin-buildKonfig = { module = "com.codingfeline.buildkonfig:buildkonfig-gradle-plugin", version = "0.13.3" }
 plugin-mokoResources = { module = "dev.icerock.moko:resources-generator", version.ref = "mokoResources" }
+plugin-mokoKswift = { module = "dev.icerock.moko:kswift-gradle-plugin", version.ref = "mokoKswift" }
 
 kotlin-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.3.2" }
 kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
@@ -64,6 +66,8 @@ viewbinding = { module = "com.github.kirich1409:viewbindingpropertydelegate", ve
 
 mokoResources-main = { module = "dev.icerock.moko:resources", version.ref = "mokoResources" }
 mokoResources-test = { module = "dev.icerock.moko:resources-test", version.ref = "mokoResources" }
+
+mokoKswiftRuntime-main = { module = "dev.icerock.moko:kswift-runtime", version.ref = "mokoKswift" }
 
 ktlintRules = { module = "ru.nobird.android.ktlint:rules", version.ref = "ktlintRules" }
 

--- a/iosHyperskillApp/.swiftlint.yml
+++ b/iosHyperskillApp/.swiftlint.yml
@@ -2,6 +2,9 @@ warning_threshold: 15
 
 indentation: 4
 
+excluded: 
+  - iosHyperskillApp/Sources/Frameworks/sharedSwift/Hyperskill-Mobile_shared.swift
+
 analyzer_rules:
   - explicit_self
   - unused_declaration

--- a/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
+++ b/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		2C0DB912286455D8001EA35E /* CodePlaygroundManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0DB911286455D8001EA35E /* CodePlaygroundManager.swift */; };
 		2C0DB91C28645ADA001EA35E /* CodeCompletionKeywords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0DB91B28645ADA001EA35E /* CodeCompletionKeywords.swift */; };
 		2C0DB91E2864617E001EA35E /* code-completion-keywords.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2C0DB91D2864617E001EA35E /* code-completion-keywords.plist */; };
+		2C0DFB9A2923BB4300D30921 /* ProfileFeatureStateKsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0DFB992923BB4300D30921 /* ProfileFeatureStateKsExtensions.swift */; };
 		2C0EC2DF28F9E92D004A36B2 /* ModalRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0EC2DE28F9E92D004A36B2 /* ModalRouter.swift */; };
 		2C1061A2285C349400EBD614 /* StepQuizChildQuizAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1061A1285C349400EBD614 /* StepQuizChildQuizAssembly.swift */; };
 		2C1061A4285C34C900EBD614 /* StepQuizChildQuizOutputProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1061A3285C34C900EBD614 /* StepQuizChildQuizOutputProtocol.swift */; };
@@ -389,6 +390,7 @@
 		2C0DB911286455D8001EA35E /* CodePlaygroundManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePlaygroundManager.swift; sourceTree = "<group>"; };
 		2C0DB91B28645ADA001EA35E /* CodeCompletionKeywords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeCompletionKeywords.swift; sourceTree = "<group>"; };
 		2C0DB91D2864617E001EA35E /* code-completion-keywords.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "code-completion-keywords.plist"; sourceTree = "<group>"; };
+		2C0DFB992923BB4300D30921 /* ProfileFeatureStateKsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileFeatureStateKsExtensions.swift; sourceTree = "<group>"; };
 		2C0EC2DE28F9E92D004A36B2 /* ModalRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalRouter.swift; sourceTree = "<group>"; };
 		2C1061A1285C349400EBD614 /* StepQuizChildQuizAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizChildQuizAssembly.swift; sourceTree = "<group>"; };
 		2C1061A3285C34C900EBD614 /* StepQuizChildQuizOutputProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizChildQuizOutputProtocol.swift; sourceTree = "<group>"; };
@@ -1365,6 +1367,7 @@
 			isa = PBXGroup;
 			children = (
 				2C7A1B1E2922EB070018D72C /* Hyperskill-Mobile_shared.swift */,
+				2C0DFB992923BB4300D30921 /* ProfileFeatureStateKsExtensions.swift */,
 			);
 			path = sharedSwift;
 			sourceTree = "<group>";
@@ -2472,6 +2475,7 @@
 				2C9EB9552861BA02007DDE44 /* AppTabItem.swift in Sources */,
 				2C336D282865E53800C91342 /* CodeInputAccessoryBuilder.swift in Sources */,
 				E900D10128434D0400A77BBC /* StepQuizSortingView.swift in Sources */,
+				2C0DFB9A2923BB4300D30921 /* ProfileFeatureStateKsExtensions.swift in Sources */,
 				E9C3506F2886D0600080D277 /* OpenURLInsideAppButton.swift in Sources */,
 				2C23C0062879EA7D0083709F /* StreakDayState.swift in Sources */,
 				2C963BC72812D1BF0036DD53 /* HomeAssembly.swift in Sources */,

--- a/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
+++ b/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
@@ -42,6 +42,9 @@
 		2C1061AC285C3C4300EBD614 /* StepQuizChoiceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1061AB285C3C4300EBD614 /* StepQuizChoiceViewModel.swift */; };
 		2C106D9928C1CE6E004FA584 /* SendEmailFeedbackController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C106D9828C1CE6E004FA584 /* SendEmailFeedbackController.swift */; };
 		2C177EC32837B65500D841DB /* View+Frame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C177EC22837B65500D841DB /* View+Frame.swift */; };
+		2C1860FA2923BE7E007D4EBF /* TrackFeatureStateKsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1860F92923BE7E007D4EBF /* TrackFeatureStateKsExtensions.swift */; };
+		2C1860FC2923C540007D4EBF /* AppFeatureStateKsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1860FB2923C540007D4EBF /* AppFeatureStateKsExtensions.swift */; };
+		2C1860FF2923CAAD007D4EBF /* HomeFeatureStateKsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1860FE2923CAAD007D4EBF /* HomeFeatureStateKsExtensions.swift */; };
 		2C1F5869280D063800372A37 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1F5868280D063800372A37 /* WebViewController.swift */; };
 		2C1F586B280D094A00372A37 /* WebControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1F586A280D094A00372A37 /* WebControllerManager.swift */; };
 		2C1F5870280D0CB700372A37 /* WebCacheCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1F586F280D0CB700372A37 /* WebCacheCleaner.swift */; };
@@ -399,6 +402,9 @@
 		2C1061AB285C3C4300EBD614 /* StepQuizChoiceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizChoiceViewModel.swift; sourceTree = "<group>"; };
 		2C106D9828C1CE6E004FA584 /* SendEmailFeedbackController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendEmailFeedbackController.swift; sourceTree = "<group>"; };
 		2C177EC22837B65500D841DB /* View+Frame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Frame.swift"; sourceTree = "<group>"; };
+		2C1860F92923BE7E007D4EBF /* TrackFeatureStateKsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackFeatureStateKsExtensions.swift; sourceTree = "<group>"; };
+		2C1860FB2923C540007D4EBF /* AppFeatureStateKsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureStateKsExtensions.swift; sourceTree = "<group>"; };
+		2C1860FE2923CAAD007D4EBF /* HomeFeatureStateKsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFeatureStateKsExtensions.swift; sourceTree = "<group>"; };
 		2C1F5868280D063800372A37 /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		2C1F586A280D094A00372A37 /* WebControllerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebControllerManager.swift; sourceTree = "<group>"; };
 		2C1F586F280D0CB700372A37 /* WebCacheCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCacheCleaner.swift; sourceTree = "<group>"; };
@@ -885,6 +891,17 @@
 			path = Controllers;
 			sourceTree = "<group>";
 		};
+		2C1860FD2923C549007D4EBF /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				2C1860FB2923C540007D4EBF /* AppFeatureStateKsExtensions.swift */,
+				2C1860FE2923CAAD007D4EBF /* HomeFeatureStateKsExtensions.swift */,
+				2C0DFB992923BB4300D30921 /* ProfileFeatureStateKsExtensions.swift */,
+				2C1860F92923BE7E007D4EBF /* TrackFeatureStateKsExtensions.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		2C1DEE2C27EC3FE00001A567 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
@@ -1367,7 +1384,7 @@
 			isa = PBXGroup;
 			children = (
 				2C7A1B1E2922EB070018D72C /* Hyperskill-Mobile_shared.swift */,
-				2C0DFB992923BB4300D30921 /* ProfileFeatureStateKsExtensions.swift */,
+				2C1860FD2923C549007D4EBF /* Extensions */,
 			);
 			path = sharedSwift;
 			sourceTree = "<group>";
@@ -2479,6 +2496,7 @@
 				E9C3506F2886D0600080D277 /* OpenURLInsideAppButton.swift in Sources */,
 				2C23C0062879EA7D0083709F /* StreakDayState.swift in Sources */,
 				2C963BC72812D1BF0036DD53 /* HomeAssembly.swift in Sources */,
+				2C1860FC2923C540007D4EBF /* AppFeatureStateKsExtensions.swift in Sources */,
 				2C4FBD8E2876C94800ACA5C8 /* ProfileAboutSocialAccountsView.swift in Sources */,
 				2CBFB94A28897DBB0044D1BA /* StepQuizCodeFullScreenView.swift in Sources */,
 				2C0DB90A2864515B001EA35E /* CodeEditorViewDelegate.swift in Sources */,
@@ -2511,6 +2529,7 @@
 				E9F504D029128B5300B788C7 /* StepQuizHintsAssembly.swift in Sources */,
 				2CEEE03128916A3100282849 /* ProblemOfDayAssembly.swift in Sources */,
 				2C8E4FB628490C020011ADFA /* PanModalPresenter.swift in Sources */,
+				2C1860FA2923BE7E007D4EBF /* TrackFeatureStateKsExtensions.swift in Sources */,
 				2C55133B28B8DFE8009F7627 /* Debouncer.swift in Sources */,
 				E9A6250D28ABAE30009423EE /* OnboardingAssembly.swift in Sources */,
 				2C336D172865C9CD00C91342 /* UIView+TraitCollection.swift in Sources */,
@@ -2548,6 +2567,7 @@
 				2CBD1919291D399500F5FB0B /* UIKitBounceButton.swift in Sources */,
 				2CCF3B5828004FC40075D12C /* UserAgentBuilder.swift in Sources */,
 				2C963BC52812D1A70036DD53 /* HomeView.swift in Sources */,
+				2C1860FF2923CAAD007D4EBF /* HomeFeatureStateKsExtensions.swift in Sources */,
 				E9101713283296F3002E70F5 /* RadioButton.swift in Sources */,
 				2C20FBC2284F66FC006D879E /* NSAttributedString+TrimmingCharacters.swift in Sources */,
 				2C20B28A286C350C000F458A /* CodeEditor.swift in Sources */,

--- a/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
+++ b/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		2C772E7D28ABB4E500A58758 /* AppleIDSocialAuthSDKProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C772E7C28ABB4E500A58758 /* AppleIDSocialAuthSDKProvider.swift */; };
 		2C7802C5285C93F900082547 /* StepQuizActionButtonState+SubmissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7802C4285C93F900082547 /* StepQuizActionButtonState+SubmissionStatus.swift */; };
 		2C792324287B759500A3F61D /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C792323287B759500A3F61D /* StringExtensions.swift */; };
+		2C7A1B1F2922EB070018D72C /* Hyperskill-Mobile_shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7A1B1E2922EB070018D72C /* Hyperskill-Mobile_shared.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2C80D4FD288C4D0D00B2CD1E /* StepQuizCodeFullScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C80D4FC288C4D0D00B2CD1E /* StepQuizCodeFullScreenViewModel.swift */; };
 		2C80D4FF288C4D4400B2CD1E /* StepQuizCodeFullScreenOutputProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C80D4FE288C4D4400B2CD1E /* StepQuizCodeFullScreenOutputProtocol.swift */; };
 		2C80D503288C5EBB00B2CD1E /* StepQuizCodeNavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C80D502288C5EBB00B2CD1E /* StepQuizCodeNavigationState.swift */; };
@@ -504,6 +505,7 @@
 		2C772E7C28ABB4E500A58758 /* AppleIDSocialAuthSDKProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIDSocialAuthSDKProvider.swift; sourceTree = "<group>"; };
 		2C7802C4285C93F900082547 /* StepQuizActionButtonState+SubmissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StepQuizActionButtonState+SubmissionStatus.swift"; sourceTree = "<group>"; };
 		2C792323287B759500A3F61D /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
+		2C7A1B1E2922EB070018D72C /* Hyperskill-Mobile_shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Hyperskill-Mobile_shared.swift"; sourceTree = "<group>"; };
 		2C80D4FC288C4D0D00B2CD1E /* StepQuizCodeFullScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizCodeFullScreenViewModel.swift; sourceTree = "<group>"; };
 		2C80D4FE288C4D4400B2CD1E /* StepQuizCodeFullScreenOutputProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizCodeFullScreenOutputProtocol.swift; sourceTree = "<group>"; };
 		2C80D502288C5EBB00B2CD1E /* StepQuizCodeNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizCodeNavigationState.swift; sourceTree = "<group>"; };
@@ -1359,6 +1361,14 @@
 			path = StepQuizActionButtons;
 			sourceTree = "<group>";
 		};
+		2C7A1B1D2922EADC0018D72C /* sharedSwift */ = {
+			isa = PBXGroup;
+			children = (
+				2C7A1B1E2922EB070018D72C /* Hyperskill-Mobile_shared.swift */,
+			);
+			path = sharedSwift;
+			sourceTree = "<group>";
+		};
 		2C82BA302844AFED004C9013 /* PlaceholderView */ = {
 			isa = PBXGroup;
 			children = (
@@ -1915,6 +1925,7 @@
 				E9FB89A12893CC790011EFFB /* Notifications */,
 				2C8E4F032848788D0011ADFA /* PanModal */,
 				2CB279AB28C7279800EDDCC8 /* Routers */,
+				2C7A1B1D2922EADC0018D72C /* sharedSwift */,
 				2C1F5867280D061800372A37 /* WebController */,
 			);
 			path = Frameworks;
@@ -2478,6 +2489,7 @@
 				2C84094F2805B28B009C6BE9 /* StepRatingControl.swift in Sources */,
 				2CBFB94C28897DD70044D1BA /* StepQuizCodeFullScreenAssembly.swift in Sources */,
 				2C02962028BEA000001BAFB3 /* AuthNewUserPlaceholderOutputProtocol.swift in Sources */,
+				2C7A1B1F2922EB070018D72C /* Hyperskill-Mobile_shared.swift in Sources */,
 				2C0146AA28FDF2350083DA9C /* StepQuizCodeFullScreenInputProtocol.swift in Sources */,
 				E9B2CF5D2822975400B2DC6F /* StepQuizStatsView.swift in Sources */,
 				2CA7B89428932EB100A789EF /* UIWindowExtensions.swift in Sources */,

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/Core/FeatureViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/Core/FeatureViewModel.swift
@@ -13,7 +13,10 @@ class FeatureViewModel<State, Message, ViewAction>: ObservableObject {
     private var viewActionQueue = Queue<ViewAction>()
     private var isListeningForChanges = false
 
+    /// Represents the last feature state that was rendered.
+    /// See `updateState(newState:)` logic for more info.
     private var oldState: State
+    /// Represents the current feature state.
     var state: State {
         if let state = self.feature.state as? State {
             return state
@@ -69,7 +72,11 @@ class FeatureViewModel<State, Message, ViewAction>: ObservableObject {
     // MARK: Private API
 
     private func updateState(newState: State) {
-        defer { oldState = newState }
+        defer {
+            if isListeningForChanges {
+                oldState = newState
+            }
+        }
 
         guard isListeningForChanges,
               shouldNotifyStateDidChange(oldState: oldState, newState: newState) else {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Extensions/AppFeatureStateKsExtensions.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Extensions/AppFeatureStateKsExtensions.swift
@@ -1,0 +1,42 @@
+import Foundation
+import shared
+
+#warning("TODO: Replce with source code generator Sourcery")
+extension AppFeatureStateKs: Equatable {
+    public static func == (lhs: AppFeatureStateKs, rhs: AppFeatureStateKs) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle):
+            return true
+        case (.loading, .loading):
+            return true
+        case (.networkError, .networkError):
+            return true
+        case (.ready(let lhsData), .ready(let rhsData)):
+            return lhsData.isEqual(rhsData)
+        case (.ready, .idle):
+            return false
+        case (.ready, .loading):
+            return false
+        case (.ready, .networkError):
+            return false
+        case (.networkError, .idle):
+            return false
+        case (.networkError, .loading):
+            return false
+        case (.networkError, .ready):
+            return false
+        case (.loading, .idle):
+            return false
+        case (.loading, .networkError):
+            return false
+        case (.loading, .ready):
+            return false
+        case (.idle, .loading):
+            return false
+        case (.idle, .networkError):
+            return false
+        case (.idle, .ready):
+            return false
+        }
+    }
+}

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Extensions/HomeFeatureStateKsExtensions.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Extensions/HomeFeatureStateKsExtensions.swift
@@ -1,0 +1,74 @@
+import Foundation
+import shared
+
+#warning("TODO: Replce with source code generator Sourcery")
+extension HomeFeatureStateKs: Equatable {
+    public static func == (lhs: HomeFeatureStateKs, rhs: HomeFeatureStateKs) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle):
+            return true
+        case (.loading, .loading):
+            return true
+        case (.networkError, .networkError):
+            return true
+        case (.content(let lhsData), .content(let rhsData)):
+            guard lhsData.isRefreshing == rhsData.isRefreshing else {
+                return false
+            }
+
+            guard let lhsStreak = lhsData.streak,
+                  let rhsStreak = rhsData.streak,
+                  lhsStreak.isEqual(rhsStreak) else {
+                return false
+            }
+
+            let lhsProblemOfDayStateKs = HomeFeatureProblemOfDayStateKs(lhsData.problemOfDayState)
+            let rhsProblemOfDayStateKs = HomeFeatureProblemOfDayStateKs(rhsData.problemOfDayState)
+
+            switch (lhsProblemOfDayStateKs, rhsProblemOfDayStateKs) {
+            case (.empty, .empty):
+                return true
+            case (.needToSolve(let lhsData), .needToSolve(let rhsData)):
+                return lhsData.isEqual(rhsData)
+            case (.solved(let lhsData), .solved(let rhsData)):
+                return lhsData.isEqual(rhsData)
+            case (.solved, .empty):
+                return false
+            case (.solved, .needToSolve):
+                return false
+            case (.needToSolve, .empty):
+                return false
+            case (.needToSolve, .solved):
+                return false
+            case (.empty, .needToSolve):
+                return false
+            case (.empty, .solved):
+                return false
+            }
+        case (.content, .idle):
+            return false
+        case (.content, .loading):
+            return false
+        case (.content, .networkError):
+            return false
+        case (.networkError, .idle):
+            return false
+        case (.networkError, .loading):
+            return false
+        case (.networkError, .content):
+            return false
+        case (.loading, .idle):
+            return false
+        case (.loading, .content):
+            return false
+        case (.loading, .networkError):
+            return false
+        case (.idle, .loading):
+            return false
+        case (.idle, .content):
+            return false
+        case (.idle, .networkError):
+            return false
+        }
+    }
+}

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Extensions/ProfileFeatureStateKsExtensions.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Extensions/ProfileFeatureStateKsExtensions.swift
@@ -1,41 +1,42 @@
 import Foundation
 import shared
 
+#warning("TODO: Replce with source code generator Sourcery")
 extension ProfileFeatureStateKs: Equatable {
     public static func == (lhs: ProfileFeatureStateKs, rhs: ProfileFeatureStateKs) -> Bool {
         switch (lhs, rhs) {
         case (.idle, .idle):
-            return false
+            return true
         case (.loading, .loading):
-            return false
-        case (.content(let oldContent), .content(let newContent)):
-            return !oldContent.isEqual(newContent)
+            return true
+        case (.content(let lhsData), .content(let rhsData)):
+            return lhsData.isEqual(rhsData)
         case (.error, .error):
-            return false
+            return true
         case (.error, .idle):
-            return true
+            return false
         case (.error, .loading):
-            return true
+            return false
         case (.error, .content):
-            return true
+            return false
         case (.content, .idle):
-            return true
+            return false
         case (.content, .loading):
-            return true
+            return false
         case (.content, .error):
-            return true
+            return false
         case (.loading, .idle):
-            return true
+            return false
         case (.loading, .content):
-            return true
+            return false
         case (.loading, .error):
-            return true
+            return false
         case (.idle, .loading):
-            return true
+            return false
         case (.idle, .content):
-            return true
+            return false
         case (.idle, .error):
-            return true
+            return false
         }
     }
 }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Extensions/TrackFeatureStateKsExtensions.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Extensions/TrackFeatureStateKsExtensions.swift
@@ -1,0 +1,42 @@
+import Foundation
+import shared
+
+#warning("TODO: Replce with source code generator Sourcery")
+extension TrackFeatureStateKs: Equatable {
+    public static func == (lhs: TrackFeatureStateKs, rhs: TrackFeatureStateKs) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle):
+            return true
+        case (.loading, .loading):
+            return true
+        case (.content(let lhsData), .content(let rhsData)):
+            return lhsData.isEqual(rhsData)
+        case (.networkError, .networkError):
+            return true
+        case (.networkError, .idle):
+            return false
+        case (.networkError, .loading):
+            return false
+        case (.networkError, .content):
+            return false
+        case (.content, .idle):
+            return false
+        case (.content, .loading):
+            return false
+        case (.content, .networkError):
+            return false
+        case (.loading, .idle):
+            return false
+        case (.loading, .content):
+            return false
+        case (.loading, .networkError):
+            return false
+        case (.idle, .loading):
+            return false
+        case (.idle, .content):
+            return false
+        case (.idle, .networkError):
+            return false
+        }
+    }
+}

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/ProfileFeatureStateKsExtensions.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/ProfileFeatureStateKsExtensions.swift
@@ -1,0 +1,41 @@
+import Foundation
+import shared
+
+extension ProfileFeatureStateKs: Equatable {
+    public static func == (lhs: ProfileFeatureStateKs, rhs: ProfileFeatureStateKs) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle):
+            return false
+        case (.loading, .loading):
+            return false
+        case (.content(let oldContent), .content(let newContent)):
+            return !oldContent.isEqual(newContent)
+        case (.error, .error):
+            return false
+        case (.error, .idle):
+            return true
+        case (.error, .loading):
+            return true
+        case (.error, .content):
+            return true
+        case (.content, .idle):
+            return true
+        case (.content, .loading):
+            return true
+        case (.content, .error):
+            return true
+        case (.loading, .idle):
+            return true
+        case (.loading, .content):
+            return true
+        case (.loading, .error):
+            return true
+        case (.idle, .loading):
+            return true
+        case (.idle, .content):
+            return true
+        case (.idle, .error):
+            return true
+        }
+    }
+}

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/AppView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/AppView.swift
@@ -53,21 +53,19 @@ final class AppView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func renderState(_ state: AppFeatureState) {
+    func renderState(_ state: AppFeatureStateKs) {
         switch state {
-        case is AppFeatureStateIdle, is AppFeatureStateLoading:
+        case .idle, .loading:
             loadingIndicator.isHidden = false
             loadingIndicator.startAnimating()
 
             setPlaceholderHidden(true)
-        case is AppFeatureStateNetworkError:
+        case .networkError:
             loadingIndicator.stopAnimating()
             setPlaceholderHidden(false)
-        case is AppFeatureStateReady:
+        case .ready:
             loadingIndicator.stopAnimating()
             setPlaceholderHidden(true)
-        default:
-            break
         }
     }
 

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/AppViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/AppViewModel.swift
@@ -35,7 +35,7 @@ final class AppViewModel: FeatureViewModel<AppFeatureState, AppFeatureMessage, A
     }
 
     func loadApp(forceUpdate: Bool = false) {
-        onNewMessage(AppFeatureMessageInit(forceUpdate: forceUpdate))
+        onNewMessage(AppFeatureMessageInitialize(forceUpdate: forceUpdate))
     }
 
     // MARK: Private API

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/AppViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/AppViewModel.swift
@@ -20,7 +20,7 @@ final class AppViewModel: FeatureViewModel<AppFeatureState, AppFeatureMessage, A
                     return
                 }
 
-                strongSelf.viewController?.displayState(strongSelf.state)
+                strongSelf.viewController?.displayState(AppFeatureStateKs(strongSelf.state))
             }
         }
         self.onViewAction = { [weak self] viewAction in
@@ -29,9 +29,13 @@ final class AppViewModel: FeatureViewModel<AppFeatureState, AppFeatureMessage, A
                     return
                 }
 
-                strongSelf.viewController?.displayViewAction(viewAction)
+                strongSelf.viewController?.displayViewAction(AppFeatureActionViewActionKs(viewAction))
             }
         }
+    }
+
+    override func shouldNotifyStateDidChange(oldState: AppFeatureState, newState: AppFeatureState) -> Bool {
+        AppFeatureStateKs(oldState) != AppFeatureStateKs(newState)
     }
 
     func loadApp(forceUpdate: Bool = false) {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/ViewControllers/AppViewController.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/ViewControllers/AppViewController.swift
@@ -4,8 +4,8 @@ import SwiftUI
 import UIKit
 
 protocol AppViewControllerProtocol: AnyObject {
-    func displayState(_ state: AppFeatureState)
-    func displayViewAction(_ viewAction: AppFeatureActionViewAction)
+    func displayState(_ state: AppFeatureStateKs)
+    func displayViewAction(_ viewAction: AppFeatureActionViewActionKs)
 }
 
 extension AppViewController {
@@ -61,26 +61,27 @@ final class AppViewController: UIViewController {
 // MARK: - AppViewController: AppViewControllerProtocol -
 
 extension AppViewController: AppViewControllerProtocol {
-    func displayState(_ state: AppFeatureState) {
+    func displayState(_ state: AppFeatureStateKs) {
         appView?.renderState(state)
     }
 
-    func displayViewAction(_ viewAction: AppFeatureActionViewAction) {
+    func displayViewAction(_ viewAction: AppFeatureActionViewActionKs) {
         let viewControllerToPresent: UIViewController? = {
-            switch viewAction {
-            case is AppFeatureActionViewActionNavigateToOnboardingScreen:
+            guard case .navigateTo(let navigateToViewAction) = viewAction else {
+                return nil
+            }
+
+            switch AppFeatureActionViewActionNavigateToKs(navigateToViewAction) {
+            case .onboardingScreen:
                 return UIHostingController(rootView: OnboardingAssembly(output: viewModel).makeModule())
-            case is AppFeatureActionViewActionNavigateToHomeScreen:
+            case .homeScreen:
                 let controller = AppTabBarController()
                 controller.appTabBarControllerDelegate = viewModel
                 return controller
-            case is AppFeatureActionViewActionNavigateToAuthScreen:
+            case .authScreen:
                 return UIHostingController(rootView: AuthSocialAssembly(output: viewModel).makeModule())
-            case is AppFeatureActionViewActionNavigateToNewUserScreen:
+            case .newUserScreen:
                 return UIHostingController(rootView: AuthNewUserPlaceholderAssembly(output: viewModel).makeModule())
-            default:
-                print("AppView :: unhandled viewAction = \(viewAction)")
-                return nil
             }
         }()
 

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
@@ -6,6 +6,8 @@ final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage
     private var applicationWasInBackground = false
     private var shouldReloadContent = false
 
+    var stateKs: HomeFeatureStateKs { .init(state) }
+
     override init(feature: Presentation_reduxFeature, mainScheduler: AnySchedulerOf<RunLoop> = .main) {
         super.init(feature: feature, mainScheduler: mainScheduler)
 
@@ -21,6 +23,10 @@ final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage
             name: UIApplication.didEnterBackgroundNotification,
             object: UIApplication.shared
         )
+    }
+
+    override func shouldNotifyStateDidChange(oldState: HomeFeatureState, newState: HomeFeatureState) -> Bool {
+        HomeFeatureStateKs(oldState) != HomeFeatureStateKs(newState)
     }
 
     func doLoadContent(forceUpdate: Bool = false) {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
@@ -24,7 +24,7 @@ final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage
     }
 
     func doLoadContent(forceUpdate: Bool = false) {
-        onNewMessage(HomeFeatureMessageInit(forceUpdate: forceUpdate || shouldReloadContent))
+        onNewMessage(HomeFeatureMessageInitialize(forceUpdate: forceUpdate || shouldReloadContent))
 
         if shouldReloadContent {
             shouldReloadContent = false

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/Views/HomeView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/Views/HomeView.swift
@@ -43,21 +43,21 @@ struct HomeView: View {
 
     @ViewBuilder
     private func buildBody() -> some View {
-        switch viewModel.state {
-        case is HomeFeatureStateIdle:
+        switch viewModel.stateKs {
+        case .idle:
             ProgressView()
                 .onAppear {
                     viewModel.doLoadContent()
                 }
-        case is HomeFeatureStateLoading:
+        case .loading:
             ProgressView()
-        case is HomeFeatureStateNetworkError:
+        case .networkError:
             PlaceholderView(
                 configuration: .networkError(backgroundColor: appearance.backgroundColor) {
                     viewModel.doLoadContent(forceUpdate: true)
                 }
             )
-        case let state as HomeFeatureStateContent:
+        case .content(let data):
             ScrollView {
                 VStack(alignment: .leading, spacing: appearance.spacingBetweenContainers) {
                     Text(Strings.Home.helloLetsLearn)
@@ -68,18 +68,18 @@ struct HomeView: View {
                         .font(.subheadline)
                         .foregroundColor(.secondaryText)
 
-                    if let streak = state.streak {
+                    if let streak = data.streak {
                         StreakViewBuilder(streak: streak, viewType: .card).build()
                     }
 
                     ProblemOfDayAssembly(
-                        problemOfDayState: state.problemOfDayState,
+                        problemOfDayState: data.problemOfDayState,
                         output: viewModel
                     )
                     .makeModule()
 
-                    let shouldShowContinueInWebButton = state.problemOfDayState is HomeFeatureProblemOfDayStateEmpty ||
-                      state.problemOfDayState is HomeFeatureProblemOfDayStateSolved
+                    let shouldShowContinueInWebButton = data.problemOfDayState is HomeFeatureProblemOfDayStateEmpty ||
+                      data.problemOfDayState is HomeFeatureProblemOfDayStateSolved
 
                     if shouldShowContinueInWebButton {
                         OpenURLInsideAppButton(
@@ -102,7 +102,7 @@ struct HomeView: View {
                 .padding()
                 .pullToRefresh(
                     isShowing: Binding(
-                        get: { state.isRefreshing },
+                        get: { data.isRefreshing },
                         set: { _ in }
                     ),
                     onRefresh: viewModel.doPullToRefresh
@@ -110,18 +110,17 @@ struct HomeView: View {
             }
             .frame(maxWidth: .infinity)
             .padding(.top, 0.1)
-        default:
-            Text("Unkwown state")
         }
     }
 
     private func handleViewAction(_ viewAction: HomeFeatureActionViewAction) {
-        switch viewAction {
-        case let navigateToStepScreenViewAction as HomeFeatureActionViewActionNavigateToStepScreen:
-            let assembly = StepAssembly(stepID: Int(navigateToStepScreenViewAction.stepId))
-            pushRouter.pushViewController(assembly.makeModule())
-        default:
-            print("HomeView :: unhandled viewAction = \(viewAction)")
+        switch HomeFeatureActionViewActionKs(viewAction) {
+        case .navigateTo(let navigateToViewAction):
+            switch HomeFeatureActionViewActionNavigateToKs(navigateToViewAction) {
+            case .stepScreen(let data):
+                let assembly = StepAssembly(stepID: Int(data.stepId))
+                pushRouter.pushViewController(assembly.makeModule())
+            }
         }
     }
 }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Onboarding/OnboardingViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Onboarding/OnboardingViewModel.swift
@@ -9,7 +9,7 @@ final class OnboardingViewModel: FeatureViewModel<
     weak var moduleOutput: OnboardingOutputProtocol?
 
     func loadOnboarding() {
-        onNewMessage(OnboardingFeatureMessageInit())
+        onNewMessage(OnboardingFeatureMessageInitialize())
     }
 
     func doSignPresentation() {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Profile/ProfileViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Profile/ProfileViewModel.swift
@@ -45,10 +45,10 @@ final class ProfileViewModel: FeatureViewModel<
     func doLoadProfile(forceUpdate: Bool = false) {
         switch presentationDescription.profileType {
         case .currentUser:
-            onNewMessage(ProfileFeatureMessageInit(isInitCurrent: true, profileId: nil, forceUpdate: forceUpdate))
+            onNewMessage(ProfileFeatureMessageInitialize(isInitCurrent: true, profileId: nil, forceUpdate: forceUpdate))
         case .otherUser(let profileUserID):
             onNewMessage(
-                ProfileFeatureMessageInit(
+                ProfileFeatureMessageInitialize(
                     isInitCurrent: false,
                     profileId: KotlinLong(value: Int64(profileUserID)),
                     forceUpdate: forceUpdate

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Profile/ProfileViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Profile/ProfileViewModel.swift
@@ -14,6 +14,8 @@ final class ProfileViewModel: FeatureViewModel<
     private let notificationsRegistrationService: NotificationsRegistrationService
     private let notificationInteractor: NotificationInteractor
 
+    var stateKs: ProfileFeatureStateKs { .init(state) }
+
     init(
         presentationDescription: ProfilePresentationDescription,
         viewDataMapper: ProfileViewDataMapper,
@@ -40,6 +42,10 @@ final class ProfileViewModel: FeatureViewModel<
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+    }
+
+    override func shouldNotifyStateDidChange(oldState: ProfileFeatureState, newState: ProfileFeatureState) -> Bool {
+        ProfileFeatureStateKs(oldState) != ProfileFeatureStateKs(newState)
     }
 
     func doLoadProfile(forceUpdate: Bool = false) {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Profile/Views/ProfileView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Profile/Views/ProfileView.swift
@@ -53,22 +53,22 @@ struct ProfileView: View {
 
     @ViewBuilder
     private func buildBody() -> some View {
-        switch viewModel.state {
-        case is ProfileFeatureStateIdle:
+        switch viewModel.stateKs {
+        case .idle:
             ProgressView()
                 .onAppear {
                     viewModel.doLoadProfile()
                 }
-        case is ProfileFeatureStateLoading:
+        case .loading:
             ProgressView()
-        case is ProfileFeatureStateError:
+        case .error:
             PlaceholderView(
                 configuration: .networkError(backgroundColor: appearance.backgroundColor) {
                     viewModel.doLoadProfile(forceUpdate: true)
                 }
             )
-        case let state as ProfileFeatureStateContent:
-            let viewData = viewModel.makeViewData(state.profile)
+        case .content(let data):
+            let viewData = viewModel.makeViewData(data.profile)
 
             ScrollView {
                 VStack(spacing: appearance.spacingBetweenContainers) {
@@ -78,7 +78,7 @@ struct ProfileView: View {
                         subtitle: viewData.role
                     )
 
-                    if let streak = state.streak {
+                    if let streak = data.streak {
                         StreakViewBuilder(streak: streak, viewType: .plain)
                             .build()
                             .padding()
@@ -106,15 +106,13 @@ struct ProfileView: View {
                 .padding(.vertical)
                 .pullToRefresh(
                     isShowing: Binding(
-                        get: { state.isRefreshing },
+                        get: { data.isRefreshing },
                         set: { _ in }
                     ),
                     onRefresh: viewModel.doPullToRefresh
                 )
             }
             .frame(maxWidth: .infinity)
-        default:
-            Text("Unkwown state")
         }
     }
 

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/StepViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/StepViewModel.swift
@@ -13,7 +13,7 @@ final class StepViewModel: FeatureViewModel<StepFeatureState, StepFeatureMessage
     }
 
     func loadStep(forceUpdate: Bool = false) {
-        self.onNewMessage(StepFeatureMessageInit(stepId: Int64(stepID), forceUpdate: forceUpdate))
+        self.onNewMessage(StepFeatureMessageInitialize(stepId: Int64(stepID), forceUpdate: forceUpdate))
     }
 
     func makeViewData(_ step: Step) -> StepViewData {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/TrackViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/TrackViewModel.swift
@@ -4,9 +4,15 @@ import SwiftUI
 final class TrackViewModel: FeatureViewModel<TrackFeatureState, TrackFeatureMessage, TrackFeatureActionViewAction> {
     private let viewDataMapper: TrackViewDataMapper
 
+    var stateKs: TrackFeatureStateKs { .init(state) }
+
     init(viewDataMapper: TrackViewDataMapper, feature: Presentation_reduxFeature) {
         self.viewDataMapper = viewDataMapper
         super.init(feature: feature)
+    }
+
+    override func shouldNotifyStateDidChange(oldState: TrackFeatureState, newState: TrackFeatureState) -> Bool {
+        TrackFeatureStateKs(oldState) != TrackFeatureStateKs(newState)
     }
 
     func doLoadTrack(forceUpdate: Bool = false) {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/TrackViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/TrackViewModel.swift
@@ -10,7 +10,7 @@ final class TrackViewModel: FeatureViewModel<TrackFeatureState, TrackFeatureMess
     }
 
     func doLoadTrack(forceUpdate: Bool = false) {
-        onNewMessage(TrackFeatureMessageInit(forceUpdate: forceUpdate))
+        onNewMessage(TrackFeatureMessageInitialize(forceUpdate: forceUpdate))
     }
 
     func doPullToRefresh() {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/Views/TrackView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/Views/TrackView.swift
@@ -36,25 +36,25 @@ struct TrackView: View {
 
     @ViewBuilder
     private func buildBody() -> some View {
-        switch viewModel.state {
-        case is TrackFeatureStateIdle:
+        switch viewModel.stateKs {
+        case .idle:
             ProgressView()
                 .onAppear {
                     viewModel.doLoadTrack()
                 }
-        case is TrackFeatureStateLoading:
+        case .loading:
             ProgressView()
-        case is TrackFeatureStateNetworkError:
+        case .networkError:
             PlaceholderView(
                 configuration: .networkError(backgroundColor: appearance.backgroundColor) {
                     viewModel.doLoadTrack(forceUpdate: true)
                 }
             )
-        case let state as TrackFeatureStateContent:
+        case .content(let data):
             let viewData = viewModel.makeViewData(
-                track: state.track,
-                trackProgress: state.trackProgress,
-                studyPlan: state.studyPlan
+                track: data.track,
+                trackProgress: data.trackProgress,
+                studyPlan: data.studyPlan
             )
 
             ScrollView {
@@ -88,15 +88,13 @@ struct TrackView: View {
                 .padding(.vertical)
                 .pullToRefresh(
                     isShowing: Binding(
-                        get: { state.isRefreshing },
+                        get: { data.isRefreshing },
                         set: { _ in }
                     ),
                     onRefresh: viewModel.doPullToRefresh
                 )
             }
             .frame(maxWidth: .infinity)
-        default:
-            Text("Unkwown state")
         }
     }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -181,12 +181,20 @@ tasks.withType<KotlinNativeLink>()
             val kSwiftGeneratedDir = destinationDirectory.get()
                 .dir("${binary.baseName}Swift")
                 .asFile
+            println("kSwiftGeneratedDir=$kSwiftGeneratedDir")
             val kSwiftSharedGeneratedSwiftFile = kSwiftGeneratedDir
                 .resolve("Hyperskill-Mobile_shared.swift")
+            println("kSwiftSharedGeneratedSwiftFile=$kSwiftSharedGeneratedSwiftFile")
 
             val iosHyperskillAppSharedSwiftFile = rootDir
                 .resolve("iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Hyperskill-Mobile_shared.swift")
+            println("iosHyperskillAppSharedSwiftFile=$iosHyperskillAppSharedSwiftFile")
+            if (!iosHyperskillAppSharedSwiftFile.exists()) {
+                iosHyperskillAppSharedSwiftFile.createNewFile()
+                println("created iosHyperskillAppSharedSwiftFile")
+            }
 
             kSwiftSharedGeneratedSwiftFile.copyTo(iosHyperskillAppSharedSwiftFile, overwrite = true)
+            println("copied $kSwiftSharedGeneratedSwiftFile -> $iosHyperskillAppSharedSwiftFile")
         }
     }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -181,20 +181,15 @@ tasks.withType<KotlinNativeLink>()
             val kSwiftGeneratedDir = destinationDirectory.get()
                 .dir("${binary.baseName}Swift")
                 .asFile
-            println("kSwiftGeneratedDir=$kSwiftGeneratedDir")
             val kSwiftSharedGeneratedSwiftFile = kSwiftGeneratedDir
                 .resolve("Hyperskill-Mobile_shared.swift")
-            println("kSwiftSharedGeneratedSwiftFile=$kSwiftSharedGeneratedSwiftFile")
 
             val iosHyperskillAppSharedSwiftFile = rootDir
                 .resolve("iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Hyperskill-Mobile_shared.swift")
-            println("iosHyperskillAppSharedSwiftFile=$iosHyperskillAppSharedSwiftFile")
             if (!iosHyperskillAppSharedSwiftFile.exists()) {
                 iosHyperskillAppSharedSwiftFile.createNewFile()
-                println("created iosHyperskillAppSharedSwiftFile")
             }
 
             kSwiftSharedGeneratedSwiftFile.copyTo(iosHyperskillAppSharedSwiftFile, overwrite = true)
-            println("copied $kSwiftSharedGeneratedSwiftFile -> $iosHyperskillAppSharedSwiftFile")
         }
     }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,7 +1,9 @@
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
+import org.gradle.internal.os.OperatingSystem
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 import org.jetbrains.kotlin.konan.properties.loadProperties
 import org.jetbrains.kotlin.konan.properties.propertyString
-import org.gradle.internal.os.OperatingSystem
 
 plugins {
     kotlin("multiplatform")
@@ -10,6 +12,7 @@ plugins {
     id("com.android.library")
     id("com.codingfeline.buildkonfig")
     id("dev.icerock.mobile.multiplatform-resources")
+    id("dev.icerock.moko.kswift")
 }
 
 dependencies {
@@ -48,6 +51,7 @@ kotlin {
 
                 api(libs.kit.presentation.redux)
                 api(libs.mokoResources.main)
+                api(libs.mokoKswiftRuntime.main)
                 api(libs.multiplatform.settings)
             }
         }
@@ -162,3 +166,27 @@ ktlint {
         exclude { element -> element.file.path.contains("build/") }
     }
 }
+
+kswift {
+    install(dev.icerock.moko.kswift.plugin.feature.SealedToSwiftEnumFeature)
+
+    iosDeploymentTarget.set("14.0")
+}
+
+// Copies generated shared Swift file by moko-kswift to iosHyperskillApp
+tasks.withType<KotlinNativeLink>()
+    .matching { it.binary is Framework }
+    .configureEach {
+        doLast {
+            val kSwiftGeneratedDir = destinationDirectory.get()
+                .dir("${binary.baseName}Swift")
+                .asFile
+            val kSwiftSharedGeneratedSwiftFile = kSwiftGeneratedDir
+                .resolve("Hyperskill-Mobile_shared.swift")
+
+            val iosHyperskillAppSharedSwiftFile = rootDir
+                .resolve("iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/sharedSwift/Hyperskill-Mobile_shared.swift")
+
+            kSwiftSharedGeneratedSwiftFile.copyTo(iosHyperskillAppSharedSwiftFile, overwrite = true)
+        }
+    }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/home/presentation/HomeFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/home/presentation/HomeFeature.kt
@@ -44,7 +44,7 @@ interface HomeFeature {
     }
 
     sealed interface Message {
-        data class Init(val forceUpdate: Boolean) : Message
+        data class Initialize(val forceUpdate: Boolean) : Message
         data class HomeSuccess(val streak: Streak?, val problemOfDayState: ProblemOfDayState) : Message
         object HomeFailure : Message
         object PullToRefresh : Message

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/home/presentation/HomeReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/home/presentation/HomeReducer.kt
@@ -12,7 +12,7 @@ import ru.nobird.app.presentation.redux.reducer.StateReducer
 class HomeReducer : StateReducer<State, Message, Action> {
     override fun reduce(state: State, message: Message): Pair<State, Set<Action>> =
         when (message) {
-            is Message.Init ->
+            is Message.Initialize ->
                 if (state is State.Idle ||
                     (message.forceUpdate && (state is State.Content || state is State.NetworkError))
                 ) {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/main/presentation/AppFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/main/presentation/AppFeature.kt
@@ -12,7 +12,7 @@ interface AppFeature {
     }
 
     sealed interface Message {
-        data class Init(val forceUpdate: Boolean = false) : Message
+        data class Initialize(val forceUpdate: Boolean = false) : Message
         data class UserAuthorized(val isNewUser: Boolean) : Message
         data class UserDeauthorized(val reason: Reason) : Message
         data class UserAccountStatus(val profile: Profile) : Message

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/main/presentation/AppReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/main/presentation/AppReducer.kt
@@ -12,7 +12,7 @@ class AppReducer : StateReducer<State, Message, Action> {
         message: Message
     ): Pair<State, Set<Action>> =
         when (message) {
-            is Message.Init -> {
+            is Message.Initialize -> {
                 if (state is State.Idle || (state is State.NetworkError && message.forceUpdate)) {
                     State.Loading to setOf(Action.DetermineUserAccountStatus)
                 } else {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/onboarding/presentation/OnboardingFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/onboarding/presentation/OnboardingFeature.kt
@@ -8,7 +8,7 @@ interface OnboardingFeature {
     }
 
     sealed interface Message {
-        object Init : Message
+        object Initialize : Message
 
         /**
          * Analytic

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/onboarding/presentation/OnboardingReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/onboarding/presentation/OnboardingReducer.kt
@@ -11,7 +11,7 @@ import ru.nobird.app.presentation.redux.reducer.StateReducer
 class OnboardingReducer : StateReducer<State, Message, Action> {
     override fun reduce(state: State, message: Message): Pair<State, Set<Action>> =
         when (message) {
-            is Message.Init ->
+            is Message.Initialize ->
                 state to setOf(Action.FetchOnboarding)
             is Message.ViewedEventMessage ->
                 state to setOf(Action.LogAnalyticEvent(OnboardingViewedHyperskillAnalyticEvent()))

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile/presentation/ProfileFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile/presentation/ProfileFeature.kt
@@ -38,7 +38,7 @@ interface ProfileFeature {
     }
 
     sealed interface Message {
-        data class Init(
+        data class Initialize(
             val isInitCurrent: Boolean = true,
             val profileId: Long? = null,
             val forceUpdate: Boolean = false

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile/presentation/ProfileReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile/presentation/ProfileReducer.kt
@@ -14,7 +14,7 @@ import ru.nobird.app.presentation.redux.reducer.StateReducer
 class ProfileReducer : StateReducer<State, Message, Action> {
     override fun reduce(state: State, message: Message): Pair<State, Set<Action>> =
         when (message) {
-            is Message.Init -> {
+            is Message.Initialize -> {
                 if (state is State.Idle ||
                     (message.forceUpdate && (state is State.Content || state is State.Error))
                 ) {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step/presentation/StepFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step/presentation/StepFeature.kt
@@ -11,7 +11,7 @@ interface StepFeature {
     }
 
     sealed interface Message {
-        data class Init(
+        data class Initialize(
             val stepId: Long,
             val forceUpdate: Boolean = false
         ) : Message

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step/presentation/StepReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step/presentation/StepReducer.kt
@@ -8,7 +8,7 @@ import ru.nobird.app.presentation.redux.reducer.StateReducer
 class StepReducer : StateReducer<State, Message, Action> {
     override fun reduce(state: State, message: Message): Pair<State, Set<Action>> =
         when (message) {
-            is Message.Init ->
+            is Message.Initialize ->
                 if (state is State.Idle ||
                     (message.forceUpdate && (state is State.Data || state is State.Error))
                 ) {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/track/presentation/TrackFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/track/presentation/TrackFeature.kt
@@ -42,7 +42,7 @@ interface TrackFeature {
     }
 
     sealed interface Message {
-        data class Init(val forceUpdate: Boolean = false) : Message
+        data class Initialize(val forceUpdate: Boolean = false) : Message
 
         data class TrackSuccess(
             val track: Track,

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/track/presentation/TrackReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/track/presentation/TrackReducer.kt
@@ -11,7 +11,7 @@ import ru.nobird.app.presentation.redux.reducer.StateReducer
 class TrackReducer : StateReducer<State, Message, Action> {
     override fun reduce(state: State, message: Message): Pair<State, Set<Action>> =
         when (message) {
-            is Message.Init ->
+            is Message.Initialize ->
                 if (state is State.Idle ||
                     (message.forceUpdate && (state is State.Content || state is State.NetworkError))
                 ) {


### PR DESCRIPTION
Task: [#ALTAPPS-392](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-392)

**Reviewers**
- [x] @vladkash 

**Description**
1. Setups [moko-kswift](https://github.com/icerockdev/moko-kswift), that generate Swift-friendly API for the shared framework. Outputs result to `Sources/Frameworks/sharedSwift/Hyperskill-Mobile_shared.swift`.
2. Migrates `Appfeature`, `HomeFeature`, `Track`, and  `Profile`, see changes for more info. This is the first brute-force usage, in the future we may improve this. But now we had already achieved States updates only when it changed.

Example output:
```kotlin
interface ProfileFeature {
    sealed interface State {
        object Idle : State
        object Loading : State
        object Error : State
        data class Content(
            val profile: Profile,
            val streak: Streak?
        ) : State
    }
}
```
```swift
public enum ProfileFeatureStateKs {
  case idle
  case loading
  case content(ProfileFeatureStateContent)
  case error

  public var sealed: ProfileFeatureState {
    switch self {
    case .idle:
      return shared.ProfileFeatureStateIdle() as shared.ProfileFeatureState
    case .loading:
      return shared.ProfileFeatureStateLoading() as shared.ProfileFeatureState
    case .content(let obj):
      return obj as! shared.ProfileFeatureState
    case .error:
      return shared.ProfileFeatureStateError() as shared.ProfileFeatureState
    }
  }

  public init(_ obj: ProfileFeatureState) {
    if obj is shared.ProfileFeatureStateIdle {
      self = .idle
    } else if obj is shared.ProfileFeatureStateLoading {
      self = .loading
    } else if let obj = obj as? shared.ProfileFeatureStateContent {
      self = .content(obj)
    } else if obj is shared.ProfileFeatureStateError {
      self = .error
    } else {
      fatalError("ProfileFeatureStateKs not synchronized with ProfileFeatureState class")
    }
  }
}
```