### PR TITLE
ALTAPPS-534: Move ImageLoade intoAndroidAppComponent root

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/core/injection/AndroidAppComponent.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/core/injection/AndroidAppComponent.kt
@@ -2,6 +2,7 @@ package org.hyperskill.app.android.core.injection
 
 import android.content.Context
 import org.hyperskill.app.android.code.injection.PlatformCodeEditorComponent
+import org.hyperskill.app.android.image_loading.injection.ImageLoadingComponent
 import org.hyperskill.app.android.latex.injection.PlatformLatexComponent
 import org.hyperskill.app.android.notification.injection.PlatformNotificationComponent
 import org.hyperskill.app.auth.injection.AuthCredentialsComponent
@@ -37,6 +38,7 @@ interface AndroidAppComponent : AppGraph {
     val context: Context
     val platformMainComponent: PlatformMainComponent
     val platformNotificationComponent: PlatformNotificationComponent
+    val imageLoadingComponent: ImageLoadingComponent
 
     fun buildPlatformAuthSocialWebViewComponent(): PlatformAuthSocialWebViewComponent
     fun buildPlatformAuthSocialComponent(authSocialComponent: AuthSocialComponent): PlatformAuthSocialComponent

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/core/injection/AndroidAppComponentImpl.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/core/injection/AndroidAppComponentImpl.kt
@@ -6,6 +6,8 @@ import org.hyperskill.app.analytic.injection.AnalyticComponent
 import org.hyperskill.app.analytic.injection.AnalyticComponentImpl
 import org.hyperskill.app.android.code.injection.PlatformCodeEditorComponent
 import org.hyperskill.app.android.code.injection.PlatformCodeEditorComponentImpl
+import org.hyperskill.app.android.image_loading.injection.ImageLoadingComponent
+import org.hyperskill.app.android.image_loading.injection.ImageLoadingComponentImpl
 import org.hyperskill.app.android.latex.injection.PlatformLatexComponent
 import org.hyperskill.app.android.latex.injection.PlatformLatexComponentImpl
 import org.hyperskill.app.android.notification.injection.PlatformNotificationComponent
@@ -132,6 +134,9 @@ class AndroidAppComponentImpl(
 
     override val platformMainComponent: PlatformMainComponent =
         PlatformMainComponentImpl(mainComponent)
+
+    override val imageLoadingComponent: ImageLoadingComponent =
+        ImageLoadingComponentImpl(context)
 
     override val networkComponent: NetworkComponent =
         NetworkComponentImpl(this)

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/image_loading/injection/ImageLoadingComponent.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/image_loading/injection/ImageLoadingComponent.kt
@@ -1,0 +1,7 @@
+package org.hyperskill.app.android.image_loading.injection
+
+import coil.ImageLoader
+
+interface ImageLoadingComponent {
+    val imageLoader: ImageLoader
+}

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/image_loading/injection/ImageLoadingComponentImpl.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/image_loading/injection/ImageLoadingComponentImpl.kt
@@ -1,0 +1,14 @@
+package org.hyperskill.app.android.image_loading.injection
+
+import android.content.Context
+import coil.ImageLoader
+import coil.decode.SvgDecoder
+
+class ImageLoadingComponentImpl(context: Context) : ImageLoadingComponent {
+    override val imageLoader: ImageLoader =
+        ImageLoader.Builder(context)
+            .components {
+                add(SvgDecoder.Factory())
+            }
+            .build()
+}

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/placeholder_new_user/dialog/NewUserTrackDetailsBottomSheet.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/placeholder_new_user/dialog/NewUserTrackDetailsBottomSheet.kt
@@ -9,13 +9,13 @@ import android.view.ViewGroup
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.fragment.app.viewModels
 import coil.ImageLoader
-import coil.decode.SvgDecoder
 import coil.load
 import com.chrynan.parcelable.core.getParcelable
 import com.chrynan.parcelable.core.putParcelable
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import org.hyperskill.app.android.HyperskillApp
 import org.hyperskill.app.android.R
 import org.hyperskill.app.android.databinding.FragmentNewUserTrackDetailsBinding
 import org.hyperskill.app.placeholder_new_user.presentation.PlaceholderNewUserFeature
@@ -41,12 +41,8 @@ class NewUserTrackDetailsBottomSheet : BottomSheetDialogFragment() {
 
     private var track: PlaceholderNewUserViewData.Track? = null
 
-    private val svgImageLoader by lazy(LazyThreadSafetyMode.NONE) {
-        ImageLoader.Builder(requireContext())
-            .components {
-                add(SvgDecoder.Factory())
-            }
-            .build()
+    private val svgImageLoader: ImageLoader by lazy(LazyThreadSafetyMode.NONE) {
+        HyperskillApp.graph().imageLoadingComponent.imageLoader
     }
 
     private val placeholderNewUserViewModel: PlaceholderNewUserViewModel by viewModels(ownerProducer = ::requireParentFragment)

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/placeholder_new_user/fragment/PlaceholderNewUserFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/placeholder_new_user/fragment/PlaceholderNewUserFragment.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import by.kirich1409.viewbindingdelegate.viewBinding
 import coil.ImageLoader
-import coil.decode.SvgDecoder
 import coil.load
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -53,12 +52,8 @@ class PlaceholderNewUserFragment :
 
     private var viewDataMapper: PlaceholderNewUserViewDataMapper? = null
 
-    private val svgImageLoader by lazy(LazyThreadSafetyMode.NONE) {
-        ImageLoader.Builder(requireContext())
-            .components {
-                add(SvgDecoder.Factory())
-            }
-            .build()
+    private val svgImageLoader: ImageLoader by lazy(LazyThreadSafetyMode.NONE) {
+        HyperskillApp.graph().imageLoadingComponent.imageLoader
     }
 
     private val trackAdapter by lazy(LazyThreadSafetyMode.NONE) {

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/profile/view/fragment/ProfileFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/profile/view/fragment/ProfileFragment.kt
@@ -9,7 +9,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import by.kirich1409.viewbindingdelegate.viewBinding
 import coil.ImageLoader
-import coil.decode.SvgDecoder
 import coil.load
 import coil.transform.CircleCropTransformation
 import java.util.Locale
@@ -69,11 +68,7 @@ class ProfileFragment :
         HyperskillApp.graph().platformNotificationComponent
 
     private val imageLoader: ImageLoader by lazy(LazyThreadSafetyMode.NONE) {
-        ImageLoader.Builder(requireContext())
-            .components {
-                add(SvgDecoder.Factory())
-            }
-            .build()
+        HyperskillApp.graph().imageLoadingComponent.imageLoader
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz_hints/fragment/StepQuizHintsFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz_hints/fragment/StepQuizHintsFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import by.kirich1409.viewbindingdelegate.viewBinding
 import coil.ImageLoader
-import coil.decode.SvgDecoder
 import com.chrynan.parcelable.core.getParcelable
 import com.chrynan.parcelable.core.putParcelable
 import org.hyperskill.app.android.HyperskillApp
@@ -45,12 +44,8 @@ class StepQuizHintsFragment :
 
     private var stepQuizHintsDelegate: StepQuizHintsDelegate? = null
 
-    private val svgImageLoader by lazy(LazyThreadSafetyMode.NONE) {
-        ImageLoader.Builder(requireContext())
-            .components {
-                add(SvgDecoder.Factory())
-            }
-            .build()
+    private val svgImageLoader: ImageLoader by lazy(LazyThreadSafetyMode.NONE) {
+        HyperskillApp.graph().imageLoadingComponent.imageLoader
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/track/view/fragment/TrackFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/track/view/fragment/TrackFragment.kt
@@ -13,7 +13,6 @@ import androidx.transition.AutoTransition
 import androidx.transition.TransitionManager
 import by.kirich1409.viewbindingdelegate.viewBinding
 import coil.ImageLoader
-import coil.decode.SvgDecoder
 import coil.load
 import coil.size.Scale
 import org.hyperskill.app.SharedResources

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/track/view/fragment/TrackFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/track/view/fragment/TrackFragment.kt
@@ -61,6 +61,10 @@ class TrackFragment :
         }
     }
 
+    private val imageLoader: ImageLoader by lazy(LazyThreadSafetyMode.NONE) {
+        HyperskillApp.graph().imageLoadingComponent.imageLoader
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         injectComponents()
@@ -146,13 +150,8 @@ class TrackFragment :
     }
 
     private fun renderTrackCoverAndName(track: Track) {
-        val svgImageLoader = ImageLoader.Builder(requireContext())
-            .components {
-                add(SvgDecoder.Factory())
-            }
-            .build()
         if (track.cover != null) {
-            viewBinding.trackIconImageView.load(track.cover, svgImageLoader) {
+            viewBinding.trackIconImageView.load(track.cover, imageLoader) {
                 scale(Scale.FILL)
             }
         } else {


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-534](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-534/Move-ImageLoader-into-AndroidAppComponent-root)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] Sentry Performance Monitoring of screen loading is added for new screens;
- [x] View analytics events are added for new screens;
- [x] New analytics events are documented;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
Use a singleton instance of ImageLoader across application
