### PR TITLE
ALTAPPS-414: iOS fix choices elements HTML-content rendering (no line breaks)

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Helpers/HTMLToAttributedStringConverter.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Helpers/HTMLToAttributedStringConverter.swift
@@ -7,11 +7,7 @@ protocol HTMLToAttributedStringConverterProtocol {
 }
 
 final class HTMLToAttributedStringConverter: HTMLToAttributedStringConverterProtocol {
-    static let defaultTagTransformers: [TagTransformer] = [
-        TagTransformer.brTransformer,
-        TagTransformer(tagName: "p", tagType: .start, replaceValue: "\n"),
-        TagTransformer(tagName: "p", tagType: .end, replaceValue: "\n")
-    ]
+    static let defaultTagTransformers: [TagTransformer] = [.brTransformer]
 
     static let defaultLinkStyle = Style("a")
         .foregroundColor(
@@ -41,7 +37,7 @@ final class HTMLToAttributedStringConverter: HTMLToAttributedStringConverterProt
     init(
         font: UIFont,
         tagStyles: [Style] = [],
-        tagTransformers: [TagTransformer] = []
+        tagTransformers: [TagTransformer] = defaultTagTransformers
     ) {
         let defaultStyles = Self.defaultTagStyles(fontSize: font.pointSize)
         let finalStyles = tagStyles.isEmpty


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-414](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-414)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] Sentry Performance Monitoring of screen loading is added for new screens;
- [x] View analytics events are added for new screens;
- [x] New analytics events are documented;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Updates `HTMLToAttributedStringConverter` initializer to use `defaultTagTransformers`