### PR TITLE
ALTAPPS-404: CI/CD Bump Xcode version from 14.0.1 to 14.1

### DIFF
--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -24,8 +24,8 @@ runs:
     - name: Setup Xcode version
       uses: maxim-lobanov/setup-xcode@v1.5.1
       with:
-        xcode-version: '14.0.1'
-        
+        xcode-version: '14.1'
+
     - name: Homebrew install git-crypt
       run: brew install git-crypt
       shell: bash


### PR DESCRIPTION
Task: [#ALTAPPS-404](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-404)

**Reviewers**
- [ ] @ivan-magda 

**Description**
- CI/CD Bump Xcode version from 14.0.1 to 14.1
