### PR TITLE
ALTAPPS-459: Replace spiner loading with skeleton on Home and Track screens.

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/home/view/ui/fragment/HomeFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/home/view/ui/fragment/HomeFragment.kt
@@ -8,6 +8,8 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
+import androidx.transition.AutoTransition
+import androidx.transition.TransitionManager
 import by.kirich1409.viewbindingdelegate.viewBinding
 import org.hyperskill.app.SharedResources
 import org.hyperskill.app.android.HyperskillApp
@@ -128,7 +130,7 @@ class HomeFragment :
     private fun initViewStateDelegate() {
         with(viewStateDelegate) {
             addState<HomeFeature.State.Idle>()
-            addState<HomeFeature.State.Loading>(viewBinding.homeScreenProgress)
+            addState<HomeFeature.State.Loading>(viewBinding.homeScreenSkeleton.root, viewBinding.homeScreenAppBar)
             addState<HomeFeature.State.NetworkError>(viewBinding.homeScreenError.root)
             addState<HomeFeature.State.Content>(viewBinding.homeScreenContainer, viewBinding.homeScreenAppBar)
         }
@@ -153,6 +155,7 @@ class HomeFragment :
 
     override fun render(state: HomeFeature.State) {
         viewStateDelegate.switchState(state)
+        TransitionManager.beginDelayedTransition(viewBinding.root, AutoTransition())
         if (state is HomeFeature.State.Content) {
             if (state.isLoadingMagicLink) {
                 LoadingProgressDialogFragment.newInstance()

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/track/view/fragment/TrackFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/track/view/fragment/TrackFragment.kt
@@ -9,6 +9,8 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.transition.AutoTransition
+import androidx.transition.TransitionManager
 import by.kirich1409.viewbindingdelegate.viewBinding
 import coil.ImageLoader
 import coil.decode.SvgDecoder
@@ -84,7 +86,7 @@ class TrackFragment :
     private fun initViewStateDelegate() {
         with(viewStateDelegate) {
             addState<TrackFeature.State.Idle>()
-            addState<TrackFeature.State.Loading>(viewBinding.trackProgressBar)
+            addState<TrackFeature.State.Loading>(viewBinding.trackSkeleton.root)
             addState<TrackFeature.State.NetworkError>(viewBinding.trackError.root)
             addState<TrackFeature.State.Content>(viewBinding.trackContainer)
         }
@@ -124,7 +126,7 @@ class TrackFragment :
 
     override fun render(state: TrackFeature.State) {
         viewStateDelegate.switchState(state)
-
+        TransitionManager.beginDelayedTransition(viewBinding.root, AutoTransition())
         if (state is TrackFeature.State.Content) {
             renderContent(state)
         }

--- a/androidHyperskillApp/src/main/res/layout/fragment_home.xml
+++ b/androidHyperskillApp/src/main/res/layout/fragment_home.xml
@@ -106,7 +106,6 @@
                 android:text="@string/home_keep_practicing_text"
                 />
 
-
             <include
                 android:id="@+id/homeScreenProblemOfDayCard"
                 layout="@layout/layout_problem_of_the_day_card"
@@ -171,11 +170,15 @@
 
     </androidx.core.widget.NestedScrollView>
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
-        android:id="@+id/homeScreenProgress"
-        android:layout_width="wrap_content"
+    <include
+        android:id="@+id/homeScreenSkeleton"
+        layout="@layout/layout_home_skeleton"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="16dp"
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
+        />
 
     <include
         android:id="@+id/homeScreenError"

--- a/androidHyperskillApp/src/main/res/layout/fragment_track.xml
+++ b/androidHyperskillApp/src/main/res/layout/fragment_track.xml
@@ -19,8 +19,8 @@
             <com.google.android.material.imageview.ShapeableImageView
                 android:id="@+id/trackIconImageView"
                 style="@style/TrackIconStrokeStyle"
-                android:layout_width="34dp"
-                android:layout_height="34dp"
+                android:layout_width="@dimen/track_icon_size"
+                android:layout_height="@dimen/track_icon_size"
                 android:padding="1dp"
                 android:src="@drawable/ic_project_graduate"
                 app:contentPadding="-1dp"
@@ -369,18 +369,20 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
-        android:id="@+id/trackProgressBar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+    <include
+        android:id="@+id/trackSkeleton"
+        layout="@layout/layout_track_skeleton"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="20dp"
+        />
 
     <include
         android:id="@+id/trackError"
         layout="@layout/error_no_connection_with_button"
-
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="gone" />
+        android:visibility="gone"
+        />
 
 </FrameLayout>

--- a/androidHyperskillApp/src/main/res/layout/layout_home_skeleton.xml
+++ b/androidHyperskillApp/src/main/res/layout/layout_home_skeleton.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    >
+
+    <org.hyperskill.app.android.ui.custom.LoadingView
+        android:layout_width="match_parent"
+        android:layout_height="20dp"/>
+
+    <org.hyperskill.app.android.ui.custom.LoadingView
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:layout_marginTop="20dp"
+        />
+
+    <org.hyperskill.app.android.ui.custom.LoadingView
+        android:layout_width="match_parent"
+        android:layout_height="120dp"
+        android:layout_marginTop="20dp"
+        />
+
+    <org.hyperskill.app.android.ui.custom.LoadingView
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/auth_button_height"
+        android:layout_marginTop="24dp"
+        />
+
+</LinearLayout>

--- a/androidHyperskillApp/src/main/res/layout/layout_track_skeleton.xml
+++ b/androidHyperskillApp/src/main/res/layout/layout_track_skeleton.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        >
+
+        <org.hyperskill.app.android.ui.custom.LoadingView
+            android:layout_width="@dimen/track_icon_size"
+            android:layout_height="@dimen/track_icon_size"
+            app:radius="50dp"
+            android:layout_gravity="center_horizontal"
+            />
+
+        <org.hyperskill.app.android.ui.custom.LoadingView
+            android:layout_width="180dp"
+            android:layout_height="25dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="16dp"
+            />
+
+        <org.hyperskill.app.android.ui.custom.LoadingView
+            android:layout_width="80dp"
+            android:layout_height="15dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="8dp"
+            />
+
+        <org.hyperskill.app.android.ui.custom.LoadingView
+            android:layout_width="200dp"
+            android:layout_height="25dp"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="40dp"
+            />
+
+        <org.hyperskill.app.android.ui.custom.LoadingView
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:layout_marginHorizontal="@dimen/track_next_topic_horizontal_item_margin"
+            android:layout_marginTop="8dp"
+            />
+
+        <org.hyperskill.app.android.ui.custom.LoadingView
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:layout_marginHorizontal="@dimen/track_next_topic_horizontal_item_margin"
+            android:layout_marginTop="8dp"
+            />
+
+        <org.hyperskill.app.android.ui.custom.LoadingView
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:layout_marginHorizontal="@dimen/track_next_topic_horizontal_item_margin"
+            android:layout_marginTop="8dp"
+            />
+
+        <org.hyperskill.app.android.ui.custom.LoadingView
+            android:layout_width="200dp"
+            android:layout_height="25dp"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="20dp"
+            />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginHorizontal="20dp"
+            >
+
+            <org.hyperskill.app.android.ui.custom.LoadingView
+                android:layout_width="0dp"
+                android:layout_height="100dp"
+                android:layout_marginTop="20dp"
+                android:layout_weight="1"
+                />
+
+            <org.hyperskill.app.android.ui.custom.LoadingView
+                android:layout_width="0dp"
+                android:layout_height="100dp"
+                android:layout_marginTop="20dp"
+                android:layout_weight="1"
+                android:layout_marginStart="8dp"
+                />
+
+        </LinearLayout>
+
+        <org.hyperskill.app.android.ui.custom.LoadingView
+            android:layout_width="match_parent"
+            android:layout_height="100dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginHorizontal="20dp"
+            />
+
+        <org.hyperskill.app.android.ui.custom.LoadingView
+            android:layout_width="match_parent"
+            android:layout_height="100dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginHorizontal="20dp"
+            />
+
+    </LinearLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/androidHyperskillApp/src/main/res/values/dimens.xml
+++ b/androidHyperskillApp/src/main/res/values/dimens.xml
@@ -80,6 +80,7 @@
     <dimen name="onboarding_splash_icon_height">45dp</dimen>
 
     <!-- Track screen -->
+    <dimen name="track_icon_size">34dp</dimen>
     <dimen name="track_next_topic_vertical_item_margin">8dp</dimen>
     <dimen name="track_next_topic_header_vertical_item_margin">20dp</dimen>
     <dimen name="track_next_topic_horizontal_item_margin">20dp</dimen>


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-459](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-459)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] Sentry Performance Monitoring of screen loading is added for new screens;
- [x] View analytics events are added for new screens;
- [x] New analytics events are documented;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Add skeleton loading view to HomeFragment and TrackFragment