### PR TITLE
ALTTAPPS-457: Android topics from other track for repetition

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/core/view/ui/adapter/decoration/CustomDividerItemDecoration.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/core/view/ui/adapter/decoration/CustomDividerItemDecoration.kt
@@ -16,13 +16,11 @@ class CustomDividerItemDecoration(
         state: RecyclerView.State,
     ) {
         val position = parent.getChildAdapterPosition(view)
-        if(position != RecyclerView.NO_POSITION) {
+        if (position != RecyclerView.NO_POSITION) {
             setRectOffset(position, outRect, state)
         }
     }
 }
 
-fun RecyclerView.itemDecoration(
-    setRectOffset: SetRectOffset
-) : RecyclerView.ItemDecoration = CustomDividerItemDecoration(setRectOffset)
-    .also { addItemDecoration(it) }
+fun RecyclerView.itemDecoration(setRectOffset: SetRectOffset): RecyclerView.ItemDecoration =
+    CustomDividerItemDecoration(setRectOffset).also { addItemDecoration(it) }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/core/view/ui/adapter/decoration/CustomDividerItemDecoration.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/core/view/ui/adapter/decoration/CustomDividerItemDecoration.kt
@@ -1,0 +1,28 @@
+package org.hyperskill.app.android.core.view.ui.adapter.decoration
+
+import android.graphics.Rect
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+private typealias SetRectOffset = (position: Int, rect: Rect, state: RecyclerView.State) -> Unit
+
+class CustomDividerItemDecoration(
+    private val setRectOffset: SetRectOffset
+) : RecyclerView.ItemDecoration() {
+    override fun getItemOffsets(
+        outRect: Rect,
+        view: View,
+        parent: RecyclerView,
+        state: RecyclerView.State,
+    ) {
+        val position = parent.getChildAdapterPosition(view)
+        if(position != RecyclerView.NO_POSITION) {
+            setRectOffset(position, outRect, state)
+        }
+    }
+}
+
+fun RecyclerView.itemDecoration(
+    setRectOffset: SetRectOffset
+) : RecyclerView.ItemDecoration = CustomDividerItemDecoration(setRectOffset)
+    .also { addItemDecoration(it) }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/topics_repetitions/view/delegate/TopicsRepetitionListDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/topics_repetitions/view/delegate/TopicsRepetitionListDelegate.kt
@@ -55,7 +55,7 @@ class TopicsRepetitionListDelegate(
                     is TopicsRepetitionListItem.Topic,
                     TopicsRepetitionListItem.LoadingStub -> {
                         val isAfterHeader  = if (position > 0) {
-                            topicsAdapter.items.getOrNull(position -1 ) is TopicsRepetitionListItem.Header
+                            topicsAdapter.items.getOrNull(position - 1) is TopicsRepetitionListItem.Header
                         } else {
                             false
                         }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/topics_repetitions/view/delegate/TopicsRepetitionListDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/topics_repetitions/view/delegate/TopicsRepetitionListDelegate.kt
@@ -55,7 +55,7 @@ class TopicsRepetitionListDelegate(
                     is TopicsRepetitionListItem.Topic,
                     TopicsRepetitionListItem.LoadingStub -> {
                         val isAfterHeader  = if (position > 0) {
-                            topicsAdapter.items[position - 1] is TopicsRepetitionListItem.Header
+                            topicsAdapter.items.getOrNull(position -1 ) is TopicsRepetitionListItem.Header
                         } else {
                             false
                         }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/topics_repetitions/view/delegate/TopicsRepetitionListDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/topics_repetitions/view/delegate/TopicsRepetitionListDelegate.kt
@@ -71,18 +71,21 @@ class TopicsRepetitionListDelegate(
     fun render(context: Context, previousState: TopicsRepetitionListState?, state: TopicsRepetitionListState) {
         if (previousState == state) return
         with(binding) {
-            root.isVisible = state.topicsToRepeatFromCurrentTrack.isNotEmpty()
+            root.isVisible =
+                state.topicsToRepeatFromCurrentTrack.isNotEmpty() || state.topicsToRepeatFromOtherTracks.isNotEmpty()
+
             topicsListTitleTextView.setTextIfChanged(state.repeatBlockTitle)
 
             if (previousState?.showMoreButtonState != state.showMoreButtonState) {
                 topicsListsShowMoreButton.isVisible =
                     state.showMoreButtonState == ShowMoreButtonState.AVAILABLE
             }
-            topicsListRecyclerView.isVisible =
-                state.topicsToRepeatFromCurrentTrack.isNotEmpty() || state.topicsToRepeatFromOtherTracks.isNotEmpty()
+
             topicsAdapter.items = buildList {
-                add(TopicsRepetitionListItem.Header(state.trackTopicsTitle))
-                addAll(state.topicsToRepeatFromCurrentTrack.map(TopicsRepetitionListItem::Topic))
+                if (state.topicsToRepeatFromCurrentTrack.isNotEmpty()) {
+                    add(TopicsRepetitionListItem.Header(state.trackTopicsTitle))
+                    addAll(state.topicsToRepeatFromCurrentTrack.map(TopicsRepetitionListItem::Topic))
+                }
                 if (state.topicsToRepeatFromOtherTracks.isNotEmpty()) {
                     add(
                         TopicsRepetitionListItem.Header(

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/topics_repetitions/view/fragment/TopicsRepetitionFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/topics_repetitions/view/fragment/TopicsRepetitionFragment.kt
@@ -133,11 +133,13 @@ class TopicsRepetitionFragment :
                     state = viewState.repetitionsStatus
                 )
                 topicsRepetitionListDelegate?.render(
+                    context = requireContext(),
                     previousState = this@TopicsRepetitionFragment.viewState?.let {
                         TopicsRepetitionListState(
                             repeatBlockTitle = it.repeatBlockTitle,
                             trackTopicsTitle = it.trackTopicsTitle,
-                            topicsToRepeat = it.topicsToRepeatFromCurrentTrack,
+                            topicsToRepeatFromCurrentTrack = it.topicsToRepeatFromCurrentTrack,
+                            topicsToRepeatFromOtherTracks = it.topicsToRepeatFromOtherTracks,
                             topicsToRepeatWillLoadedCount = it.topicsToRepeatWillLoadedCount,
                             showMoreButtonState = it.showMoreButtonState
                         )
@@ -145,7 +147,8 @@ class TopicsRepetitionFragment :
                     state = TopicsRepetitionListState(
                         repeatBlockTitle = viewState.repeatBlockTitle,
                         trackTopicsTitle = viewState.trackTopicsTitle,
-                        topicsToRepeat = viewState.topicsToRepeatFromCurrentTrack,
+                        topicsToRepeatFromCurrentTrack = viewState.topicsToRepeatFromCurrentTrack,
+                        topicsToRepeatFromOtherTracks = viewState.topicsToRepeatFromOtherTracks,
                         topicsToRepeatWillLoadedCount = viewState.topicsToRepeatWillLoadedCount,
                         showMoreButtonState = viewState.showMoreButtonState
                     )

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/topics_repetitions/view/model/TopicsRepetitionListItem.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/topics_repetitions/view/model/TopicsRepetitionListItem.kt
@@ -5,4 +5,5 @@ import org.hyperskill.app.topics_repetitions.view.model.TopicToRepeat
 sealed interface TopicsRepetitionListItem {
     data class Topic(val topic: TopicToRepeat) : TopicsRepetitionListItem
     object LoadingStub : TopicsRepetitionListItem
+    data class Header(val title: String) : TopicsRepetitionListItem
 }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/topics_repetitions/view/model/TopicsRepetitionListState.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/topics_repetitions/view/model/TopicsRepetitionListState.kt
@@ -6,7 +6,8 @@ import org.hyperskill.app.topics_repetitions.view.model.TopicToRepeat
 data class TopicsRepetitionListState(
     val repeatBlockTitle: String,
     val trackTopicsTitle: String,
-    val topicsToRepeat: List<TopicToRepeat>,
+    val topicsToRepeatFromCurrentTrack: List<TopicToRepeat>,
+    val topicsToRepeatFromOtherTracks: List<TopicToRepeat>,
     val showMoreButtonState: ShowMoreButtonState,
     val topicsToRepeatWillLoadedCount: Int
 )

--- a/androidHyperskillApp/src/main/res/layout/item_topics_to_repeat_header.xml
+++ b/androidHyperskillApp/src/main/res/layout/item_topics_to_repeat_header.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/topicsListTrackTitleTextView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textSize="12sp"
+    tools:text="Topics from track Python Core"
+    />

--- a/androidHyperskillApp/src/main/res/layout/layout_topics_repetition_topics_list.xml
+++ b/androidHyperskillApp/src/main/res/layout/layout_topics_repetition_topics_list.xml
@@ -3,8 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="20dp"
-    android:paddingBottom="10dp"
+    android:padding="20dp"
     android:background="@color/color_surface"
     android:orientation="vertical"
     >
@@ -15,18 +14,7 @@
         android:layout_height="wrap_content"
         android:textAppearance="@style/TextAppearance.AppCompat.Body2"
         android:textSize="18sp"
-        android:layout_marginHorizontal="20dp"
         tools:text="8 topics to repeat"
-        />
-
-    <TextView
-        android:id="@+id/topicsListTrackTitleTextView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textSize="12sp"
-        android:layout_marginTop="20dp"
-        android:layout_marginHorizontal="20dp"
-        tools:text="Topics from track Python Core"
         />
 
     <androidx.recyclerview.widget.RecyclerView
@@ -34,7 +22,6 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:layout_marginTop="20dp"
         tools:listitem="@layout/item_topic_to_repeat"
         tools:itemCount="3"
         />
@@ -47,12 +34,8 @@
         android:clickable="true"
         android:focusable="true"
         android:foreground="?attr/selectableItemBackground"
-        android:paddingTop="10dp"
-        android:layout_marginTop="10dp"
-        android:paddingHorizontal="10dp"
-        android:layout_marginHorizontal="10dp"
-        android:paddingBottom="10dp"
         android:text="@string/step_quiz_hints_show_more_text"
+        android:layout_marginTop="20dp"
         />
 
 </LinearLayout>

--- a/androidHyperskillApp/src/main/res/values/dimens.xml
+++ b/androidHyperskillApp/src/main/res/values/dimens.xml
@@ -80,7 +80,8 @@
     <dimen name="onboarding_splash_icon_height">45dp</dimen>
 
     <!-- Track screen -->
-    <dimen name="track_next_topic_vertical_item_margin">16dp</dimen>
+    <dimen name="track_next_topic_vertical_item_margin">8dp</dimen>
+    <dimen name="track_next_topic_header_vertical_item_margin">20dp</dimen>
     <dimen name="track_next_topic_horizontal_item_margin">20dp</dimen>
 
     <!--New user screen-->


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-457](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-457)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] Sentry Performance Monitoring of screen loading is added for new screens;
- [x] View analytics events are added for new screens;
- [x] New analytics events are documented;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Move topics-to-repeat-list header into recyclerView
- Add topics-from-other tracks rendering in recyclerView
- Implement CustomDividerItemDecoration for conditional dividers 
