### PR TITLE
ALTAPPS-729: Shared study plan filter sections

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSection.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSection.kt
@@ -33,6 +33,3 @@ data class StudyPlanSection(
     val type: StudyPlanSectionType?
         get() = StudyPlanSectionType.getByValue(typeValue)
 }
-
-val StudyPlanSection.isSupported: Boolean
-    get() = StudyPlanSectionType.supportedTypes().contains(type)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSection.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSection.kt
@@ -9,6 +9,8 @@ data class StudyPlanSection(
     val id: Long,
     @SerialName("study_plan_id")
     val studyPlanId: Long,
+    @SerialName("type")
+    private val typeValue: String,
     @SerialName("target_id")
     val targetId: Long? = null,
     @SerialName("target_type")
@@ -27,4 +29,10 @@ data class StudyPlanSection(
     val secondsToComplete: Float? = null,
     @SerialName("activities")
     val activities: List<Long>
-)
+) {
+    val type: StudyPlanSectionType?
+        get() = StudyPlanSectionType.getByValue(typeValue)
+}
+
+val StudyPlanSection.isSupported: Boolean
+    get() = StudyPlanSectionType.supportedTypes().contains(type)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSectionType.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSectionType.kt
@@ -1,0 +1,21 @@
+package org.hyperskill.app.study_plan.domain.model
+
+enum class StudyPlanSectionType(val value: String) {
+    STAGE("stage"),
+    WRAP_UP_PROJECT("wrap up your project"),
+    WRAP_UP_TRACK("wrap up your track"),
+    EXTRA_TOPICS("extra topics"),
+    NEXT_PROJECT("next project"),
+    ROOT_TOPICS("root topics"),
+    NEXT_TRACK("next track");
+
+    companion object {
+        private val VALUES: Array<StudyPlanSectionType> = values()
+
+        fun getByValue(value: String): StudyPlanSectionType? =
+            VALUES.firstOrNull { it.value == value }
+
+        fun supportedTypes(): Set<StudyPlanSectionType> =
+            setOf(STAGE, EXTRA_TOPICS, ROOT_TOPICS)
+    }
+}

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StateExtentions.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StateExtentions.kt
@@ -2,10 +2,11 @@ package org.hyperskill.app.study_plan.widget.presentation
 
 import org.hyperskill.app.learning_activities.domain.model.LearningActivity
 import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
+import org.hyperskill.app.study_plan.domain.model.StudyPlanSectionType
 
-internal fun StudyPlanWidgetFeature.State.firstVisibleSection(): StudyPlanSection? =
+internal fun StudyPlanWidgetFeature.State.firstSection(): StudyPlanSection? =
     studyPlanSections.values
-        .firstOrNull { it.studyPlanSection.isVisible }
+        .firstOrNull { it.studyPlanSection.isSupportedInStudyPlan }
         ?.studyPlanSection
 
 internal fun StudyPlanWidgetFeature.State.getSectionActivities(sectionId: Long): List<LearningActivity> =
@@ -13,3 +14,6 @@ internal fun StudyPlanWidgetFeature.State.getSectionActivities(sectionId: Long):
         ?.studyPlanSection
         ?.activities
         ?.mapNotNull { id -> activities[id] } ?: emptyList()
+
+internal val StudyPlanSection.isSupportedInStudyPlan: Boolean
+    get() = isVisible && StudyPlanSectionType.supportedTypes().contains(type)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -153,7 +153,11 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
         )
 
         return if (sortedSupportedSectionsIds.isNotEmpty()) {
-            changeSectionExpanse(loadedSectionsState, sortedSupportedSectionsIds.first(), shouldLogAnalyticEvent = false)
+            changeSectionExpanse(
+                loadedSectionsState,
+                sortedSupportedSectionsIds.first(),
+                shouldLogAnalyticEvent = false
+            )
         } else {
             loadedSectionsState to emptySet()
         }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -33,7 +33,7 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
                 state.copy(
                     studyPlanSections = state.studyPlanSections.mapValues { (sectionId, sectionInfo) ->
                         sectionInfo.copy(
-                            contentStatus = if (sectionId == state.firstVisibleSection()?.id) {
+                            contentStatus = if (sectionId == state.firstSection()?.id) {
                                 sectionInfo.contentStatus
                             } else {
                                 StudyPlanWidgetFeature.ContentStatus.IDLE
@@ -124,9 +124,9 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
         state: State,
         message: StudyPlanWidgetFeature.SectionsFetchResult.Success
     ): StudyPlanWidgetReducerResult {
-        val visibleSections = message.sections.filter { it.isVisible }
+        val supportedSections = message.sections.filter { it.isSupportedInStudyPlan }
 
-        val studyPlanSections = visibleSections.associate { studyPlanSection ->
+        val studyPlanSections = supportedSections.associate { studyPlanSection ->
             studyPlanSection.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                 studyPlanSection = studyPlanSection,
                 isExpanded = false,
@@ -134,10 +134,10 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
             )
         }
 
-        val sortedVisibleSections =
+        val sortedSupportedSectionsIds =
             if (state.studyPlan != null) {
-                val visibleSectionsIds = visibleSections.map { it.id }.toSet()
-                state.studyPlan.sections.intersect(visibleSectionsIds).toList()
+                val supportedSectionsIds = supportedSections.map { it.id }.toSet()
+                state.studyPlan.sections.intersect(supportedSectionsIds).toList()
             } else {
                 return state to emptySet()
             }
@@ -148,8 +148,8 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
             isRefreshing = false
         )
 
-        return if (sortedVisibleSections.isNotEmpty()) {
-            changeSectionExpanse(loadedSectionsState, sortedVisibleSections.first())
+        return if (sortedSupportedSectionsIds.isNotEmpty()) {
+            changeSectionExpanse(loadedSectionsState, sortedSupportedSectionsIds.first())
         } else {
             loadedSectionsState to emptySet()
         }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/StudyPlanWidgetViewStateMapper.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/StudyPlanWidgetViewStateMapper.kt
@@ -5,7 +5,7 @@ import org.hyperskill.app.core.view.mapper.DateFormatter
 import org.hyperskill.app.learning_activities.domain.model.LearningActivity
 import org.hyperskill.app.learning_activities.domain.model.LearningActivityState
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
-import org.hyperskill.app.study_plan.widget.presentation.firstVisibleSection
+import org.hyperskill.app.study_plan.widget.presentation.firstSection
 import org.hyperskill.app.study_plan.widget.presentation.getSectionActivities
 import org.hyperskill.app.study_plan.widget.view.StudyPlanWidgetViewState.SectionContent
 
@@ -19,14 +19,14 @@ class StudyPlanWidgetViewStateMapper(private val dateFormatter: DateFormatter) {
         }
 
     private fun getLoadedWidgetContent(state: StudyPlanWidgetFeature.State): StudyPlanWidgetViewState.Content {
-        val firstVisibleSectionId = state.firstVisibleSection()?.id
+        val firstSectionId = state.firstSection()?.id
 
         return StudyPlanWidgetViewState.Content(
             sections = state.studyPlan?.sections?.mapNotNull { sectionId ->
                 val sectionInfo = state.studyPlanSections[sectionId] ?: return@mapNotNull null
                 val section = sectionInfo.studyPlanSection
 
-                val shouldShowSectionStatistics = firstVisibleSectionId == section.id || sectionInfo.isExpanded
+                val shouldShowSectionStatistics = firstSectionId == section.id || sectionInfo.isExpanded
 
                 StudyPlanWidgetViewState.Section(
                     id = section.id,


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-729](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-729)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
Adds study plan sections filtering (display only supported ones):
1. `stage`
2. `extra topics`
3. `root topics`