### PR TITLE
ALTAPPS-657: Shared short pull study plan

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetActionDispatcher.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetActionDispatcher.kt
@@ -1,5 +1,6 @@
 package org.hyperskill.app.study_plan.widget.presentation
 
+import kotlinx.coroutines.delay
 import org.hyperskill.app.core.presentation.ActionDispatcherOptions
 import org.hyperskill.app.study_plan.domain.interactor.StudyPlanInteractor
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.Action
@@ -15,10 +16,13 @@ class StudyPlanWidgetActionDispatcher(
 ) : CoroutineActionDispatcher<Action, Message>(config.createConfig()) {
     override suspend fun doSuspendableAction(action: Action) {
         when (action) {
-            InternalAction.FetchStudyPlan -> {
+            is InternalAction.FetchStudyPlan -> {
+                if (action.delay != null) {
+                    delay(action.delay.inWholeMilliseconds)
+                }
                 studyPlanInteractor.getCurrentStudyPlan()
                     .onSuccess { studyPlan ->
-                        onNewMessage(StudyPlanWidgetFeature.StudyPlanFetchResult.Success(studyPlan))
+                        onNewMessage(StudyPlanWidgetFeature.StudyPlanFetchResult.Success(studyPlan, action.tryNumber))
                     }
                     .onFailure {
                         onNewMessage(StudyPlanWidgetFeature.StudyPlanFetchResult.Failed)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
@@ -6,8 +6,12 @@ import org.hyperskill.app.learning_activities.domain.model.LearningActivityType
 import org.hyperskill.app.study_plan.domain.model.StudyPlan
 import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
 import org.hyperskill.app.track.domain.model.Track
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 object StudyPlanWidgetFeature {
+
+    val StudyPlanFetchInterval: Duration = 1.seconds
 
     data class State(
         val studyPlan: StudyPlan? = null,
@@ -55,7 +59,7 @@ object StudyPlanWidgetFeature {
     }
 
     internal sealed interface StudyPlanFetchResult : Message {
-        data class Success(val studyPlan: StudyPlan) : StudyPlanFetchResult
+        data class Success(val studyPlan: StudyPlan, val tryNumber: Int) : StudyPlanFetchResult
 
         object Failed : StudyPlanFetchResult
     }
@@ -93,7 +97,7 @@ object StudyPlanWidgetFeature {
     }
 
     internal sealed interface InternalAction : Action {
-        object FetchStudyPlan : InternalAction
+        data class FetchStudyPlan(val delay: Duration? = null, val tryNumber: Int = 1) : InternalAction
 
         data class FetchSections(val sectionsIds: List<Long>) : InternalAction
 

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -1,10 +1,12 @@
 package org.hyperskill.app.study_plan.widget.presentation
 
 import org.hyperskill.app.learning_activities.domain.model.LearningActivityType
+import org.hyperskill.app.study_plan.domain.model.StudyPlanStatus
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.Action
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.InternalAction
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.Message
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.State
+import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.StudyPlanFetchInterval
 import ru.nobird.app.presentation.redux.reducer.StateReducer
 
 internal typealias StudyPlanWidgetReducerResult = Pair<State, Set<Action>>
@@ -13,13 +15,8 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
     override fun reduce(state: State, message: Message): StudyPlanWidgetReducerResult =
         when (message) {
             Message.Initialize -> coldContentFetch()
-            is StudyPlanWidgetFeature.StudyPlanFetchResult.Success -> {
-                state.copy(studyPlan = message.studyPlan) to
-                    setOfNotNull(
-                        InternalAction.FetchSections(message.studyPlan.sections),
-                        message.studyPlan.trackId?.let(InternalAction::FetchTrack)
-                    )
-            }
+            is StudyPlanWidgetFeature.StudyPlanFetchResult.Success ->
+                handleStudyPlanFetchSuccess(state, message)
             is StudyPlanWidgetFeature.SectionsFetchResult.Success ->
                 handleSectionsFetchSuccess(state, message)
             Message.RetryContentLoading -> coldContentFetch()
@@ -44,7 +41,30 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
 
     private fun coldContentFetch(): StudyPlanWidgetReducerResult =
         State(sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADING) to
-            setOf(InternalAction.FetchStudyPlan)
+            setOf(InternalAction.FetchStudyPlan())
+
+    private fun handleStudyPlanFetchSuccess(
+        state: State,
+        message: StudyPlanWidgetFeature.StudyPlanFetchResult.Success
+    ): StudyPlanWidgetReducerResult {
+        val actions = if (message.studyPlan.status != StudyPlanStatus.READY) {
+            setOf(
+                InternalAction.FetchStudyPlan(
+                    delay = StudyPlanFetchInterval * message.tryNumber,
+                    tryNumber = message.tryNumber + 1
+                )
+            )
+        } else {
+            setOfNotNull(
+                InternalAction.FetchSections(message.studyPlan.sections),
+                message.studyPlan.trackId?.let(InternalAction::FetchTrack)
+            )
+        }
+        return State(
+            studyPlan = message.studyPlan,
+            sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADING
+        ) to actions
+    }
 
     private fun handleSectionsFetchSuccess(
         state: State,

--- a/shared/src/commonTest/kotlin/org/hyperskill/StudyPlanWidgetTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/StudyPlanWidgetTest.kt
@@ -17,6 +17,7 @@ import org.hyperskill.app.study_plan.widget.view.StudyPlanWidgetViewStateMapper
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class StudyPlanWidgetTest {
 
@@ -42,26 +43,90 @@ class StudyPlanWidgetTest {
     fun `Initialize message should trigger studyPLan fetching`() {
         val initialState = StudyPlanWidgetFeature.State()
         val (state, actions) = reducer.reduce(initialState, StudyPlanWidgetFeature.Message.Initialize)
-        assertContains(actions, StudyPlanWidgetFeature.InternalAction.FetchStudyPlan)
+        assertContains(actions, StudyPlanWidgetFeature.InternalAction.FetchStudyPlan())
         assertEquals(state.sectionsStatus, StudyPlanWidgetFeature.ContentStatus.LOADING)
     }
 
     @Test
-    fun `Sections loading is should be triggered after`() {
+    fun `Receiving not ready studyPlan should trigger fetch studyPlan again`() {
+        val initialState = StudyPlanWidgetFeature.State()
+        StudyPlanStatus.values()
+            .asSequence()
+            .filterNot { it == StudyPlanStatus.READY }
+            .forEach { status ->
+                val studyPlan = studyPlanStub(id = 0, status = status)
+                val (_, actions) = reducer.reduce(
+                    initialState,
+                    StudyPlanWidgetFeature.StudyPlanFetchResult.Success(studyPlan, 1)
+                )
+                assertTrue {
+                    actions.any {
+                        it is StudyPlanWidgetFeature.InternalAction.FetchStudyPlan
+                    }
+                }
+            }
+    }
+
+    @Test
+    fun `Receiving not ready studyPlan should trigger fetch studyPlan with delay`() {
+        val initialState = StudyPlanWidgetFeature.State()
+        val studyPlan = studyPlanStub(id = 0, status = StudyPlanStatus.INITING)
+        repeat(5) { tryNumber ->
+            val (_, actions) = reducer.reduce(
+                initialState,
+                StudyPlanWidgetFeature.StudyPlanFetchResult.Success(studyPlan, tryNumber)
+            )
+            val expectedAction = StudyPlanWidgetFeature.InternalAction.FetchStudyPlan(
+                delay = StudyPlanWidgetFeature.StudyPlanFetchInterval * tryNumber,
+                tryNumber = tryNumber + 1
+            )
+            assertContains(actions, expectedAction)
+        }
+    }
+
+    @Test
+    fun `Receiving ready studyPlan should stop study plan polling`() {
+        val initialState = StudyPlanWidgetFeature.State()
+        val studyPlan = studyPlanStub(id = 0, status = StudyPlanStatus.READY)
+        val (_, actions) = reducer.reduce(
+            initialState,
+            StudyPlanWidgetFeature.StudyPlanFetchResult.Success(studyPlan, 1)
+        )
+        assertTrue {
+            actions.none {
+                it is StudyPlanWidgetFeature.InternalAction.FetchStudyPlan
+            }
+        }
+    }
+
+    @Test
+    fun `Receiving not ready studyPlan loading state should be shown`() {
+        val initialState = StudyPlanWidgetFeature.State()
+        StudyPlanStatus.values()
+            .asSequence()
+            .filterNot { it == StudyPlanStatus.READY }
+            .forEach { status ->
+                val studyPlan = studyPlanStub(id = 0, status = status)
+                val (state, _) = reducer.reduce(
+                    initialState,
+                    StudyPlanWidgetFeature.StudyPlanFetchResult.Success(studyPlan, 1)
+                )
+                val viewState = studyPlanWidgetViewStateMapper.map(state)
+                assertEquals(StudyPlanWidgetViewState.Loading, viewState)
+            }
+    }
+
+    @Test
+    fun `Receiving ready studyPlan should trigger sections loading`() {
         val expectedSections = listOf(0L, 1L, 2L)
-        val studyPlanStub = StudyPlan(
+        val studyPlanStub = studyPlanStub(
             id = 0,
-            trackId = null,
-            projectId = null,
-            sections = expectedSections,
-            createdAt = "",
-            secondsToReachProject = 0L,
-            secondsToReachTrack = 0L,
-            status = StudyPlanStatus.READY
+            status = StudyPlanStatus.READY,
+            sections = expectedSections
         )
         val initialState = StudyPlanWidgetFeature.State(sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADING)
         val (state, actions) =
-            reducer.reduce(initialState, StudyPlanWidgetFeature.StudyPlanFetchResult.Success(studyPlanStub))
+            reducer.reduce(initialState, StudyPlanWidgetFeature.StudyPlanFetchResult.Success(studyPlanStub, 1))
         assertContains(actions, StudyPlanWidgetFeature.InternalAction.FetchSections(expectedSections))
         assertEquals(studyPlanStub, state.studyPlan)
         assertEquals(initialState.sectionsStatus, state.sectionsStatus)
@@ -253,6 +318,21 @@ class StudyPlanWidgetTest {
             formattedTopicsCount = null,
             formattedTimeToComplete = null
         )
+
+    private fun studyPlanStub(
+        id: Long,
+        status: StudyPlanStatus,
+        sections: List<Long> = emptyList()
+    ) = StudyPlan(
+        id = id,
+        trackId = null,
+        projectId = null,
+        sections = sections,
+        status = status,
+        createdAt = "",
+        secondsToReachTrack = 0,
+        secondsToReachProject = 0
+    )
 
     private fun studyPlanSectionStub(
         id: Long,


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-657](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-657)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [ ] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
Study-plan short pulling is implemented via `StudyPlanWidgetFeature.InternalAction.FetchStudyPlan` and `StudyPlanWidgetFeature.StudyPlanFetchResult.Success`, not via `StudyPlanInteractor` method. 
The reasons for this decision are:
- test abilities of the state machine;
- holding the whole feature business logic in one place.