### PR TITLE
ALTAPPS-464: iOS add paste control to code editor input accessory view

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
+++ b/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
@@ -281,6 +281,8 @@
 		2CD3652528796C4300D61855 /* ProfileViewDataMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD3652428796C4300D61855 /* ProfileViewDataMapper.swift */; };
 		2CD3652828797D3600D61855 /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD3652728797D3600D61855 /* Formatter.swift */; };
 		2CD3652C287987FA00D61855 /* ProfileSocialAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD3652B287987FA00D61855 /* ProfileSocialAccount.swift */; };
+		2CD4148329A8C98000ACA855 /* OpaqueUIPasteControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD4148229A8C98000ACA855 /* OpaqueUIPasteControl.swift */; };
+		2CD4148729A8D92000ACA855 /* CodeInputPasteControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD4148629A8D92000ACA855 /* CodeInputPasteControl.swift */; };
 		2CD48D852858638A00CFCC4A /* StepQuizAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD48D842858638A00CFCC4A /* StepQuizAssembly.swift */; };
 		2CD48D872858639500CFCC4A /* StepQuizViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD48D862858639500CFCC4A /* StepQuizViewModel.swift */; };
 		2CD48D892858657100CFCC4A /* StepQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD48D882858657100CFCC4A /* StepQuizView.swift */; };
@@ -714,6 +716,8 @@
 		2CD3652428796C4300D61855 /* ProfileViewDataMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewDataMapper.swift; sourceTree = "<group>"; };
 		2CD3652728797D3600D61855 /* Formatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
 		2CD3652B287987FA00D61855 /* ProfileSocialAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSocialAccount.swift; sourceTree = "<group>"; };
+		2CD4148229A8C98000ACA855 /* OpaqueUIPasteControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpaqueUIPasteControl.swift; sourceTree = "<group>"; };
+		2CD4148629A8D92000ACA855 /* CodeInputPasteControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeInputPasteControl.swift; sourceTree = "<group>"; };
 		2CD48D842858638A00CFCC4A /* StepQuizAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizAssembly.swift; sourceTree = "<group>"; };
 		2CD48D862858639500CFCC4A /* StepQuizViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizViewModel.swift; sourceTree = "<group>"; };
 		2CD48D882858657100CFCC4A /* StepQuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizView.swift; sourceTree = "<group>"; };
@@ -1333,6 +1337,7 @@
 				2C336D212865E37800C91342 /* CodeInputAccessoryButtonData.swift */,
 				2C336D232865E38B00C91342 /* CodeInputAccessoryCollectionViewCell.swift */,
 				2C336D252865E39D00C91342 /* CodeInputAccessoryView.swift */,
+				2CD4148829A8D92B00ACA855 /* PasteControl */,
 			);
 			path = Toolbar;
 			sourceTree = "<group>";
@@ -2069,6 +2074,15 @@
 				2C8E66D42878771B00D3928D /* ProfilePresentationDescription.swift */,
 			);
 			path = Assembly;
+			sourceTree = "<group>";
+		};
+		2CD4148829A8D92B00ACA855 /* PasteControl */ = {
+			isa = PBXGroup;
+			children = (
+				2CD4148629A8D92000ACA855 /* CodeInputPasteControl.swift */,
+				2CD4148229A8C98000ACA855 /* OpaqueUIPasteControl.swift */,
+			);
+			path = PasteControl;
 			sourceTree = "<group>";
 		};
 		2CD48D8C28586B5C00CFCC4A /* ViewData */ = {
@@ -3025,6 +3039,7 @@
 				2C079687285CFFF500EE0487 /* StepQuizSortingAssembly.swift in Sources */,
 				2C58DE2B2803DEE2002A2774 /* VerticalCenteredScrollView.swift in Sources */,
 				2CD48D892858657100CFCC4A /* StepQuizView.swift in Sources */,
+				2CD4148729A8D92000ACA855 /* CodeInputPasteControl.swift in Sources */,
 				2C8E4FA12848BF1F0011ADFA /* StepQuizTableSelectColumnsViewController.swift in Sources */,
 				2C1AE99D29926C02008122D9 /* TopicsToDiscoverNextFeatureStateKsExtensions.swift in Sources */,
 				2C1F5877280D2B4800372A37 /* ApplicationInfo.swift in Sources */,
@@ -3171,6 +3186,7 @@
 				E9FAF38F299F61AE001FC596 /* View+MeasureSize.swift in Sources */,
 				2C96744428883E710091B6C9 /* BlockOptionsExtensions.swift in Sources */,
 				2C9CC1BD280920B5006604D7 /* KeyboardManager.swift in Sources */,
+				2CD4148329A8C98000ACA855 /* OpaqueUIPasteControl.swift in Sources */,
 				2C32375328380C340062CAF6 /* NavigationToolbarInfoItem.swift in Sources */,
 				2C8409532805BF3C009C6BE9 /* StepTheoryContentView.swift in Sources */,
 				E9102759288D1BDB00FF4564 /* ProblemOfDayViewDataMapper.swift in Sources */,

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeEditorView/CodeEditorView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeEditorView/CodeEditorView.swift
@@ -157,7 +157,8 @@ final class CodeEditorView: UIView {
             },
             hideKeyboardAction: { [weak self] in
                 self?.codeTextView.resignFirstResponder()
-            }
+            },
+            pasteConfigurationSupporting: codeTextView
         )
     }
 

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeInputAccessory/CodeInputAccessoryBuilder.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeInputAccessory/CodeInputAccessoryBuilder.swift
@@ -6,16 +6,12 @@ enum CodeInputAccessoryBuilder {
         language: CodeLanguage,
         tabAction: @escaping () -> Void,
         insertStringAction: @escaping (String) -> Void,
-        hideKeyboardAction: @escaping () -> Void
+        hideKeyboardAction: @escaping () -> Void,
+        pasteConfigurationSupporting: UIPasteConfigurationSupporting
     ) -> UIView {
         let symbols = CodeInputAccessorySymbols.symbols(for: language)
 
-        var buttons = [
-            CodeInputAccessoryButtonData(title: "Tab", action: tabAction),
-            CodeInputAccessoryButtonData(title: "📋", action: {
-                insertStringAction(UIPasteboard.general.string ?? "")
-            })
-        ]
+        var buttons = [CodeInputAccessoryButtonData(title: "Tab", action: tabAction)]
 
         for symbol in symbols {
             let button = CodeInputAccessoryButtonData(title: symbol, action: { insertStringAction(symbol) })
@@ -29,7 +25,8 @@ enum CodeInputAccessoryBuilder {
             frame: frame,
             buttons: buttons,
             size: size,
-            hideKeyboardAction: { hideKeyboardAction() }
+            hideKeyboardAction: { hideKeyboardAction() },
+            pasteConfigurationSupporting: pasteConfigurationSupporting
         )
 
         return accessoryView

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeInputAccessory/CodeInputAccessoryBuilder.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeInputAccessory/CodeInputAccessoryBuilder.swift
@@ -10,7 +10,12 @@ enum CodeInputAccessoryBuilder {
     ) -> UIView {
         let symbols = CodeInputAccessorySymbols.symbols(for: language)
 
-        var buttons = [CodeInputAccessoryButtonData(title: "Tab", action: tabAction)]
+        var buttons = [
+            CodeInputAccessoryButtonData(title: "Tab", action: tabAction),
+            CodeInputAccessoryButtonData(title: "📋", action: {
+                insertStringAction(UIPasteboard.general.string ?? "")
+            })
+        ]
 
         for symbol in symbols {
             let button = CodeInputAccessoryButtonData(title: symbol, action: { insertStringAction(symbol) })

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeInputAccessory/Toolbar/CodeInputAccessoryView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeInputAccessory/Toolbar/CodeInputAccessoryView.swift
@@ -6,8 +6,7 @@ extension CodeInputAccessoryView {
         let hideKeyboardImageViewTintColor = UIColor.disabledText
         let hideKeyboardImageViewInsets = LayoutInsets(top: 4, leading: 4, bottom: 4, trailing: 8)
 
-        let pasteButtonTintColor = UIColor.disabledText
-        let pasteButtonInsets = LayoutInsets(top: 8, leading: 4, bottom: 8, trailing: 8)
+        let pasteButtonInsets = LayoutInsets(top: 4, leading: 4, bottom: 4, trailing: 8)
 
         let collectionViewInsets = LayoutInsets(top: 4, leading: 8, bottom: 4, trailing: 0)
         let collectionViewLayoutSectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 4)
@@ -41,30 +40,9 @@ final class CodeInputAccessoryView: UIView {
         return imageView
     }()
 
-    private lazy var pasteControlView: UIView = {
-        if #available(iOS 16, *) {
-            let configuration = UIPasteControl.Configuration()
-            configuration.displayMode = .iconOnly
-            configuration.baseBackgroundColor = appearance.backgroundColor
-            configuration.baseForegroundColor = appearance.hideKeyboardImageViewTintColor
-
-            let pasteButton = UIPasteControl(configuration: configuration)
-            pasteButton.target = pasteConfigurationSupporting
-            return pasteButton
-        } else {
-            let imageView = UIImageView(image: UIImage(systemName: "doc.on.clipboard"))
-            imageView.tintColor = appearance.pasteButtonTintColor
-            imageView.contentMode = .scaleAspectFit
-            imageView.isUserInteractionEnabled = true
-
-            let tapGestureRecognizer = UITapGestureRecognizer(
-                target: self,
-                action: #selector(didTapUIPasteControlView)
-            )
-            imageView.addGestureRecognizer(tapGestureRecognizer)
-            return imageView
-        }
-    }()
+    private lazy var pasteControlView = CodeInputPasteControl(
+        pasteConfigurationSupporting: pasteConfigurationSupporting
+    )
 
     private lazy var collectionView: UICollectionView = {
         let collectionViewLayout = UICollectionViewFlowLayout()
@@ -115,14 +93,6 @@ final class CodeInputAccessoryView: UIView {
     @objc
     private func didTapHideKeyboardImageView(recognizer: UIGestureRecognizer) {
         hideKeyboardAction?()
-    }
-
-    @objc
-    private func didTapUIPasteControlView(recognizer: UIGestureRecognizer) {
-        let itemProviders = UIPasteboard.general.itemProviders
-        if let pasteConfigurationSupporting, pasteConfigurationSupporting.canPaste?(itemProviders) == true {
-            pasteConfigurationSupporting.paste?(itemProviders: itemProviders)
-        }
     }
 }
 

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeInputAccessory/Toolbar/PasteControl/CodeInputPasteControl.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeInputAccessory/Toolbar/PasteControl/CodeInputPasteControl.swift
@@ -1,0 +1,100 @@
+import SnapKit
+import UIKit
+
+extension CodeInputPasteControl {
+    struct Appearance {
+        let backgroundColor = CodeInputAccessoryCollectionViewCell.Appearance.backgroundColor
+        let foregroundColor = CodeInputAccessoryCollectionViewCell.Appearance.textColor
+        let cornerRadius = CodeInputAccessoryCollectionViewCell.Appearance.cornerRadius
+
+        let imageViewSize = CGSize(width: 26, height: 26)
+    }
+}
+
+final class CodeInputPasteControl: UIView {
+    let appearance: Appearance
+
+    private weak var pasteConfigurationSupporting: UIPasteConfigurationSupporting?
+
+    init(
+        frame: CGRect = .zero,
+        appearance: Appearance = Appearance(),
+        pasteConfigurationSupporting: UIPasteConfigurationSupporting?
+    ) {
+        self.appearance = appearance
+        self.pasteConfigurationSupporting = pasteConfigurationSupporting
+        super.init(frame: frame)
+
+        setupView()
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        if #available(iOS 16.0, *) {
+            let configuration = UIPasteControl.Configuration()
+            configuration.baseBackgroundColor = appearance.backgroundColor
+            configuration.baseForegroundColor = appearance.foregroundColor
+            configuration.cornerRadius = appearance.cornerRadius
+            configuration.cornerStyle = .fixed
+            configuration.displayMode = .iconOnly
+
+            let pasteControl = OpaqueUIPasteControl(configuration: configuration)
+            pasteControl.target = pasteConfigurationSupporting
+
+            addSubview(pasteControl)
+            pasteControl.translatesAutoresizingMaskIntoConstraints = false
+            pasteControl.snp.makeConstraints { make in
+                make.edges.equalToSuperview()
+            }
+        } else {
+            let backgroundView = UIView()
+            backgroundView.backgroundColor = appearance.backgroundColor
+            backgroundView.layer.cornerRadius = appearance.cornerRadius
+            backgroundView.layer.masksToBounds = true
+
+            addSubview(backgroundView)
+            backgroundView.translatesAutoresizingMaskIntoConstraints = false
+            backgroundView.snp.makeConstraints { make in
+                make.edges.equalToSuperview()
+            }
+
+            let imageView = UIImageView(image: UIImage(systemName: "doc.on.clipboard"))
+            imageView.tintColor = appearance.foregroundColor
+            imageView.backgroundColor = appearance.backgroundColor
+            imageView.contentMode = .scaleAspectFit
+            imageView.isUserInteractionEnabled = true
+
+            let tapGestureRecognizer = UITapGestureRecognizer(
+                target: self,
+                action: #selector(didTapImageView)
+            )
+            imageView.addGestureRecognizer(tapGestureRecognizer)
+
+            backgroundView.addSubview(imageView)
+            imageView.translatesAutoresizingMaskIntoConstraints = false
+            imageView.snp.makeConstraints { make in
+                make.center.equalToSuperview()
+                make.size.equalTo(appearance.imageViewSize)
+            }
+        }
+    }
+
+    @objc
+    private func didTapImageView() {
+        guard let pasteConfigurationSupporting else {
+            return
+        }
+
+        let itemProviders = UIPasteboard.general.itemProviders
+
+        guard pasteConfigurationSupporting.canPaste?(itemProviders) == true else {
+            return
+        }
+
+        pasteConfigurationSupporting.paste?(itemProviders: itemProviders)
+    }
+}

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeInputAccessory/Toolbar/PasteControl/OpaqueUIPasteControl.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeInputAccessory/Toolbar/PasteControl/OpaqueUIPasteControl.swift
@@ -1,0 +1,32 @@
+import UIKit
+
+@available(iOS 16.0, *)
+final class OpaqueUIPasteControl: UIPasteControl {
+    private var observation: NSKeyValueObservation?
+
+    override func removeFromSuperview() {
+        super.removeFromSuperview()
+        observation = nil
+    }
+
+    override func didAddSubview(_ subview: UIView) {
+        super.didAddSubview(subview)
+
+        guard observation == nil else {
+            return
+        }
+
+        observation = subview.observe(\.alpha, options: [.new]) { [weak self] view, change in
+            guard let strongSelf = self else {
+                return
+            }
+
+            if strongSelf.isHighlighted {
+                return
+            }
+            if change.newValue != 1 {
+                view.alpha = 1
+            }
+        }
+    }
+}


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-464](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-464)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Adds paste control to the code editor's inputAccessoryView