### PR TITLE
ALTAPPS-687: Shared disable project auto selection for new users with freemium

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/placeholder_new_user/injection/PlaceholderNewUserComponentImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/placeholder_new_user/injection/PlaceholderNewUserComponentImpl.kt
@@ -14,7 +14,8 @@ class PlaceholderNewUserComponentImpl(
             appGraph.sentryComponent.sentryInteractor,
             appGraph.buildTrackDataComponent().trackInteractor,
             appGraph.buildProgressesDataComponent().progressesInteractor,
-            appGraph.buildProfileDataComponent().profileInteractor
+            appGraph.buildProfileDataComponent().profileInteractor,
+            appGraph.buildFreemiumDataComponent().freemiumInteractor
         )
 
     override val placeHolderNewUserViewDataMapper: PlaceholderNewUserViewDataMapper

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/placeholder_new_user/injection/PlaceholderNewUserFeatureBuilder.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/placeholder_new_user/injection/PlaceholderNewUserFeatureBuilder.kt
@@ -2,6 +2,7 @@ package org.hyperskill.app.placeholder_new_user.injection
 
 import org.hyperskill.app.analytic.domain.interactor.AnalyticInteractor
 import org.hyperskill.app.core.presentation.ActionDispatcherOptions
+import org.hyperskill.app.freemium.domain.interactor.FreemiumInteractor
 import org.hyperskill.app.placeholder_new_user.presentation.PlaceholderNewUserActionDispatcher
 import org.hyperskill.app.placeholder_new_user.presentation.PlaceholderNewUserFeature.State
 import org.hyperskill.app.placeholder_new_user.presentation.PlaceholderNewUserFeature.Message
@@ -21,7 +22,8 @@ object PlaceholderNewUserFeatureBuilder {
         sentryInteractor: SentryInteractor,
         trackInteractor: TrackInteractor,
         progressesInteractor: ProgressesInteractor,
-        profileInteractor: ProfileInteractor
+        profileInteractor: ProfileInteractor,
+        freemiumInteractor: FreemiumInteractor
     ): Feature<State, Message, Action> {
         val placeholderNewUserReducer = PlaceholderNewUserReducer()
         val placeholderNewUserActionDispatcher = PlaceholderNewUserActionDispatcher(
@@ -30,7 +32,8 @@ object PlaceholderNewUserFeatureBuilder {
             sentryInteractor,
             trackInteractor,
             progressesInteractor,
-            profileInteractor
+            profileInteractor,
+            freemiumInteractor
         )
 
         return ReduxFeature(State.Idle, placeholderNewUserReducer)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/placeholder_new_user/presentation/PlaceholderNewUserActionDispatcher.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/placeholder_new_user/presentation/PlaceholderNewUserActionDispatcher.kt
@@ -2,10 +2,10 @@ package org.hyperskill.app.placeholder_new_user.presentation
 
 import org.hyperskill.app.analytic.domain.interactor.AnalyticInteractor
 import org.hyperskill.app.core.presentation.ActionDispatcherOptions
+import org.hyperskill.app.freemium.domain.interactor.FreemiumInteractor
 import org.hyperskill.app.placeholder_new_user.presentation.PlaceholderNewUserFeature.Action
 import org.hyperskill.app.placeholder_new_user.presentation.PlaceholderNewUserFeature.Message
 import org.hyperskill.app.profile.domain.interactor.ProfileInteractor
-import org.hyperskill.app.profile.domain.model.isFreemiumEnabled
 import org.hyperskill.app.progresses.domain.interactor.ProgressesInteractor
 import org.hyperskill.app.sentry.domain.interactor.SentryInteractor
 import org.hyperskill.app.sentry.domain.model.transaction.HyperskillSentryTransactionBuilder
@@ -18,7 +18,8 @@ class PlaceholderNewUserActionDispatcher(
     private val sentryInteractor: SentryInteractor,
     private val trackInteractor: TrackInteractor,
     private val progressesInteractor: ProgressesInteractor,
-    private val profileInteractor: ProfileInteractor
+    private val profileInteractor: ProfileInteractor,
+    private val freemiumInteractor: FreemiumInteractor
 ) : CoroutineActionDispatcher<Action, Message>(config.createConfig()) {
     override suspend fun doSuspendableAction(action: Action) {
         when (action) {
@@ -59,7 +60,13 @@ class PlaceholderNewUserActionDispatcher(
                         return onNewMessage(Message.TrackSelected.Error)
                     }
 
-                if (currentProfile.isFreemiumEnabled) {
+                val isFreemiumEnabled = freemiumInteractor
+                    .isFreemiumEnabled()
+                    .getOrElse {
+                        return onNewMessage(Message.TrackSelected.Error)
+                    }
+
+                if (isFreemiumEnabled) {
                     profileInteractor.selectTrack(currentProfile.id, action.track.id)
                         .getOrElse {
                             return onNewMessage(Message.TrackSelected.Error)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile/data/repository/ProfileRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile/data/repository/ProfileRepositoryImpl.kt
@@ -27,6 +27,9 @@ class ProfileRepositoryImpl(
     override suspend fun selectTrackWithProject(profileId: Long, trackId: Long, projectId: Long): Result<Profile> =
         profileRemoteDataSource.selectTrackWithProject(profileId, trackId, projectId)
 
+    override suspend fun selectTrack(profileId: Long, trackId: Long): Result<Profile> =
+        profileRemoteDataSource.selectTrack(profileId, trackId)
+
     override suspend fun clearCache() {
         profileCacheDataSource.clearCache()
     }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile/data/source/ProfileRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile/data/source/ProfileRemoteDataSource.kt
@@ -6,4 +6,6 @@ interface ProfileRemoteDataSource {
     suspend fun getCurrentProfile(): Result<Profile>
 
     suspend fun selectTrackWithProject(profileId: Long, trackId: Long, projectId: Long): Result<Profile>
+
+    suspend fun selectTrack(profileId: Long, trackId: Long): Result<Profile>
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/interactor/ProfileInteractor.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/interactor/ProfileInteractor.kt
@@ -20,6 +20,9 @@ class ProfileInteractor(
     suspend fun selectTrackWithProject(profileId: Long, trackId: Long, projectId: Long): Result<Profile> =
         profileRepository.selectTrackWithProject(profileId, trackId, projectId)
 
+    suspend fun selectTrack(profileId: Long, trackId: Long): Result<Profile> =
+        profileRepository.selectTrack(profileId, trackId)
+
     suspend fun clearCache() {
         profileRepository.clearCache()
     }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/model/Profile.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/model/Profile.kt
@@ -42,7 +42,9 @@ data class Profile(
     @SerialName("track_id")
     val trackId: Long?,
     @SerialName("track_title")
-    val trackTitle: String?
+    val trackTitle: String?,
+    @SerialName("features")
+    val features: Map<String, Boolean>
 )
 
 internal val Profile.isNewUser: Boolean
@@ -50,3 +52,6 @@ internal val Profile.isNewUser: Boolean
 
 internal val Profile.isCurrentTrackCompleted: Boolean
     get() = trackId?.let { completedTracks.contains(it) } ?: false
+
+val Profile.isFreemiumEnabled: Boolean
+    get() = features.get("subscriptions.freemium") ?: false

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/model/Profile.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/model/Profile.kt
@@ -42,9 +42,7 @@ data class Profile(
     @SerialName("track_id")
     val trackId: Long?,
     @SerialName("track_title")
-    val trackTitle: String?,
-    @SerialName("features")
-    val features: Map<String, Boolean>
+    val trackTitle: String?
 )
 
 internal val Profile.isNewUser: Boolean
@@ -52,6 +50,3 @@ internal val Profile.isNewUser: Boolean
 
 internal val Profile.isCurrentTrackCompleted: Boolean
     get() = trackId?.let { completedTracks.contains(it) } ?: false
-
-val Profile.isFreemiumEnabled: Boolean
-    get() = features.get("subscriptions.freemium") ?: false

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/repository/ProfileRepository.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/repository/ProfileRepository.kt
@@ -6,5 +6,6 @@ import org.hyperskill.app.profile.domain.model.Profile
 interface ProfileRepository {
     suspend fun getCurrentProfile(primarySourceType: DataSourceType = DataSourceType.CACHE): Result<Profile>
     suspend fun selectTrackWithProject(profileId: Long, trackId: Long, projectId: Long): Result<Profile>
+    suspend fun selectTrack(profileId: Long, trackId: Long): Result<Profile>
     suspend fun clearCache()
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile/remote/ProfileRemoteDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile/remote/ProfileRemoteDataSourceImpl.kt
@@ -10,6 +10,7 @@ import io.ktor.http.contentType
 import org.hyperskill.app.profile.data.source.ProfileRemoteDataSource
 import org.hyperskill.app.profile.domain.model.Profile
 import org.hyperskill.app.profile.remote.model.ProfileResponse
+import org.hyperskill.app.profile.remote.model.ProfileSelectTrackRequest
 import org.hyperskill.app.profile.remote.model.ProfileSelectTrackWithProjectRequest
 
 class ProfileRemoteDataSourceImpl(
@@ -29,6 +30,15 @@ class ProfileRemoteDataSourceImpl(
                 .put("/api/profiles/$profileId") {
                     contentType(ContentType.Application.Json)
                     setBody(ProfileSelectTrackWithProjectRequest(trackId, projectId))
+                }.body<ProfileResponse>().profiles.first()
+        }
+
+    override suspend fun selectTrack(profileId: Long, trackId: Long): Result<Profile> =
+        kotlin.runCatching {
+            httpClient
+                .put("/api/profiles/$profileId") {
+                    contentType(ContentType.Application.Json)
+                    setBody(ProfileSelectTrackRequest(trackId))
                 }.body<ProfileResponse>().profiles.first()
         }
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile/remote/model/ProfileSelectTrackRequest.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile/remote/model/ProfileSelectTrackRequest.kt
@@ -1,0 +1,10 @@
+package org.hyperskill.app.profile.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ProfileSelectTrackRequest(
+    @SerialName("track_id")
+    val trackId: Long
+)


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-687](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-687)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Turn off project auto selection for new users when freemium feature is enabled

**WTD**
**Summary:**
* **Implemented Freemium Interactor**
Added a new component to manage freemium features for new users
* **Enhanced Profile Repository**
Improved track selection functionality in profile repository and data sources
* **Updated Logic for Track Selection**
Refined the decision-making process based on freemium status for selecting tracks with or without a project

**Poem:**
_In the realm of Mobile, a tale unfurls,_  
_As PlaceholderNewUserComponentImpl swirls._  
_FreemiumInteractor enters, a builder in hand,_  
_To aid ProfileRepositoryImpl, as they both stand._  
_Selecting the track, project-bound or free,_  
_As we update the dispatcher's logic, in strong unity._

**Joke:** Why did the `FreemiumInteractor` join the `mobile-app` band? Because it wanted to help select the perfect track! 🎶 📱