### PR TITLE
ALTAPPS-680: Shared add progress into gamification toolbar

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,7 +61,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.5.0
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1.118.0
+        with:
+          ruby-version: '3.1.0'
+          bundler-cache: true
+          working-directory: './iosHyperskillApp'
+
+      - name: Cache Pods
+        uses: actions/cache@v3.2.5
+        id: cache-pods
+        with:
+          path: './iosHyperskillApp/Pods'
+          key: ${{ runner.os }}-pods-${{ hashFiles('iosHyperskillApp/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Install Pods
+        if: steps.cache-pods.outputs.cache-hit != 'true'
+        working-directory: './iosHyperskillApp'
+        run: bundle exec pod install
+
       - name: Run SwiftLint
         working-directory: './iosHyperskillApp'
-        run: |
-          swiftlint --config .swiftlint.yml --path iosHyperskillApp/Sources --strict
+        run: ./lint.sh

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/core/injection/AndroidAppComponentImpl.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/core/injection/AndroidAppComponentImpl.kt
@@ -43,6 +43,7 @@ import org.hyperskill.app.discussions.injection.DiscussionsDataComponent
 import org.hyperskill.app.discussions.injection.DiscussionsDataComponentImpl
 import org.hyperskill.app.freemium.injection.FreemiumDataComponent
 import org.hyperskill.app.freemium.injection.FreemiumDataComponentImpl
+import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
 import org.hyperskill.app.gamification_toolbar.injection.GamificationToolbarComponent
 import org.hyperskill.app.gamification_toolbar.injection.GamificationToolbarComponentImpl
 import org.hyperskill.app.home.injection.HomeComponent
@@ -466,8 +467,8 @@ class AndroidAppComponentImpl(
     override fun buildStreaksDataComponent(): StreaksDataComponent =
         StreaksDataComponentImpl(this)
 
-    override fun buildGamificationToolbarComponent(): GamificationToolbarComponent =
-        GamificationToolbarComponentImpl(this)
+    override fun buildGamificationToolbarComponent(screen: GamificationToolbarScreen): GamificationToolbarComponent =
+        GamificationToolbarComponentImpl(this, screen)
 
     override fun buildStudyPlanDataComponent(): StudyPlanDataComponent =
         StudyPlanDataComponentImpl(this)

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/gamification_toolbar/view/ui/delegate/GamificationToolbarDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/gamification_toolbar/view/ui/delegate/GamificationToolbarDelegate.kt
@@ -5,13 +5,11 @@ import androidx.lifecycle.LifecycleOwner
 import org.hyperskill.app.android.R
 import org.hyperskill.app.android.databinding.LayoutGamificationToolbarBinding
 import org.hyperskill.app.android.view.base.ui.extension.setElevationOnCollapsed
-import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
 import org.hyperskill.app.gamification_toolbar.presentation.GamificationToolbarFeature
 
 class GamificationToolbarDelegate(
     lifecycleOwner: LifecycleOwner,
     private val viewBinding: LayoutGamificationToolbarBinding,
-    screen: GamificationToolbarScreen,
     onNewMessage: (GamificationToolbarFeature.Message) -> Unit
 ) {
 
@@ -22,12 +20,12 @@ class GamificationToolbarDelegate(
 
             gamificationGemsCountTextView.setOnClickListener {
                 onNewMessage(
-                    GamificationToolbarFeature.Message.ClickedGems(screen)
+                    GamificationToolbarFeature.Message.ClickedGems
                 )
             }
             gamificationStreakDurationTextView.setOnClickListener {
                 onNewMessage(
-                    GamificationToolbarFeature.Message.ClickedStreak(screen)
+                    GamificationToolbarFeature.Message.ClickedStreak
                 )
             }
         }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/home/view/ui/fragment/HomeFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/home/view/ui/fragment/HomeFragment.kt
@@ -29,7 +29,6 @@ import org.hyperskill.app.android.topics.view.delegate.TopicsToDiscoverNextDeleg
 import org.hyperskill.app.android.topics_repetitions.view.delegate.TopicsRepetitionCardFormDelegate
 import org.hyperskill.app.android.topics_repetitions.view.screen.TopicsRepetitionScreen
 import org.hyperskill.app.android.view.base.ui.extension.snackbar
-import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
 import org.hyperskill.app.gamification_toolbar.presentation.GamificationToolbarFeature
 import org.hyperskill.app.home.presentation.HomeFeature
 import org.hyperskill.app.home.presentation.HomeViewModel
@@ -168,8 +167,7 @@ class HomeFragment :
             requireContext().getString(org.hyperskill.app.R.string.home_title)
         gamificationToolbarDelegate = GamificationToolbarDelegate(
             viewLifecycleOwner,
-            viewBinding.homeScreenAppBar,
-            GamificationToolbarScreen.HOME
+            viewBinding.homeScreenAppBar
         ) { message ->
             homeViewModel.onNewMessage(HomeFeature.Message.GamificationToolbarMessage(message))
         }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/track/view/fragment/TrackFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/track/view/fragment/TrackFragment.kt
@@ -13,6 +13,7 @@ import by.kirich1409.viewbindingdelegate.viewBinding
 import coil.ImageLoader
 import coil.load
 import coil.size.Scale
+import kotlin.math.roundToInt
 import org.hyperskill.app.SharedResources
 import org.hyperskill.app.android.HyperskillApp
 import org.hyperskill.app.android.R
@@ -27,7 +28,6 @@ import org.hyperskill.app.android.profile.view.navigation.ProfileScreen
 import org.hyperskill.app.android.step.view.screen.StepScreen
 import org.hyperskill.app.android.topics.view.delegate.TopicsToDiscoverNextDelegate
 import org.hyperskill.app.android.view.base.ui.extension.snackbar
-import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
 import org.hyperskill.app.gamification_toolbar.presentation.GamificationToolbarFeature
 import org.hyperskill.app.step.domain.model.StepRoute
 import org.hyperskill.app.topics_to_discover_next.presentation.TopicsToDiscoverNextFeature
@@ -38,7 +38,6 @@ import ru.nobird.android.view.base.ui.delegate.ViewStateDelegate
 import ru.nobird.android.view.base.ui.extension.showIfNotExists
 import ru.nobird.android.view.redux.ui.extension.reduxViewModel
 import ru.nobird.app.presentation.redux.container.ReduxView
-import kotlin.math.roundToInt
 
 class TrackFragment :
     Fragment(R.layout.fragment_track),
@@ -116,8 +115,7 @@ class TrackFragment :
             requireContext().getString(org.hyperskill.app.R.string.track_title)
         gamificationToolbarDelegate = GamificationToolbarDelegate(
             viewLifecycleOwner,
-            viewBinding.trackAppBar,
-            GamificationToolbarScreen.TRACK
+            viewBinding.trackAppBar
         ) { message ->
             trackViewModel.onNewMessage(TrackFeature.Message.GamificationToolbarMessage(message))
         }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
@@ -56,7 +56,7 @@ final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage
     func doStreakBarButtonItemAction() {
         onNewMessage(
             HomeFeatureMessageGamificationToolbarMessage(
-                message: GamificationToolbarFeatureMessageClickedStreak(screen: GamificationToolbarScreen.home)
+                message: GamificationToolbarFeatureMessageClickedStreak.shared
             )
         )
     }
@@ -64,7 +64,7 @@ final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage
     func doGemsBarButtonItemAction() {
         onNewMessage(
             HomeFeatureMessageGamificationToolbarMessage(
-                message: GamificationToolbarFeatureMessageClickedGems(screen: GamificationToolbarScreen.home)
+                message: GamificationToolbarFeatureMessageClickedGems.shared
             )
         )
     }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
@@ -56,7 +56,7 @@ final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage
     func doStreakBarButtonItemAction() {
         onNewMessage(
             HomeFeatureMessageGamificationToolbarMessage(
-                message: GamificationToolbarFeatureMessageClickedStreak.shared
+                message: GamificationToolbarFeatureMessageClickedStreak()
             )
         )
     }
@@ -64,7 +64,7 @@ final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage
     func doGemsBarButtonItemAction() {
         onNewMessage(
             HomeFeatureMessageGamificationToolbarMessage(
-                message: GamificationToolbarFeatureMessageClickedGems.shared
+                message: GamificationToolbarFeatureMessageClickedGems()
             )
         )
     }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Profile/Views/Statistics/ProfileStatisticsItemView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Profile/Views/Statistics/ProfileStatisticsItemView.swift
@@ -38,8 +38,7 @@ struct ProfileStatisticsItemView: View {
         .cornerRadius(appearance.cornerRadius)
     }
 
-    @ViewBuilder
-    private var image: some View {
+    @ViewBuilder private var image: some View {
         switch icon.renderingMode {
         case .original:
             Image(icon.imageName)

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Profile/Views/Statistics/ProfileStatisticsItemView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Profile/Views/Statistics/ProfileStatisticsItemView.swift
@@ -38,7 +38,8 @@ struct ProfileStatisticsItemView: View {
         .cornerRadius(appearance.cornerRadius)
     }
 
-    @ViewBuilder private var image: some View {
+    @ViewBuilder
+    private var image: some View {
         switch icon.renderingMode {
         case .original:
             Image(icon.imageName)

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/TrackViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/TrackViewModel.swift
@@ -48,7 +48,7 @@ final class TrackViewModel: FeatureViewModel<TrackFeatureState, TrackFeatureMess
     func doStreakBarButtonItemAction() {
         onNewMessage(
             TrackFeatureMessageGamificationToolbarMessage(
-                message: GamificationToolbarFeatureMessageClickedStreak(screen: GamificationToolbarScreen.track)
+                message: GamificationToolbarFeatureMessageClickedStreak.shared
             )
         )
     }
@@ -56,7 +56,7 @@ final class TrackViewModel: FeatureViewModel<TrackFeatureState, TrackFeatureMess
     func doGemsBarButtonItemAction() {
         onNewMessage(
             TrackFeatureMessageGamificationToolbarMessage(
-                message: GamificationToolbarFeatureMessageClickedGems(screen: GamificationToolbarScreen.track)
+                message: GamificationToolbarFeatureMessageClickedGems.shared
             )
         )
     }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/TrackViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/TrackViewModel.swift
@@ -48,7 +48,7 @@ final class TrackViewModel: FeatureViewModel<TrackFeatureState, TrackFeatureMess
     func doStreakBarButtonItemAction() {
         onNewMessage(
             TrackFeatureMessageGamificationToolbarMessage(
-                message: GamificationToolbarFeatureMessageClickedStreak.shared
+                message: GamificationToolbarFeatureMessageClickedStreak()
             )
         )
     }
@@ -56,7 +56,7 @@ final class TrackViewModel: FeatureViewModel<TrackFeatureState, TrackFeatureMess
     func doGemsBarButtonItemAction() {
         onNewMessage(
             TrackFeatureMessageGamificationToolbarMessage(
-                message: GamificationToolbarFeatureMessageClickedGems.shared
+                message: GamificationToolbarFeatureMessageClickedGems()
             )
         )
     }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/Views/DiscoverNext/TopicToDiscoverNextButtonView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/Views/DiscoverNext/TopicToDiscoverNextButtonView.swift
@@ -97,8 +97,7 @@ struct TopicToDiscoverNextButtonView: View {
         }
     }
 
-    @ViewBuilder
-    private var learnNextBadge: some View {
+    @ViewBuilder private var learnNextBadge: some View {
         if isLearnNext {
             Text(Strings.Track.TopicsToDiscoverNext.learnNextBadge)
                 .font(.caption)

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/Views/DiscoverNext/TopicToDiscoverNextButtonView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Track/Views/DiscoverNext/TopicToDiscoverNextButtonView.swift
@@ -97,7 +97,8 @@ struct TopicToDiscoverNextButtonView: View {
         }
     }
 
-    @ViewBuilder private var learnNextBadge: some View {
+    @ViewBuilder
+    private var learnNextBadge: some View {
         if isLearnNext {
             Text(Strings.Track.TopicsToDiscoverNext.learnNextBadge)
                 .font(.caption)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/core/injection/AppGraph.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/core/injection/AppGraph.kt
@@ -8,6 +8,7 @@ import org.hyperskill.app.comments.injection.CommentsDataComponent
 import org.hyperskill.app.debug.injection.DebugComponent
 import org.hyperskill.app.discussions.injection.DiscussionsDataComponent
 import org.hyperskill.app.freemium.injection.FreemiumDataComponent
+import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
 import org.hyperskill.app.gamification_toolbar.injection.GamificationToolbarComponent
 import org.hyperskill.app.home.injection.HomeComponent
 import org.hyperskill.app.items.injection.ItemsDataComponent
@@ -113,7 +114,7 @@ interface AppGraph {
     fun buildProductsDataComponent(): ProductsDataComponent
     fun buildItemsDataComponent(): ItemsDataComponent
     fun buildDebugComponent(): DebugComponent
-    fun buildGamificationToolbarComponent(): GamificationToolbarComponent
+    fun buildGamificationToolbarComponent(screen: GamificationToolbarScreen): GamificationToolbarComponent
     fun buildTopicsToDiscoverNextComponent(screen: TopicsToDiscoverNextScreen): TopicsToDiscoverNextComponent
     fun buildTopicsToDiscoverNextDataComponent(): TopicsToDiscoverNextDataComponent
     fun buildStudyPlanDataComponent(): StudyPlanDataComponent

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/domain/model/GamificationToolbarScreen.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/domain/model/GamificationToolbarScreen.kt
@@ -14,9 +14,12 @@ enum class GamificationToolbarScreen {
             TRACK -> HyperskillAnalyticRoute.Track()
         }
 
-    internal val sentryTransaction: HyperskillSentryTransaction
+    internal val fetchContentSentryTransaction: HyperskillSentryTransaction
         get() = when (this) {
             HOME -> HyperskillSentryTransactionBuilder.buildGamificationToolbarHomeScreenRemoteDataLoading()
             TRACK -> HyperskillSentryTransactionBuilder.buildGamificationToolbarTrackScreenRemoteDataLoading()
         }
+
+    internal val fetchTrackProgressSentryTransaction: HyperskillSentryTransaction
+        get() = HyperskillSentryTransactionBuilder.buildGamificationToolbarTrackProgressLoading(this)
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/injection/GamificationToolbarComponentImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/injection/GamificationToolbarComponentImpl.kt
@@ -19,6 +19,7 @@ class GamificationToolbarComponentImpl(private val appGraph: AppGraph) : Gamific
             appGraph.streakFlowDataComponent.streakFlow,
             appGraph.stateRepositoriesComponent.currentStudyPlanStateRepository,
             appGraph.buildTrackDataComponent().trackRepository,
-            appGraph.buildProgressesDataComponent().progressesRepository
+            appGraph.buildProgressesDataComponent().progressesRepository,
+            appGraph.stepCompletionFlowDataComponent.topicCompletedFlow
         )
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/injection/GamificationToolbarComponentImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/injection/GamificationToolbarComponentImpl.kt
@@ -2,12 +2,13 @@ package org.hyperskill.app.gamification_toolbar.injection
 
 import org.hyperskill.app.core.injection.AppGraph
 import org.hyperskill.app.core.presentation.ActionDispatcherOptions
+import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
 import org.hyperskill.app.gamification_toolbar.presentation.GamificationToolbarActionDispatcher
 import org.hyperskill.app.gamification_toolbar.presentation.GamificationToolbarReducer
 
-class GamificationToolbarComponentImpl(private val appGraph: AppGraph) : GamificationToolbarComponent {
+class GamificationToolbarComponentImpl(private val appGraph: AppGraph, private val screen: GamificationToolbarScreen) : GamificationToolbarComponent {
     override val gamificationToolbarReducer: GamificationToolbarReducer
-        get() = GamificationToolbarReducer()
+        get() = GamificationToolbarReducer(screen)
 
     override val gamificationToolbarActionDispatcher: GamificationToolbarActionDispatcher
         get() = GamificationToolbarActionDispatcher(

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/injection/GamificationToolbarComponentImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/injection/GamificationToolbarComponentImpl.kt
@@ -6,7 +6,10 @@ import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarS
 import org.hyperskill.app.gamification_toolbar.presentation.GamificationToolbarActionDispatcher
 import org.hyperskill.app.gamification_toolbar.presentation.GamificationToolbarReducer
 
-class GamificationToolbarComponentImpl(private val appGraph: AppGraph, private val screen: GamificationToolbarScreen) : GamificationToolbarComponent {
+class GamificationToolbarComponentImpl(
+    private val appGraph: AppGraph,
+    private val screen: GamificationToolbarScreen
+) : GamificationToolbarComponent {
     override val gamificationToolbarReducer: GamificationToolbarReducer
         get() = GamificationToolbarReducer(screen)
 

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/injection/GamificationToolbarComponentImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/injection/GamificationToolbarComponentImpl.kt
@@ -16,6 +16,9 @@ class GamificationToolbarComponentImpl(private val appGraph: AppGraph) : Gamific
             appGraph.buildStreaksDataComponent().streaksInteractor,
             appGraph.analyticComponent.analyticInteractor,
             appGraph.sentryComponent.sentryInteractor,
-            appGraph.streakFlowDataComponent.streakFlow
+            appGraph.streakFlowDataComponent.streakFlow,
+            appGraph.stateRepositoriesComponent.currentStudyPlanStateRepository,
+            appGraph.buildTrackDataComponent().trackRepository,
+            appGraph.buildProgressesDataComponent().progressesRepository
         )
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarActionDispatcher.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarActionDispatcher.kt
@@ -119,13 +119,16 @@ class GamificationToolbarActionDispatcher(
                 )
             }
             is Action.FetchTrackWithProgress -> {
+                sentryInteractor.startTransaction(action.transaction)
                 fetchTrackWithProgress(action.trackId, true)
                     .fold(
                         onSuccess = { trackWithProgress ->
                             onNewMessage(Message.FetchTrackWithProgressResult.Success(trackWithProgress))
+                            sentryInteractor.finishTransaction(action.transaction)
                         },
                         onFailure = {
                             onNewMessage(Message.FetchTrackWithProgressResult.Error)
+                            sentryInteractor.finishTransaction(action.transaction)
                         }
                     )
             }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarActionDispatcher.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarActionDispatcher.kt
@@ -87,7 +87,7 @@ class GamificationToolbarActionDispatcher(
                     profileInteractor.getCurrentProfile(sourceType = DataSourceType.REMOTE)
                 }
                 val trackWithProgressDeferred = async {
-                    fetchTrackWithProgressThoughtStudyPlan(action.forceUpdate)
+                    fetchTrackWithProgressThroughStudyPlan(action.forceUpdate)
                 }
 
                 val streak = streakResult.await().getOrElse {
@@ -140,7 +140,7 @@ class GamificationToolbarActionDispatcher(
         }
     }
 
-    private suspend fun fetchTrackWithProgressThoughtStudyPlan(forceLoadFromRemote: Boolean): Result<TrackWithProgress?> =
+    private suspend fun fetchTrackWithProgressThroughStudyPlan(forceLoadFromRemote: Boolean): Result<TrackWithProgress?> =
         kotlin.runCatching {
             val studyPlan =
                 currentStudyPlanStateRepository.getState(forceLoadFromRemote).getOrThrow()
@@ -151,7 +151,10 @@ class GamificationToolbarActionDispatcher(
             }
         }
 
-    private suspend fun fetchTrackWithProgress(trackId: Long, forceLoadFromRemote: Boolean): Result<TrackWithProgress?> =
+    private suspend fun fetchTrackWithProgress(
+        trackId: Long,
+        forceLoadFromRemote: Boolean
+    ): Result<TrackWithProgress?> =
         coroutineScope {
             kotlin.runCatching {
                 val trackDeferred = async {
@@ -163,8 +166,7 @@ class GamificationToolbarActionDispatcher(
                 }
                 TrackWithProgress(
                     track = trackDeferred.await().getOrThrow(),
-                    trackProgress = trackProgressDeferred.await().getOrThrow()
-                        ?: return@runCatching null
+                    trackProgress = trackProgressDeferred.await().getOrThrow() ?: return@runCatching null
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarFeature.kt
@@ -2,6 +2,7 @@ package org.hyperskill.app.gamification_toolbar.presentation
 
 import org.hyperskill.app.analytic.domain.model.AnalyticEvent
 import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
+import org.hyperskill.app.sentry.domain.model.transaction.HyperskillSentryTransaction
 import org.hyperskill.app.streaks.domain.model.Streak
 import org.hyperskill.app.study_plan.domain.model.StudyPlan
 import org.hyperskill.app.track.domain.model.TrackWithProgress
@@ -24,7 +25,7 @@ interface GamificationToolbarFeature {
         /**
          * Initialization
          */
-        data class Initialize(val screen: GamificationToolbarScreen, val forceUpdate: Boolean = false) : Message
+        data class Initialize(val forceUpdate: Boolean = false) : Message
 
         object FetchGamificationToolbarDataError : Message
         data class FetchGamificationToolbarDataSuccess(
@@ -38,7 +39,7 @@ interface GamificationToolbarFeature {
             object Error : FetchTrackWithProgressResult
         }
 
-        data class PullToRefresh(val screen: GamificationToolbarScreen) : Message
+        object PullToRefresh : Message
 
         /**
          * Flow Messages
@@ -52,8 +53,8 @@ interface GamificationToolbarFeature {
         /**
          * Clicks
          */
-        data class ClickedGems(val screen: GamificationToolbarScreen) : Message
-        data class ClickedStreak(val screen: GamificationToolbarScreen) : Message
+        object ClickedGems : Message
+        object ClickedStreak : Message
     }
 
     sealed interface Action {
@@ -62,7 +63,10 @@ interface GamificationToolbarFeature {
             val forceUpdate: Boolean
         ) : Action
 
-        data class FetchTrackWithProgress(val trackId: Long) : Action
+        data class FetchTrackWithProgress(
+            val trackId: Long,
+            val transaction: HyperskillSentryTransaction
+        ) : Action
 
         data class LogAnalyticEvent(val analyticEvent: AnalyticEvent) : Action
 

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarFeature.kt
@@ -3,9 +3,11 @@ package org.hyperskill.app.gamification_toolbar.presentation
 import org.hyperskill.app.analytic.domain.model.AnalyticEvent
 import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
 import org.hyperskill.app.streaks.domain.model.Streak
+import org.hyperskill.app.study_plan.domain.model.StudyPlan
 import org.hyperskill.app.track.domain.model.TrackWithProgress
 
 interface GamificationToolbarFeature {
+
     sealed interface State {
         object Idle : State
         object Loading : State
@@ -23,12 +25,18 @@ interface GamificationToolbarFeature {
          * Initialization
          */
         data class Initialize(val screen: GamificationToolbarScreen, val forceUpdate: Boolean = false) : Message
+
         object FetchGamificationToolbarDataError : Message
         data class FetchGamificationToolbarDataSuccess(
             val streak: Streak?,
             val hypercoinsBalance: Int,
             val trackWithProgress: TrackWithProgress?
         ) : Message
+
+        sealed interface FetchTrackWithProgressResult : Message {
+            data class Success(val trackWithProgress: TrackWithProgress?) : FetchTrackWithProgressResult
+            object Error : FetchTrackWithProgressResult
+        }
 
         data class PullToRefresh(val screen: GamificationToolbarScreen) : Message
 
@@ -38,6 +46,8 @@ interface GamificationToolbarFeature {
         object StepSolved : Message
         data class HypercoinsBalanceChanged(val hypercoinsBalance: Int) : Message
         data class StreakChanged(val streak: Streak?) : Message
+        data class StudyPlanChanged(val studyPlan: StudyPlan) : Message
+        object TopicCompleted : Message
 
         /**
          * Clicks
@@ -51,6 +61,8 @@ interface GamificationToolbarFeature {
             val screen: GamificationToolbarScreen,
             val forceUpdate: Boolean
         ) : Action
+
+        data class FetchTrackWithProgress(val trackId: Long) : Action
 
         data class LogAnalyticEvent(val analyticEvent: AnalyticEvent) : Action
 

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarFeature.kt
@@ -3,6 +3,7 @@ package org.hyperskill.app.gamification_toolbar.presentation
 import org.hyperskill.app.analytic.domain.model.AnalyticEvent
 import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
 import org.hyperskill.app.streaks.domain.model.Streak
+import org.hyperskill.app.track.domain.model.TrackWithProgress
 
 interface GamificationToolbarFeature {
     sealed interface State {
@@ -12,6 +13,7 @@ interface GamificationToolbarFeature {
         data class Content(
             val streak: Streak?,
             val hypercoinsBalance: Int,
+            val trackWithProgress: TrackWithProgress?,
             internal val isRefreshing: Boolean = false
         ) : State
     }
@@ -24,7 +26,8 @@ interface GamificationToolbarFeature {
         object FetchGamificationToolbarDataError : Message
         data class FetchGamificationToolbarDataSuccess(
             val streak: Streak?,
-            val hypercoinsBalance: Int
+            val hypercoinsBalance: Int,
+            val trackWithProgress: TrackWithProgress?
         ) : Message
 
         data class PullToRefresh(val screen: GamificationToolbarScreen) : Message
@@ -44,7 +47,10 @@ interface GamificationToolbarFeature {
     }
 
     sealed interface Action {
-        data class FetchGamificationToolbarData(val screen: GamificationToolbarScreen) : Action
+        data class FetchGamificationToolbarData(
+            val screen: GamificationToolbarScreen,
+            val forceUpdate: Boolean
+        ) : Action
 
         data class LogAnalyticEvent(val analyticEvent: AnalyticEvent) : Action
 

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarReducer.kt
@@ -43,7 +43,6 @@ class GamificationToolbarReducer(
                     else ->
                         null
                 }
-
             is Message.FetchTrackWithProgressResult -> {
                 if (state is State.Content && message is Message.FetchTrackWithProgressResult.Success) {
                     state.copy(trackWithProgress = message.trackWithProgress) to emptySet()
@@ -51,7 +50,6 @@ class GamificationToolbarReducer(
                     null
                 }
             }
-
             // Flow Messages
             is Message.StepSolved ->
                 if (state is State.Content) {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarReducer.kt
@@ -40,6 +40,15 @@ class GamificationToolbarReducer : StateReducer<State, Message, Action> {
                     else ->
                         null
                 }
+
+            is Message.FetchTrackWithProgressResult -> {
+                if (state is State.Content && message is Message.FetchTrackWithProgressResult.Success) {
+                    state.copy(trackWithProgress = message.trackWithProgress) to emptySet()
+                } else {
+                    null
+                }
+            }
+
             // Flow Messages
             is Message.StepSolved ->
                 if (state is State.Content) {
@@ -59,6 +68,29 @@ class GamificationToolbarReducer : StateReducer<State, Message, Action> {
                 } else {
                     null
                 }
+            is Message.StudyPlanChanged -> {
+                if (state is State.Content) {
+                    if (message.studyPlan.trackId != null) {
+                        state to setOf(Action.FetchTrackWithProgress(message.studyPlan.trackId))
+                    } else {
+                        state.copy(trackWithProgress = null) to emptySet()
+                    }
+                } else {
+                    null
+                }
+            }
+            is Message.TopicCompleted -> {
+                if (state is State.Content) {
+                    val trackId = state.trackWithProgress?.track?.id
+                    if (trackId != null) {
+                        state to setOf(Action.FetchTrackWithProgress(trackId))
+                    } else {
+                        state to emptySet()
+                    }
+                } else {
+                    null
+                }
+            }
             // Click Messages
             is Message.ClickedGems ->
                 if (state is State.Content) {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/gamification_toolbar/presentation/GamificationToolbarReducer.kt
@@ -14,21 +14,29 @@ class GamificationToolbarReducer : StateReducer<State, Message, Action> {
                 if (state is State.Idle ||
                     (message.forceUpdate && (state is State.Content || state is State.Error))
                 ) {
-                    State.Loading to setOf(Action.FetchGamificationToolbarData(message.screen))
+                    State.Loading to setOf(Action.FetchGamificationToolbarData(message.screen, message.forceUpdate))
                 } else {
                     null
                 }
             is Message.FetchGamificationToolbarDataError ->
                 State.Error to emptySet()
             is Message.FetchGamificationToolbarDataSuccess ->
-                State.Content(message.streak, message.hypercoinsBalance) to emptySet()
+                State.Content(
+                    streak = message.streak,
+                    hypercoinsBalance = message.hypercoinsBalance,
+                    trackWithProgress = message.trackWithProgress
+                ) to emptySet()
             is Message.PullToRefresh ->
                 when (state) {
                     is State.Content ->
-                        if (state.isRefreshing) null
-                        else state.copy(isRefreshing = true) to setOf(Action.FetchGamificationToolbarData(message.screen))
+                        if (state.isRefreshing) {
+                            null
+                        } else {
+                            state.copy(isRefreshing = true) to
+                                setOf(Action.FetchGamificationToolbarData(message.screen, true))
+                        }
                     is State.Error ->
-                        State.Loading to setOf(Action.FetchGamificationToolbarData(message.screen))
+                        State.Loading to setOf(Action.FetchGamificationToolbarData(message.screen, true))
                     else ->
                         null
                 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/home/injection/HomeComponentImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/home/injection/HomeComponentImpl.kt
@@ -1,6 +1,7 @@
 package org.hyperskill.app.home.injection
 
 import org.hyperskill.app.core.injection.AppGraph
+import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
 import org.hyperskill.app.gamification_toolbar.injection.GamificationToolbarComponent
 import org.hyperskill.app.home.domain.interactor.HomeInteractor
 import org.hyperskill.app.home.presentation.HomeFeature
@@ -13,7 +14,7 @@ class HomeComponentImpl(private val appGraph: AppGraph) : HomeComponent {
         HomeInteractor(appGraph.submissionDataComponent.submissionRepository)
 
     private val gamificationToolbarComponent: GamificationToolbarComponent =
-        appGraph.buildGamificationToolbarComponent()
+        appGraph.buildGamificationToolbarComponent(GamificationToolbarScreen.HOME)
 
     private val topicsToDiscoverNextComponent: TopicsToDiscoverNextComponent =
         appGraph.buildTopicsToDiscoverNextComponent(TopicsToDiscoverNextScreen.HOME)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/home/presentation/HomeReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/home/presentation/HomeReducer.kt
@@ -1,7 +1,7 @@
 package org.hyperskill.app.home.presentation
 
+import kotlin.math.max
 import org.hyperskill.app.core.domain.url.HyperskillUrlPath
-import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
 import org.hyperskill.app.gamification_toolbar.presentation.GamificationToolbarFeature
 import org.hyperskill.app.gamification_toolbar.presentation.GamificationToolbarReducer
 import org.hyperskill.app.home.domain.analytic.HomeClickedContinueLearningOnWebHyperskillAnalyticEvent
@@ -17,7 +17,6 @@ import org.hyperskill.app.home.presentation.HomeFeature.State
 import org.hyperskill.app.topics_to_discover_next.presentation.TopicsToDiscoverNextFeature
 import org.hyperskill.app.topics_to_discover_next.presentation.TopicsToDiscoverNextReducer
 import ru.nobird.app.presentation.redux.reducer.StateReducer
-import kotlin.math.max
 
 class HomeReducer(
     private val gamificationToolbarReducer: GamificationToolbarReducer,
@@ -50,7 +49,7 @@ class HomeReducer(
 
                 val (toolbarState, toolbarActions) = reduceGamificationToolbarMessage(
                     state.toolbarState,
-                    GamificationToolbarFeature.Message.PullToRefresh(GamificationToolbarScreen.HOME)
+                    GamificationToolbarFeature.Message.PullToRefresh
                 )
 
                 val (topicsToDiscoverNextState, topicsToDiscoverNextActions) = reduceTopicsToDiscoverNextMessage(
@@ -330,7 +329,7 @@ class HomeReducer(
         val (toolbarState, toolbarActions) =
             reduceGamificationToolbarMessage(
                 state.toolbarState,
-                GamificationToolbarFeature.Message.Initialize(GamificationToolbarScreen.HOME, forceUpdate)
+                GamificationToolbarFeature.Message.Initialize(forceUpdate)
             )
 
         val (topicsToDiscoverNextState, topicsToDiscoverNextActions) =

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/sentry/domain/model/transaction/HyperskillSentryTransactionBuilder.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/sentry/domain/model/transaction/HyperskillSentryTransactionBuilder.kt
@@ -1,5 +1,7 @@
 package org.hyperskill.app.sentry.domain.model.transaction
 
+import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
+
 /**
  * Please do not change the names of transactions if they already appeared in the Sentry.
  */
@@ -169,6 +171,12 @@ object HyperskillSentryTransactionBuilder {
     fun buildGamificationToolbarTrackScreenRemoteDataLoading(): HyperskillSentryTransaction =
         HyperskillSentryTransaction(
             name = "navigation-bar-items-feature-track-screen-remote-data-loading",
+            operation = HyperskillSentryTransactionOperation.API_LOAD
+        )
+
+    fun buildGamificationToolbarTrackProgressLoading(screen: GamificationToolbarScreen): HyperskillSentryTransaction =
+        HyperskillSentryTransaction(
+            name = "navigation-bar-items-feature-${screen.name.lowercase()}-screen-fetch_track_progress",
             operation = HyperskillSentryTransactionOperation.API_LOAD
         )
 

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/sentry/domain/model/transaction/HyperskillSentryTransactionBuilder.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/sentry/domain/model/transaction/HyperskillSentryTransactionBuilder.kt
@@ -176,7 +176,7 @@ object HyperskillSentryTransactionBuilder {
 
     fun buildGamificationToolbarTrackProgressLoading(screen: GamificationToolbarScreen): HyperskillSentryTransaction =
         HyperskillSentryTransaction(
-            name = when(screen) {
+            name = when (screen) {
                 GamificationToolbarScreen.HOME -> "navigation-bar-items-feature-home-screen-fetch_track_progress"
                 GamificationToolbarScreen.TRACK -> "navigation-bar-items-feature-track-screen-fetch_track_progress"
             },

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/sentry/domain/model/transaction/HyperskillSentryTransactionBuilder.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/sentry/domain/model/transaction/HyperskillSentryTransactionBuilder.kt
@@ -176,7 +176,10 @@ object HyperskillSentryTransactionBuilder {
 
     fun buildGamificationToolbarTrackProgressLoading(screen: GamificationToolbarScreen): HyperskillSentryTransaction =
         HyperskillSentryTransaction(
-            name = "navigation-bar-items-feature-${screen.name.lowercase()}-screen-fetch_track_progress",
+            name = when(screen) {
+                GamificationToolbarScreen.HOME -> "navigation-bar-items-feature-home-screen-fetch_track_progress"
+                GamificationToolbarScreen.TRACK -> "navigation-bar-items-feature-track-screen-fetch_track_progress"
+            },
             operation = HyperskillSentryTransactionOperation.API_LOAD
         )
 

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/track/domain/model/Track.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/track/domain/model/Track.kt
@@ -45,6 +45,8 @@ data class Track(
     @SerialName("topic_providers")
     val topicProviders: List<Long>,
 
+    // TODO: replace with TrackWithProgress to use composition way
+    @Deprecated("Use TrackWithProgress instead")
     @Transient
     val progress: TrackProgress? = null
 )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/track/domain/model/TrackWithProgress.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/track/domain/model/TrackWithProgress.kt
@@ -1,0 +1,19 @@
+package org.hyperskill.app.track.domain.model
+
+import kotlin.math.floor
+
+data class TrackWithProgress(
+    val track: Track,
+    val trackProgress: TrackProgress
+) {
+    val averageProgress: Int
+        get() {
+            val currentTopicsCount =
+                trackProgress.learnedTopicsCount +
+                    trackProgress.skippedTopicsCount +
+                    trackProgress.appliedCapstoneTopicsCount
+            val maxTopicsCount =
+                track.topicsCount + track.capstoneTopicsCount
+            return floor(currentTopicsCount / maxTopicsCount.toFloat() * 100).toInt()
+        }
+}

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/track/injection/TrackComponentImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/track/injection/TrackComponentImpl.kt
@@ -1,6 +1,7 @@
 package org.hyperskill.app.track.injection
 
 import org.hyperskill.app.core.injection.AppGraph
+import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
 import org.hyperskill.app.gamification_toolbar.injection.GamificationToolbarComponent
 import org.hyperskill.app.topics_to_discover_next.domain.model.TopicsToDiscoverNextScreen
 import org.hyperskill.app.topics_to_discover_next.injection.TopicsToDiscoverNextComponent
@@ -9,7 +10,7 @@ import ru.nobird.app.presentation.redux.feature.Feature
 
 class TrackComponentImpl(private val appGraph: AppGraph) : TrackComponent {
     private val gamificationToolbarComponent: GamificationToolbarComponent =
-        appGraph.buildGamificationToolbarComponent()
+        appGraph.buildGamificationToolbarComponent(GamificationToolbarScreen.TRACK)
 
     private val topicsToDiscoverNextComponent: TopicsToDiscoverNextComponent =
         appGraph.buildTopicsToDiscoverNextComponent(TopicsToDiscoverNextScreen.TRACK)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/track/presentation/TrackReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/track/presentation/TrackReducer.kt
@@ -1,7 +1,6 @@
 package org.hyperskill.app.track.presentation
 
 import org.hyperskill.app.core.domain.url.HyperskillUrlPath
-import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
 import org.hyperskill.app.gamification_toolbar.presentation.GamificationToolbarFeature
 import org.hyperskill.app.gamification_toolbar.presentation.GamificationToolbarReducer
 import org.hyperskill.app.topics_to_discover_next.presentation.TopicsToDiscoverNextFeature
@@ -32,7 +31,7 @@ class TrackReducer(
 
                 val (toolbarState, toolbarActions) = reduceGamificationToolbarMessage(
                     state.toolbarState,
-                    GamificationToolbarFeature.Message.Initialize(GamificationToolbarScreen.TRACK, message.forceUpdate)
+                    GamificationToolbarFeature.Message.Initialize(message.forceUpdate)
                 )
 
                 val (topicsToDiscoverNextState, topicsToDiscoverNextActions) = reduceTopicsToDiscoverNextMessage(
@@ -70,7 +69,7 @@ class TrackReducer(
 
                 val (toolbarState, toolbarActions) = reduceGamificationToolbarMessage(
                     state.toolbarState,
-                    GamificationToolbarFeature.Message.PullToRefresh(GamificationToolbarScreen.TRACK)
+                    GamificationToolbarFeature.Message.PullToRefresh
                 )
 
                 val (topicsToDiscoverNextState, topicsToDiscoverNextActions) = reduceTopicsToDiscoverNextMessage(

--- a/shared/src/iosMain/kotlin/org/hyperskill/app/core/injection/AppGraphImpl.kt
+++ b/shared/src/iosMain/kotlin/org/hyperskill/app/core/injection/AppGraphImpl.kt
@@ -18,6 +18,7 @@ import org.hyperskill.app.discussions.injection.DiscussionsDataComponent
 import org.hyperskill.app.discussions.injection.DiscussionsDataComponentImpl
 import org.hyperskill.app.freemium.injection.FreemiumDataComponent
 import org.hyperskill.app.freemium.injection.FreemiumDataComponentImpl
+import org.hyperskill.app.gamification_toolbar.domain.model.GamificationToolbarScreen
 import org.hyperskill.app.gamification_toolbar.injection.GamificationToolbarComponent
 import org.hyperskill.app.gamification_toolbar.injection.GamificationToolbarComponentImpl
 import org.hyperskill.app.home.injection.HomeComponent
@@ -271,8 +272,8 @@ class AppGraphImpl(
     override fun buildDebugComponent(): DebugComponent =
         DebugComponentImpl(this)
 
-    override fun buildGamificationToolbarComponent(): GamificationToolbarComponent =
-        GamificationToolbarComponentImpl(this)
+    override fun buildGamificationToolbarComponent(screen: GamificationToolbarScreen): GamificationToolbarComponent =
+        GamificationToolbarComponentImpl(this, screen)
 
     override fun buildTopicsToDiscoverNextComponent(screen: TopicsToDiscoverNextScreen): TopicsToDiscoverNextComponent =
         TopicsToDiscoverNextComponentImpl(this, screen)


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-680](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-680)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] Sentry Performance Monitoring of screen loading is added for new screens;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- `TrackWithProgress` added into `GamificattionToolbarFeature.State`
- StudyPlan & TopicCompleted subscription added to reload `TrackWithProgress`.
- `GamificattionToolbarScreen` added as a dependency for `GamificattionToolbarActionDispatcher` to use `fetchTrackProgressSentryTransaction` for isolated `TrackWithProgress` loading.
