### PR TITLE
ALTAPPS-433: move topics-repetition screen click handling into shared

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/TopicsRepetitionsViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/TopicsRepetitionsViewModel.swift
@@ -38,11 +38,11 @@ final class TopicsRepetitionsViewModel: FeatureViewModel<
         onNewMessage(TopicsRepetitionsFeatureMessageShowMoreButtonClicked())
     }
 
-    func repeatTopicClicked(stepID: Int64) {
-        onNewMessage(TopicsRepetitionsFeatureMessageRepeatTopicClicked())
+    func doRepeatTopic(stepID: Int64) {
+        onNewMessage(TopicsRepetitionsFeatureMessageRepeatTopicClicked(stepId: stepID))
     }
 
-    func repeatNextTopicClicked() {
+    func doRepeatNextTopic() {
         onNewMessage(TopicsRepetitionsFeatureMessageRepeatNextTopicClicked())
     }
 }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/TopicsRepetitionsViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/TopicsRepetitionsViewModel.swift
@@ -38,19 +38,11 @@ final class TopicsRepetitionsViewModel: FeatureViewModel<
         onNewMessage(TopicsRepetitionsFeatureMessageShowMoreButtonClicked())
     }
 
-    func doTopicStepQuizPresentation(stepID: Int64) {
-        mainScheduler.schedule {
-            self.onViewAction?(TopicsRepetitionsFeatureActionViewActionNavigateToStepScreen(stepId: stepID))
-        }
+    func repeatTopicClicked(stepID: Int64) {
+        onNewMessage(TopicsRepetitionsFeatureMessageRepeatTopicClicked())
     }
 
-    // MARK: Analytic
-
-    func logClickedRepeatNextTopicEvent() {
-        onNewMessage(TopicsRepetitionsFeatureMessageClickedRepeatNextTopicEventMessage())
-    }
-
-    func logClickedRepeatTopicEvent() {
-        onNewMessage(TopicsRepetitionsFeatureMessageClickedRepeatTopicEventMessage())
+    func repeatNextTopicClicked() {
+        onNewMessage(TopicsRepetitionsFeatureMessageRepeatNextTopicClicked())
     }
 }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/Views/TopicsRepetitionsView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/Views/TopicsRepetitionsView.swift
@@ -80,10 +80,7 @@ struct TopicsRepetitionsView: View {
             TopicsRepetitionsStatusBlock(
                 repetitionsStatus: viewData.repetitionsStatus,
                 onRepeatNextTopicTap: {
-                    viewModel.logClickedRepeatNextTopicEvent()
-                    if let firstTopic = viewData.topicsToRepeat.first {
-                        viewModel.doTopicStepQuizPresentation(stepID: firstTopic.stepId)
-                    }
+                    viewModel.repeatNextTopicClicked()
                 }
             )
             .padding(.top, appearance.padding)
@@ -104,9 +101,7 @@ struct TopicsRepetitionsView: View {
                             topicID: Int(topic.topicId),
                             title: topic.title,
                             onTap: {
-                                viewModel.logClickedRepeatTopicEvent()
-
-                                viewModel.doTopicStepQuizPresentation(stepID: topic.stepId)
+                                viewModel.repeatTopicClicked()
                             }
                         )
                     },

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/Views/TopicsRepetitionsView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/Views/TopicsRepetitionsView.swift
@@ -80,7 +80,7 @@ struct TopicsRepetitionsView: View {
             TopicsRepetitionsStatusBlock(
                 repetitionsStatus: viewData.repetitionsStatus,
                 onRepeatNextTopicTap: {
-                    viewModel.repeatNextTopicClicked()
+                    viewModel.doRepeatNextTopic()
                 }
             )
             .padding(.top, appearance.padding)
@@ -101,7 +101,7 @@ struct TopicsRepetitionsView: View {
                             topicID: Int(topic.topicId),
                             title: topic.title,
                             onTap: {
-                                viewModel.repeatTopicClicked()
+                                viewModel.doRepeatTopic(stepID: topic.stepId)
                             }
                         )
                     },

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/presentation/TopicsRepetitionsFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/presentation/TopicsRepetitionsFeature.kt
@@ -31,7 +31,7 @@ interface TopicsRepetitionsFeature {
                 val topicsRepetitions: TopicsRepetitions,
                 val topicsToRepeat: List<TopicToRepeat>,
                 val recommendedRepetitionsCount: Int,
-                val trackTitle: String,
+                val trackTitle: String
             ) : TopicsRepetitionsLoaded
 
             object Error : TopicsRepetitionsLoaded
@@ -50,11 +50,9 @@ interface TopicsRepetitionsFeature {
 
         data class StepCompleted(val stepId: Long) : Message
 
-        /**
-         * Analytic
-         */
-        object ClickedRepeatNextTopicEventMessage : Message
-        object ClickedRepeatTopicEventMessage : Message
+        data class RepeatTopicClicked(val stepId: Long) : Message
+
+        object RepeatNextTopicClicked : Message
     }
 
     sealed interface Action {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/presentation/TopicsRepetitionsFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/presentation/TopicsRepetitionsFeature.kt
@@ -56,7 +56,6 @@ interface TopicsRepetitionsFeature {
     }
 
     sealed interface Action {
-
         data class Initialize(val recommendedRepetitionsCount: Int) : Action
 
         data class FetchNextTopics(val topicsRepetitions: TopicsRepetitions) : Action

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/presentation/TopicsRepetitionsReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/presentation/TopicsRepetitionsReducer.kt
@@ -79,10 +79,24 @@ class TopicsRepetitionsReducer : StateReducer<State, Message, Action> {
                 } else {
                     null
                 }
-            is Message.ClickedRepeatNextTopicEventMessage ->
-                state to setOf(Action.LogAnalyticEvent(TopicsRepetitionsClickedRepeatNextTopicHyperskillAnalyticEvent()))
-            is Message.ClickedRepeatTopicEventMessage ->
-                state to setOf(Action.LogAnalyticEvent(TopicsRepetitionsClickedRepeatTopicHyperskillAnalyticEvent()))
+            is Message.RepeatNextTopicClicked -> {
+                if (state is State.Content) {
+                    state to buildSet {
+                        state.topicsToRepeat.firstOrNull()?.let { topicToRepeat ->
+                            add(Action.ViewAction.NavigateTo.StepScreen(topicToRepeat.stepId))
+                        }
+                        add(Action.LogAnalyticEvent(TopicsRepetitionsClickedRepeatNextTopicHyperskillAnalyticEvent()))
+                    }
+                } else {
+                    state to emptySet()
+                }
+            }
+            is Message.RepeatTopicClicked -> {
+                state to setOf(
+                    Action.ViewAction.NavigateTo.StepScreen(message.stepId),
+                    Action.LogAnalyticEvent(TopicsRepetitionsClickedRepeatTopicHyperskillAnalyticEvent())
+                )
+            }
         } ?: (state to emptySet())
 
     private fun getNewChartData(


### PR DESCRIPTION
Task: [#ALTAPPS-433](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-433Android-Topics-repetitions-views)

**Reviewers**
- [ ] @vladkash 

**Description**
- Move clicks handling and analytics sanding into shared module to use it on Android side
