### PR TITLE
ALTAPPS-714: Shared fix study plan reload content in background

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StateExtentions.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StateExtentions.kt
@@ -3,10 +3,10 @@ package org.hyperskill.app.study_plan.widget.presentation
 import org.hyperskill.app.learning_activities.domain.model.LearningActivity
 import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
 
-internal fun StudyPlanWidgetFeature.State.firstSection(): StudyPlanSection? =
-    studyPlan?.sections?.firstOrNull()?.let { firstSectionId ->
-        studyPlanSections[firstSectionId]?.studyPlanSection
-    }
+internal fun StudyPlanWidgetFeature.State.firstVisibleSection(): StudyPlanSection? =
+    studyPlanSections.values
+        .firstOrNull { it.studyPlanSection.isVisible }
+        ?.studyPlanSection
 
 internal fun StudyPlanWidgetFeature.State.getSectionActivities(sectionId: Long): List<LearningActivity> =
     studyPlanSections[sectionId]

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -26,7 +26,7 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
                 state.copy(
                     studyPlanSections = state.studyPlanSections.mapValues { (sectionId, sectionInfo) ->
                         sectionInfo.copy(
-                            contentStatus = if (sectionId == state.firstSection()?.id) {
+                            contentStatus = if (sectionId == state.firstVisibleSection()?.id) {
                                 sectionInfo.contentStatus
                             } else {
                                 StudyPlanWidgetFeature.ContentStatus.IDLE

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/StudyPlanWidgetViewStateMapper.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/StudyPlanWidgetViewStateMapper.kt
@@ -5,7 +5,7 @@ import org.hyperskill.app.core.view.mapper.DateFormatter
 import org.hyperskill.app.learning_activities.domain.model.LearningActivity
 import org.hyperskill.app.learning_activities.domain.model.LearningActivityState
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
-import org.hyperskill.app.study_plan.widget.presentation.firstSection
+import org.hyperskill.app.study_plan.widget.presentation.firstVisibleSection
 import org.hyperskill.app.study_plan.widget.presentation.getSectionActivities
 import org.hyperskill.app.study_plan.widget.view.StudyPlanWidgetViewState.SectionContent
 
@@ -19,7 +19,7 @@ class StudyPlanWidgetViewStateMapper(private val dateFormatter: DateFormatter) {
         }
 
     private fun getLoadedWidgetContent(state: StudyPlanWidgetFeature.State): StudyPlanWidgetViewState.Content {
-        val firstSectionId = state.firstSection()?.id
+        val firstVisibleSectionId = state.firstVisibleSection()?.id
 
         return StudyPlanWidgetViewState.Content(
             sections = state.studyPlan?.sections?.mapNotNull { sectionId ->
@@ -33,7 +33,7 @@ class StudyPlanWidgetViewStateMapper(private val dateFormatter: DateFormatter) {
                         state = state,
                         sectionInfo = sectionInfo
                     ),
-                    formattedTopicsCount = if (firstSectionId == section.id) {
+                    formattedTopicsCount = if (firstVisibleSectionId == section.id) {
                         formatTopicsCount(
                             completedTopicsCount = section.completedTopicsCount,
                             topicsCount = section.topicsCount
@@ -41,7 +41,7 @@ class StudyPlanWidgetViewStateMapper(private val dateFormatter: DateFormatter) {
                     } else {
                         null
                     },
-                    formattedTimeToComplete = if (firstSectionId == section.id) {
+                    formattedTimeToComplete = if (firstVisibleSectionId == section.id) {
                         section.secondsToComplete
                             ?.roundToLong()
                             ?.let(dateFormatter::hoursWithMinutesCount)
@@ -106,7 +106,7 @@ class StudyPlanWidgetViewStateMapper(private val dateFormatter: DateFormatter) {
         )
 
     private fun formatTopicsCount(completedTopicsCount: Int, topicsCount: Int): String? =
-        if (completedTopicsCount > 0  && topicsCount > 0) {
+        if (completedTopicsCount > 0 && topicsCount > 0) {
             "$completedTopicsCount / $topicsCount"
         } else {
             null


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-714](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-714)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
* **Updated function in firstSection**
Replaced `firstSection()` with `firstVisibleSection()`.