### PR TITLE
ALTAPPS-465: Build and Deploy Analytics Documentation to GitHub Pages

### DIFF
--- a/.github/workflows/gh_pages_analytics.yml
+++ b/.github/workflows/gh_pages_analytics.yml
@@ -2,6 +2,8 @@ name: Build and Deploy Analytics Documentation to GitHub Pages
 
 on:
   push:
+    branches:
+      - 'main'
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/gh_pages_analytics.yml
+++ b/.github/workflows/gh_pages_analytics.yml
@@ -1,0 +1,52 @@
+name: Build and Deploy Analytics Documentation to GitHub Pages
+
+on:
+  push:
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.2.0
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v2.1.3
+
+      - name: Build Documentation
+        run: ./gradlew dokkaAnalytics
+
+      - name: Upload Artifact
+        uses: actions/upload-pages-artifact@v1.0.7
+        with:
+          name: 'github-pages-analytics'
+          path: 'shared/build/dokka/analytics'
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    environment:
+      name: github_pages_analytics
+      url: ${{ steps.deployment.outputs.page_url }}
+    
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1.2.3
+        with:
+          artifact_name: 'github-pages-analytics'

--- a/.github/workflows/gh_pages_analytics.yml
+++ b/.github/workflows/gh_pages_analytics.yml
@@ -23,11 +23,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.2.0
 
+      - name: Setup CI
+        uses: ./.github/actions/setup-android
+
       - name: Setup Pages
         uses: actions/configure-pages@v2.1.3
 
       - name: Build Documentation
         run: ./gradlew dokkaAnalytics
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Artifact
         uses: actions/upload-pages-artifact@v1.0.7

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,8 @@ buildscript {
         classpath(libs.plugin.buildKonfig)
         classpath(libs.plugin.mokoResources)
         classpath(libs.plugin.mokoKswift)
+        classpath(libs.plugin.dokka)
+        classpath(libs.plugin.dokkaBase)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,8 @@ kitPresentationRedux = '1.3.1'
 [libraries]
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 plugin-kotlinSerialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
+plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "kotlin" }
+plugin-dokkaBase = { module = "org.jetbrains.dokka:dokka-base", version.ref = "kotlin" }
 plugin-android = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
 plugin-ktlint = { module = "org.jlleitschuh.gradle:ktlint-gradle", version = "10.2.0" }
 plugin-gradleVersionUpdates = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.39.0" }

--- a/iosHyperskillApp/Podfile.lock
+++ b/iosHyperskillApp/Podfile.lock
@@ -30,7 +30,7 @@ PODS:
   - Sentry (7.13.0):
     - Sentry/Core (= 7.13.0)
   - Sentry/Core (7.13.0)
-  - shared (1.0)
+  - shared (1.5)
   - SkeletonUI (1.0.7)
   - SnapKit (5.6.0)
   - STRegex (2.1.1)
@@ -128,7 +128,7 @@ SPEC CHECKSUMS:
   NukeUI: 3c7ec7b299dd99707afdc783b436f39768b4493b
   PanModal: 3e16ead1a907fb06f4df3f13492fd00149fa4974
   Sentry: c55b9f69091e58cc48adc3c25bbca908a480e08d
-  shared: e454a4a5b5331ac23d196b648f28d37a269334f0
+  shared: 600d2394278b46fc1f9641384cdaa7c59fe55f79
   SkeletonUI: 18fbcd8698480432852d7e30a65b8d5e138266f0
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
   STRegex: d49e88d0fe58538d3175fdd989bc1243b9be2a07

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,5 +1,9 @@
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
+import java.time.Year
 import org.gradle.internal.os.OperatingSystem
+import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.DokkaBaseConfiguration
+import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 import org.jetbrains.kotlin.konan.properties.loadProperties
@@ -13,13 +17,14 @@ plugins {
     id("com.codingfeline.buildkonfig")
     id("dev.icerock.mobile.multiplatform-resources")
     id("dev.icerock.moko.kswift")
+    id("org.jetbrains.dokka")
 }
 
 dependencies {
     ktlintRuleset(libs.ktlintRules)
 }
 
-version = "1.0"
+version = appVersions.versions.versionName.get()
 
 kotlin {
     android()
@@ -193,3 +198,34 @@ tasks.withType<KotlinNativeLink>()
             kSwiftSharedGeneratedSwiftFile.copyTo(iosHyperskillAppSharedSwiftFile, overwrite = true)
         }
     }
+
+tasks.register("dokkaAnalytics", DokkaTask::class.java) {
+    outputDirectory.set(buildDir.resolve("dokka/analytics"))
+
+    moduleName.set("Hyperskill Mobile Analytics")
+
+    pluginConfiguration<DokkaBase, DokkaBaseConfiguration> {
+        footerMessage = "© ${Year.now().value} Hyperskill"
+    }
+
+    dokkaSourceSets {
+        configureEach {
+            // Suppress all packages and the enable only the ones we want
+            perPackageOption {
+                suppress.set(true)
+                // Do not create index pages for empty packages
+                skipEmptyPackages.set(true)
+            }
+
+            perPackageOption {
+                matchingRegex.set(""".*\.domain.analytic.*""")
+                suppress.set(false)
+            }
+
+            perPackageOption {
+                matchingRegex.set(""".*\.analytic.domain.model.*""")
+                suppress.set(false)
+            }
+        }
+    }
+}

--- a/shared/shared.podspec
+++ b/shared/shared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'shared'
-    spec.version                  = '1.0'
+    spec.version                  = '1.5'
     spec.homepage                 = 'https://github.com/hyperskill/mobile-app'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-465](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-465)

**Checklist**

_Before Code Review:_

- [ ] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [ ] Sentry Performance Monitoring of screen loading is added for new screens;
- [ ] View analytics events are added for new screens;
- [ ] New analytics events are documented;
- [ ] All checks have been passed;
- [ ] Changes have been checked locally.

**Description**
- Builds documentation with Dokka
- Adds workflow that builds and deploys analytics documentation to GitHub Pages