### PR TITLE
ALTAPPS-479: Add theory button on the repetitions quiz screen

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_practice/view/fragment/StepPracticeFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_practice/view/fragment/StepPracticeFragment.kt
@@ -56,7 +56,7 @@ class StepPracticeFragment : Fragment(R.layout.fragment_step_practice) {
                 isVisible = step.topicTheory != null && stepRoute is StepRoute.Repeat
                 actionView.setOnClickListener {
                     step.topicTheory?.let { theoryId ->
-                        requireRouter().navigateTo(StepScreen(StepRoute.Learn(theoryId)))
+                        requireRouter().navigateTo(StepScreen(StepRoute.Repeat(theoryId)))
                     }
                 }
             }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_practice/view/fragment/StepPracticeFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_practice/view/fragment/StepPracticeFragment.kt
@@ -12,6 +12,7 @@ import org.hyperskill.app.android.core.extensions.argument
 import org.hyperskill.app.android.core.view.ui.fragment.setChildFragment
 import org.hyperskill.app.android.core.view.ui.navigation.requireRouter
 import org.hyperskill.app.android.databinding.FragmentStepPracticeBinding
+import org.hyperskill.app.android.step.view.screen.StepScreen
 import org.hyperskill.app.android.step_content_text.view.fragment.TextStepContentFragment
 import org.hyperskill.app.android.step_quiz.view.factory.StepQuizFragmentFactory
 import org.hyperskill.app.android.step_quiz_hints.fragment.StepQuizHintsFragment
@@ -47,12 +48,20 @@ class StepPracticeFragment : Fragment(R.layout.fragment_step_practice) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewBinding.stepPracticeAppBar.stepQuizToolbar.root.setNavigationOnClickListener {
-            requireRouter().exit()
+        with(viewBinding.stepPracticeAppBar.stepQuizToolbar) {
+            root.setNavigationOnClickListener {
+                requireRouter().exit()
+            }
+            root.menu.findItem(R.id.theory).apply {
+                isVisible = step.topicTheory != null && stepRoute is StepRoute.Repeat
+                actionView.setOnClickListener {
+                    step.topicTheory?.let { theoryId ->
+                        requireRouter().navigateTo(StepScreen(StepRoute.Learn(theoryId)))
+                    }
+                }
+            }
+            stepQuizToolbarTitle.text = step.title
         }
-        viewBinding.stepPracticeAppBar.stepQuizToolbar.stepQuizToolbarTitle.text =
-            step.title
-
         viewBinding.stepPracticeCompletion.text = resourceProvider.getString(
             SharedResources.strings.step_quiz_stats_text,
             step.solvedBy.toString(),

--- a/androidHyperskillApp/src/main/res/layout/view_step_quiz_theory_button.xml
+++ b/androidHyperskillApp/src/main/res/layout/view_step_quiz_theory_button.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/stepQuizTheory"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:text="@string/step_theory_text"
+    android:textColor="@color/color_primary"
+    android:textSize="16sp"
+    android:gravity="center"
+    android:paddingHorizontal="16dp"
+    />

--- a/androidHyperskillApp/src/main/res/menu/step_quiz_appbar_menu.xml
+++ b/androidHyperskillApp/src/main/res/menu/step_quiz_appbar_menu.xml
@@ -3,9 +3,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/search"
-        android:icon="@drawable/ic_info_outline_24px"
-        android:title="@string/step_quiz_appbar_tooltip_title"
+        android:id="@+id/theory"
+        android:title="@string/step_theory_text"
+        app:actionLayout="@layout/view_step_quiz_theory_button"
         app:showAsAction="ifRoom" />
 
 </menu>


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-479](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-479/Android-Add-theory-button-on-the-repetitions-quiz-screen)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] Sentry Performance Monitoring of screen loading is added for new screens;
- [x] View analytics events are added for new screens;
- [x] New analytics events are documented;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
Add theory item into StepPracticeFragment's menu
