### PR TITLE
ALTAPPS-601: iOS left aligned navigation bar title appearance

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
+++ b/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
@@ -408,7 +408,7 @@
 		E9D90905289814AA00D0EE91 /* NotificationsRegistrationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D90904289814AA00D0EE91 /* NotificationsRegistrationService.swift */; };
 		E9EF705128A7DB6500EA0C1C /* DailyStudyReminderLocalNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EF705028A7DB6500EA0C1C /* DailyStudyReminderLocalNotification.swift */; };
 		E9F27D782906447A007F16D7 /* StepQuizHintCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F27D772906447A007F16D7 /* StepQuizHintCardView.swift */; };
-		E9F2CC5329223C0200691540 /* RemoveBackButtonTitleHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F2CC5229223C0200691540 /* RemoveBackButtonTitleHostingController.swift */; };
+		E9F2CC5329223C0200691540 /* StyledHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F2CC5229223C0200691540 /* StyledHostingController.swift */; };
 		E9F2CC552922694F00691540 /* TopicsRepetitionsChartBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F2CC542922694F00691540 /* TopicsRepetitionsChartBar.swift */; };
 		E9F504CC2912842D00B788C7 /* StepQuizHintsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F504CB2912842D00B788C7 /* StepQuizHintsView.swift */; };
 		E9F504CE2912891900B788C7 /* StepQuizHintsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F504CD2912891900B788C7 /* StepQuizHintsViewModel.swift */; };
@@ -845,7 +845,7 @@
 		E9D90904289814AA00D0EE91 /* NotificationsRegistrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsRegistrationService.swift; sourceTree = "<group>"; };
 		E9EF705028A7DB6500EA0C1C /* DailyStudyReminderLocalNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyStudyReminderLocalNotification.swift; sourceTree = "<group>"; };
 		E9F27D772906447A007F16D7 /* StepQuizHintCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizHintCardView.swift; sourceTree = "<group>"; };
-		E9F2CC5229223C0200691540 /* RemoveBackButtonTitleHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveBackButtonTitleHostingController.swift; sourceTree = "<group>"; };
+		E9F2CC5229223C0200691540 /* StyledHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyledHostingController.swift; sourceTree = "<group>"; };
 		E9F2CC542922694F00691540 /* TopicsRepetitionsChartBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsRepetitionsChartBar.swift; sourceTree = "<group>"; };
 		E9F504CB2912842D00B788C7 /* StepQuizHintsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizHintsView.swift; sourceTree = "<group>"; };
 		E9F504CD2912891900B788C7 /* StepQuizHintsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizHintsViewModel.swift; sourceTree = "<group>"; };
@@ -2034,8 +2034,8 @@
 				2C20FBBF284F65F6006D879E /* HTMLToAttributedStringConverter.swift */,
 				2C725B602809125700A49043 /* LayoutInsets.swift */,
 				E9C3506C2886B0FE0080D277 /* MainBundleInfo.swift */,
-				E9F2CC5229223C0200691540 /* RemoveBackButtonTitleHostingController.swift */,
 				2C863D922804279E0021EFED /* Require.swift */,
+				E9F2CC5229223C0200691540 /* StyledHostingController.swift */,
 				2CB1962328EF27F30075F7EF /* UIKitViewControllerPreview.swift */,
 				2C20FBC8284F6F97006D879E /* UnitConverters.swift */,
 				2CCF3B5728004FC40075D12C /* UserAgentBuilder.swift */,
@@ -2823,7 +2823,7 @@
 				E9886D3228ABCE5C003724F9 /* OnboardingOutputProtocol.swift in Sources */,
 				2C5CBBE12948EBEA00113007 /* StepQuizSQLViewDataMapper.swift in Sources */,
 				2CF4341228126C79002893CD /* View+EndEditing.swift in Sources */,
-				E9F2CC5329223C0200691540 /* RemoveBackButtonTitleHostingController.swift in Sources */,
+				E9F2CC5329223C0200691540 /* StyledHostingController.swift in Sources */,
 				E94F4C152923B46200DE0F7F /* TopicsRepetitionsChartAxis.swift in Sources */,
 				E9102757288D19E100FF4564 /* ProblemOfDayViewData.swift in Sources */,
 				2CA3B0362888955F00EEF716 /* StepQuizCodeSkeletonView.swift in Sources */,

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Helpers/RemoveBackButtonTitleHostingController.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Helpers/RemoveBackButtonTitleHostingController.swift
@@ -1,9 +1,0 @@
-import SwiftUI
-import UIKit
-
-final class RemoveBackButtonTitleHostingController<RootView: View>: UIHostingController<RootView> {
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        navigationController?.removeBackButtonTitleForTopController()
-    }
-}

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Helpers/StyledHostingController.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Helpers/StyledHostingController.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import UIKit
+
+extension StyledHostingController {
+    struct Appearance {
+        var navigationBar = NavigationBar()
+
+        static var withoutBackButtonTitle: Appearance {
+            Appearance(navigationBar: .init(isBackButtonTitleHidden: true))
+        }
+
+        static var leftAlignedNavigationBarTitle: Appearance {
+            Appearance(navigationBar: .init(titlePosition: .left))
+        }
+
+        struct NavigationBar {
+            var isBackButtonTitleHidden = false
+            var titlePosition = TitlePosition.default
+
+            enum TitlePosition {
+                case left
+                case `default`
+
+                fileprivate var titlePositionAdjustment: UIOffset {
+                    switch self {
+                    case .left:
+                        return UIOffset(horizontal: -CGFloat.greatestFiniteMagnitude, vertical: 0)
+                    case .default:
+                        return .zero
+                    }
+                }
+            }
+        }
+    }
+}
+
+final class StyledHostingController<RootView: View>: UIHostingController<RootView>, UINavigationControllerDelegate {
+    private let appearance: Appearance
+
+    init(rootView: RootView, appearance: Appearance = Appearance()) {
+        self.appearance = appearance
+        super.init(rootView: rootView)
+    }
+
+    @MainActor
+    @available(*, unavailable)
+    dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        if appearance.navigationBar.isBackButtonTitleHidden {
+            navigationController?.removeBackButtonTitleForTopController()
+        }
+        if appearance.navigationBar.titlePosition != .default {
+            assert(navigationController?.delegate == nil)
+            assert((navigationController?.viewControllers.count ?? 0) <= 1)
+            navigationController?.delegate = self
+        }
+    }
+
+    func navigationController(
+        _ navigationController: UINavigationController,
+        willShow viewController: UIViewController,
+        animated: Bool
+    ) {
+        guard appearance.navigationBar.titlePosition != .default else {
+            return
+        }
+
+        let defaultTitlePositionAdjustment = Appearance.NavigationBar.TitlePosition.default.titlePositionAdjustment
+        let targetTitlePositionAdjustment = viewController === self
+          ? appearance.navigationBar.titlePosition.titlePositionAdjustment
+          : defaultTitlePositionAdjustment
+
+        if animated,
+           let transitionCoordinator = navigationController.transitionCoordinator {
+            transitionCoordinator.animate(
+                alongsideTransition: { [weak self] _ in
+                    guard let strongSelf = self else {
+                        return
+                    }
+
+                    strongSelf.changeNavigationBarTitlePositionAdjustment(targetTitlePositionAdjustment)
+                },
+                completion: { [weak self] context in
+                    guard let strongSelf = self else {
+                        return
+                    }
+
+                    // Rollback appearance
+                    if context.isCancelled {
+                        strongSelf.changeNavigationBarTitlePositionAdjustment(defaultTitlePositionAdjustment)
+                    }
+                }
+            )
+        } else {
+            changeNavigationBarTitlePositionAdjustment(targetTitlePositionAdjustment)
+        }
+    }
+
+    private func changeNavigationBarTitlePositionAdjustment(_ titlePositionAdjustment: UIOffset) {
+        navigationController?.navigationBar.standardAppearance.titlePositionAdjustment = titlePositionAdjustment
+        navigationController?.navigationBar.scrollEdgeAppearance?.titlePositionAdjustment = titlePositionAdjustment
+        navigationController?.navigationBar.compactAppearance?.titlePositionAdjustment = titlePositionAdjustment
+    }
+}

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/StepAssembly.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/StepAssembly.swift
@@ -30,7 +30,7 @@ final class StepAssembly: UIKitAssembly {
             modalRouter: modalRouter,
             panModalPresenter: PanModalPresenter()
         )
-        let hostingController = RemoveBackButtonTitleHostingController(rootView: stepView)
+        let hostingController = StyledHostingController(rootView: stepView, appearance: .withoutBackButtonTitle)
 
         modalRouter.rootViewController = hostingController
         stackRouter.rootViewController = hostingController

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/TopicsRepetitionsAssembly.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/TopicsRepetitionsAssembly.swift
@@ -15,7 +15,7 @@ class TopicsRepetitionsAssembly: UIKitAssembly {
             dataMapper: topicsRepetitionsComponent.topicsRepetitionsViewDataMapper
         )
 
-        let viewController = RemoveBackButtonTitleHostingController(rootView: topicsRepetitionsView)
+        let viewController = StyledHostingController(rootView: topicsRepetitionsView, appearance: .withoutBackButtonTitle)
 
         stackRouter.rootViewController = viewController
 

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/TopicsRepetitionsAssembly.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/TopicsRepetitionsAssembly.swift
@@ -15,7 +15,10 @@ class TopicsRepetitionsAssembly: UIKitAssembly {
             dataMapper: topicsRepetitionsComponent.topicsRepetitionsViewDataMapper
         )
 
-        let viewController = StyledHostingController(rootView: topicsRepetitionsView, appearance: .withoutBackButtonTitle)
+        let viewController = StyledHostingController(
+            rootView: topicsRepetitionsView,
+            appearance: .withoutBackButtonTitle
+        )
 
         stackRouter.rootViewController = viewController
 


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-601](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-601)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Refactor rename `RemoveBackButtonTitleHostingController` -> `StyledHostingController`
- Left-aligned navigation bar title appearance implementation with animation

Usage:
- `StyledHostingController(rootView: rootView, appearance: .withoutBackButtonTitle)`
- `StyledHostingController(rootView: rootView, appearance: .leftAlignedNavigationBarTitle)`.