### PR TITLE
ALTAPPS-432: Android fix alert html classes has incorrect style

### DIFF
--- a/androidHyperskillApp/src/main/assets/css/step.css
+++ b/androidHyperskillApp/src/main/assets/css/step.css
@@ -1,3 +1,46 @@
+@media (prefers-color-scheme: light) {
+    .alert-primary {
+        background-color: #5d72e91f;
+        border-color: #5d72e961;
+    }
+
+    .alert-warning {
+        background-color: #fcba431f;
+        border-color: #fcba4361;
+    }
+
+    .alert-danger {
+        background-color: #f97a121f;
+        border-color: #f97a1261;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    .alert-primary {
+        background-color: #a4aef21f;
+        border-color: #a4aef261;
+    }
+
+    .alert-warning {
+        background-color: #fdcf7a1f;
+        border-color: #fdcf7a61;
+    }
+
+    .alert-danger {
+        background-color: #ffaa651f;
+        border-color: #ffaa6561;
+    }
+}
+
+.alert {
+    position: relative;
+    padding: 0.75rem 1.25rem;
+    margin-bottom: 1rem;
+    border-radius: 0.375rem;
+    border-width: 1px;
+    border-style: solid;
+}
+
 .type-report {
   opacity: 0.25;
   -webkit-transition: opacity 0.25s ease-in-out;

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/latex/view/mapper/LatexWebViewMapper.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/latex/view/mapper/LatexWebViewMapper.kt
@@ -6,13 +6,8 @@ import org.hyperskill.app.android.latex.view.model.TextAttributes
 import org.hyperskill.app.android.latex.view.model.block.BaseStyleBlock
 import org.hyperskill.app.android.latex.view.model.block.ContentBlock
 import org.hyperskill.app.android.latex.view.model.block.SelectionColorStyleBlock
-import javax.inject.Inject
 
-class LatexWebViewMapper
-@Inject
-constructor(
-    private val context: Context
-) {
+class LatexWebViewMapper(private val context: Context) {
     companion object {
         private const val ASSETS = "file:///android_asset/"
         private const val FONTS = "fonts/"
@@ -24,7 +19,7 @@ constructor(
 
         val blocks =
             listOf(
-                BaseStyleBlock(attributes.isNightMode, fontPath, attributes.textColor),
+                BaseStyleBlock(fontPath, attributes.textColor),
                 SelectionColorStyleBlock(attributes.textColorHighlight)
             )
 

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/latex/view/model/block/BaseStyleBlock.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/latex/view/model/block/BaseStyleBlock.kt
@@ -3,40 +3,47 @@ package org.hyperskill.app.android.latex.view.model.block
 import androidx.annotation.ColorInt
 
 class BaseStyleBlock(
-    isNightMode: Boolean,
-    fontPath: String,
-    @ColorInt
-    private val textColor: Int
+    private val fontPath: String,
+    @ColorInt private val textColor: Int
 ) : ContentBlock {
-    override val header: String = """
-        <link rel="stylesheet" type="text/css" href="file:///android_asset/css/alt.css"/>
-        <link rel="stylesheet" type="text/css" href="file:///android_asset/css/altcontent.css"/>
-        <link rel="stylesheet" type="text/css" href="file:///android_asset/css/bootstrap.css"/>
-        <link rel="stylesheet" type="text/css" href="file:///android_asset/css/fonts.css"/>
-        <link rel="stylesheet" type="text/css" href="file:///android_asset/css/highlight.css"/>
-        <link rel="stylesheet" type="text/css" href="file:///android_asset/css/hljs.css"/>
-        <link rel="stylesheet" type="text/css" href="file:///android_asset/css/icons.css"/>
-        <link rel="stylesheet" type="text/css" href="file:///android_asset/css/step.css"/>
-        <link rel="stylesheet" type="text/css" href="file:///android_asset/css/variables.css"/>
-        <link rel="stylesheet" type="text/css" href="file:///android_asset/css/wysiwyg.css"/>
-        
-        <style>
-            @font-face {
-                font-family: 'Roboto';
-                src: url("$fontPath")
-            }
-        
-            html{-webkit-text-size-adjust: 100%%;}
-            body{
-                font-family:'Roboto', Helvetica, sans-serif; line-height:1.6em;
-                color: ${formatRGBA(textColor)};
-            }
-            h1{font-size: 22px; font-family:'Roboto', Helvetica, sans-serif; line-height:1.6em;text-align: center;}
-            h2{font-size: 19px; font-family:'Roboto', Helvetica, sans-serif; line-height:1.6em;text-align: center;}
-            h3{font-size: 16px; font-family:'Roboto', Helvetica, sans-serif; line-height:1.6em;text-align: center;}
-            img { max-width: 100%%; }
-        </style>
-    """.trimIndent()
+    override val header: String
+        get() = buildHeader()
+
+    private fun buildHeader(): String {
+        val color = formatRGBA(textColor)
+        return """
+            <link rel="stylesheet" type="text/css" href="file:///android_asset/css/alt.css"/>
+                <link rel="stylesheet" type="text/css" href="file:///android_asset/css/altcontent.css"/>
+                <link rel="stylesheet" type="text/css" href="file:///android_asset/css/bootstrap.css"/>
+                <link rel="stylesheet" type="text/css" href="file:///android_asset/css/fonts.css"/>
+                <link rel="stylesheet" type="text/css" href="file:///android_asset/css/highlight.css"/>
+                <link rel="stylesheet" type="text/css" href="file:///android_asset/css/hljs.css"/>
+                <link rel="stylesheet" type="text/css" href="file:///android_asset/css/icons.css"/>
+                <link rel="stylesheet" type="text/css" href="file:///android_asset/css/step.css"/>
+                <link rel="stylesheet" type="text/css" href="file:///android_asset/css/variables.css"/>
+                <link rel="stylesheet" type="text/css" href="file:///android_asset/css/wysiwyg.css"/>
+                
+                <style>
+                    @font-face {
+                        font-family: 'Roboto';
+                        src: url("$fontPath")
+                    }
+                
+                    html{-webkit-text-size-adjust: 100%%;}
+                    body {
+                        font-family:'Roboto', Helvetica, sans-serif; line-height:1.6em;
+                        color: $color;
+                    }
+                    .alert {
+                        color: $color;
+                    }
+                    h1{font-size: 22px; font-family:'Roboto', Helvetica, sans-serif; line-height:1.6em;text-align: center;}
+                    h2{font-size: 19px; font-family:'Roboto', Helvetica, sans-serif; line-height:1.6em;text-align: center;}
+                    h3{font-size: 16px; font-family:'Roboto', Helvetica, sans-serif; line-height:1.6em;text-align: center;}
+                    img { max-width: 100%%; }
+                </style>
+        """.trimIndent()
+    }
 
     private fun formatRGBA(@ColorInt color: Int): String {
         val b = color and 0xFF


### PR DESCRIPTION
Task: [#ALTAPPS-432](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-432/Android-class-alert-alert-primary-has-incorrect-style-for-dark-theme)

**Reviewers**
- [x] @ivan-magda 

**Description**
- add missing styles for .alert html class
- apply text color to .alert html class
