### PR TITLE
ALTAPPS-332: Fix android app crash in local notifications

### DIFF
--- a/androidHyperskillApp/src/main/AndroidManifest.xml
+++ b/androidHyperskillApp/src/main/AndroidManifest.xml
@@ -6,6 +6,10 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <uses-permission
+        android:name="android.permission.WAKE_LOCK"
+        android:maxSdkVersion="26"/>
+
     <application
         android:label="@string/app_name"
         android:name=".HyperskillApp"

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification/receiver/AlarmReceiver.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification/receiver/AlarmReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import org.hyperskill.app.android.notification.service.NotificationAlarmService
 
+@Deprecated("Replace with WorkManager")
 class AlarmReceiver : BroadcastReceiver() {
     companion object {
         const val REQUEST_CODE = 151

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification/receiver/BootCompleteReceiver.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification/receiver/BootCompleteReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import org.hyperskill.app.android.notification.service.BootCompleteService
 
+@Deprecated("Replace with WorkManager")
 class BootCompleteReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == Intent.ACTION_BOOT_COMPLETED) {

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification/service/BootCompleteService.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification/service/BootCompleteService.kt
@@ -6,6 +6,7 @@ import androidx.core.app.JobIntentService
 import org.hyperskill.app.android.HyperskillApp
 import org.hyperskill.app.android.notification.NotificationDelegate
 
+@Deprecated("Replace with WorkManager")
 class BootCompleteService : JobIntentService() {
     private lateinit var notificationDelegates: Set<@JvmSuppressWildcards NotificationDelegate>
 

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification/service/NotificationAlarmService.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification/service/NotificationAlarmService.kt
@@ -6,6 +6,7 @@ import androidx.core.app.JobIntentService
 import org.hyperskill.app.android.HyperskillApp
 import org.hyperskill.app.android.notification.NotificationPublisher
 
+@Deprecated("Replace with WorkManager")
 class NotificationAlarmService : JobIntentService() {
     private lateinit var notificationPublisher: NotificationPublisher
 


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-332](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] Sentry Performance Monitoring of screen loading is added for new screens;
- [x] View analytics events are added for new screens;
- [x] New analytics events are documented;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Add missing WAKE-LOCK permisson
- Mark all current android-specific locac-notification infrastructure as Deprecated to replace it with WorkManager in future