### PR TITLE
ALTAPPS-614: GitHub Actions bump Java from 11 to 17

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -71,7 +71,7 @@ runs:
     - name: Setup Java JDK
       uses: actions/setup-java@v3.10.0
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
 
     # Cache Gradle dependencies

--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -69,7 +69,7 @@ runs:
         working-directory: './androidHyperskillApp'
 
     - name: Setup Java JDK
-      uses: actions/setup-java@v3.6.0
+      uses: actions/setup-java@v3.10.0
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -55,7 +55,7 @@ runs:
         working-directory: './iosHyperskillApp'
 
     - name: Setup Java JDK
-      uses: actions/setup-java@v3.6.0
+      uses: actions/setup-java@v3.10.0
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: Setup Java JDK
       uses: actions/setup-java@v3.10.0
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
 
     # Cache Gradle dependencies


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-614](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-614)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Bumps Java from 11 to 17
- Bumps actions/setup-java from 3.6.0 to 3.10.0