### PR TITLE
ALTAPPS-580: Android fix ResetCode action on CodeStepQuizFullScreenDialogFragment

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz_fullscreen_code/dialog/CodeStepQuizFullScreenDialogFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz_fullscreen_code/dialog/CodeStepQuizFullScreenDialogFragment.kt
@@ -214,7 +214,7 @@ class CodeStepQuizFullScreenDialogFragment : DialogFragment() {
                 false,
                 onDetailsIsExpandedStateChanged = {}
             ),
-            codeToolbarAdapter = codeToolbarAdapter,
+            codeToolbarAdapter = codeToolbarAdapter
         )
 
         codeLayoutDelegate.setLanguage(lang, code)
@@ -229,6 +229,7 @@ class CodeStepQuizFullScreenDialogFragment : DialogFragment() {
     }
 
     private fun onResetClick() {
+        syncCodeStateWithParent()
         (parentFragment as? Callback)?.onResetCodeClick()
     }
 
@@ -268,8 +269,7 @@ class CodeStepQuizFullScreenDialogFragment : DialogFragment() {
 
     override fun onPause() {
         if (!isCodeSyncedAfterSubmissionClick) {
-            (parentFragment as? Callback)
-                ?.onSyncCodeStateWithParent(codeLayout.text.toString())
+            syncCodeStateWithParent()
         }
         super.onPause()
     }
@@ -363,10 +363,14 @@ class CodeStepQuizFullScreenDialogFragment : DialogFragment() {
     }
 
     private fun submitCodeActionClick() {
-        (parentFragment as? Callback)
-            ?.onSyncCodeStateWithParent(codeLayout.text.toString(), onSubmitClicked = true)
+        syncCodeStateWithParent(onSubmitClicked = true)
         isCodeSyncedAfterSubmissionClick = true
         dismiss()
+    }
+
+    private fun syncCodeStateWithParent(onSubmitClicked: Boolean = false) {
+        (parentFragment as? Callback)
+            ?.onSyncCodeStateWithParent(codeLayout.text.toString(), onSubmitClicked)
     }
 
     interface Callback {


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-580](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-580)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [ ] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Fix local [CodeStepQuizFullScreenDialogFragment](https://github.com/hyperskill/mobile-app/commit/ea7f2a42adcfdeb3bcb54f7e052754277809a45c) state is not synced with Feature state when reset code
