### PR TITLE
ALTAPPS-463: iOS fix fullscreen code problem details latex view

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizCodeFullScreen/Views/StepQuizCodeFullScreenDetailsView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizCodeFullScreen/Views/StepQuizCodeFullScreenDetailsView.swift
@@ -24,17 +24,11 @@ struct StepQuizCodeFullScreenDetailsView: View {
             VStack(alignment: .leading, spacing: appearance.spacing) {
                 StepQuizStatsView(text: stepStats)
 
-                LatexView(
-                    text: .constant(stepText),
-                    configuration: .init(
-                        appearance: .init(labelFont: appearance.stepTextFont),
-                        contentProcessor: ContentProcessor(
-                            injections: ContentProcessor.defaultInjections + [
-                                StepStylesInjection(),
-                                FontInjection(font: appearance.stepTextFont),
-                                TextColorInjection(dynamicColor: appearance.stepTextColor)
-                            ]
-                        )
+                StepTextView(
+                    text: stepText,
+                    appearance: .init(
+                        textFont: appearance.stepTextFont,
+                        textColor: appearance.stepTextColor
                     )
                 )
 


### PR DESCRIPTION
Task: [#ALTAPPS-463](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-463)

**Reviewers**
- [ ] @vladkash 

**Description**
- Fixes rendering problem (not correct height) by replacing `LatexView` with `StepTextView` in the `StepQuizCodeFullScreenDetailsView`