### PR TITLE
ALTAPPS-673: iOS code editor disable code completion

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeEditorView/CodeEditorView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/View/UIKit/CodeEditorView/CodeEditorView.swift
@@ -162,23 +162,24 @@ final class CodeEditorView: UIView {
         )
     }
 
+    #warning("ALTAPPS-673: Code completion temporarily disabled")
     private func analyzeCodeAndComplete() {
-        guard let language = language,
-              let viewController = delegate?.codeEditorViewDidRequestSuggestionPresentationController(self)
-        else {
-            return
-        }
-
-        codePlaygroundManager.analyzeAndComplete(
-            textView: codeTextView,
-            previousText: oldCode ?? "",
-            language: language,
-            tabSize: tabSize,
-            inViewController: viewController,
-            suggestionsDelegate: self
-        )
-
-        oldCode = code
+//        guard let language = language,
+//              let viewController = delegate?.codeEditorViewDidRequestSuggestionPresentationController(self)
+//        else {
+//            return
+//        }
+//
+//        codePlaygroundManager.analyzeAndComplete(
+//            textView: codeTextView,
+//            previousText: oldCode ?? "",
+//            language: language,
+//            tabSize: tabSize,
+//            inViewController: viewController,
+//            suggestionsDelegate: self
+//        )
+//
+//        oldCode = code
     }
 }
 


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-673](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-673)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
Temporarily disables code completion in the code editor because it blocks the main thread. We need more time to investigate this.