### PR TITLE
ALTAPPS-786: Shared fix handling of empty learning activities fetch result for section

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -177,7 +177,7 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
     private fun handleLearningActivitiesFetchSuccess(
         state: State,
         message: StudyPlanWidgetFeature.LearningActivitiesFetchResult.Success
-    ): StudyPlanWidgetReducerResult  {
+    ): StudyPlanWidgetReducerResult {
         val nextState = state.copy(
             activities = state.activities.toMutableMap().apply {
                 putAll(message.activities.associateBy { it.id })

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -177,8 +177,8 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
     private fun handleLearningActivitiesFetchSuccess(
         state: State,
         message: StudyPlanWidgetFeature.LearningActivitiesFetchResult.Success
-    ): StudyPlanWidgetReducerResult =
-        state.copy(
+    ): StudyPlanWidgetReducerResult  {
+        val nextState = state.copy(
             activities = state.activities.toMutableMap().apply {
                 putAll(message.activities.associateBy { it.id })
                 // ALTAPPS-743: We should remove activities that are not in the new list
@@ -188,10 +188,27 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
                 val activitiesIdsToRemove = activitiesIds - message.activities.map { it.id }.toSet()
                 activitiesIdsToRemove.forEach { remove(it) }
             },
-            studyPlanSections = state.studyPlanSections.update(message.sectionId) { sectionInfo ->
-                sectionInfo.copy(contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED)
+            // ALTAPPS-786: We should hide sections without available activities to avoid blocking study plan
+            studyPlanSections = if (message.activities.isNotEmpty()) {
+                state.studyPlanSections.update(message.sectionId) { sectionInfo ->
+                    sectionInfo.copy(contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED)
+                }
+            } else {
+                state.studyPlanSections.toMutableMap().apply {
+                    remove(message.sectionId)
+                }
             }
-        ) to emptySet()
+        )
+
+        // ALTAPPS-786: We should expand next section if current section doesn't have available activities
+        return if (message.sectionId == state.getCurrentSection()?.id && message.activities.isEmpty()) {
+            state.studyPlanSections.keys.drop(1).firstOrNull()?.let { nextSectionId ->
+                changeSectionExpanse(nextState, nextSectionId, shouldLogAnalyticEvent = false)
+            } ?: (nextState to emptySet())
+        } else {
+            nextState to emptySet()
+        }
+    }
 
     private fun handleLearningActivitiesFetchFailed(
         state: State,

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -189,20 +189,20 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
                 activitiesIdsToRemove.forEach { remove(it) }
             },
             // ALTAPPS-786: We should hide sections without available activities to avoid blocking study plan
-            studyPlanSections = if (message.activities.isNotEmpty()) {
-                state.studyPlanSections.update(message.sectionId) { sectionInfo ->
-                    sectionInfo.copy(contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED)
-                }
-            } else {
+            studyPlanSections = if (message.activities.isEmpty()) {
                 state.studyPlanSections.toMutableMap().apply {
                     remove(message.sectionId)
+                }
+            } else {
+                state.studyPlanSections.update(message.sectionId) { sectionInfo ->
+                    sectionInfo.copy(contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED)
                 }
             }
         )
 
         // ALTAPPS-786: We should expand next section if current section doesn't have available activities
         return if (message.sectionId == state.getCurrentSection()?.id && message.activities.isEmpty()) {
-            state.studyPlanSections.keys.drop(1).firstOrNull()?.let { nextSectionId ->
+            nextState.studyPlanSections.keys.firstOrNull()?.let { nextSectionId ->
                 changeSectionExpanse(nextState, nextSectionId, shouldLogAnalyticEvent = false)
             } ?: (nextState to emptySet())
         } else {

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetTest.kt
@@ -258,9 +258,41 @@ class StudyPlanWidgetTest {
         val (state, _) =
             reducer.reduce(
                 initialState,
-                StudyPlanWidgetFeature.LearningActivitiesFetchResult.Success(sectionId = sectionId, emptyList())
+                StudyPlanWidgetFeature.LearningActivitiesFetchResult.Success(
+                    sectionId = sectionId,
+                    activities = listOf(stubLearningActivity(1L))
+                )
             )
         assertEquals(StudyPlanWidgetFeature.ContentStatus.LOADED, state.studyPlanSections[sectionId]?.contentStatus)
+    }
+
+    @Test
+    fun `Current section should be removed if no available activities loaded and next section should be expanded`() {
+        val currentSectionId = 0L
+        val nextSectionId = 1L
+        val initialState = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                currentSectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    studyPlanSection = studyPlanSectionStub(currentSectionId),
+                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADING,
+                    isExpanded = true
+                ),
+                nextSectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    studyPlanSection = studyPlanSectionStub(nextSectionId),
+                    contentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    isExpanded = false
+                )
+            )
+        )
+        val (state, _) =
+            reducer.reduce(
+                initialState,
+                StudyPlanWidgetFeature.LearningActivitiesFetchResult.Success(sectionId = currentSectionId, emptyList())
+            )
+        assertTrue(state.studyPlanSections.containsKey(currentSectionId).not())
+        val nextSection = state.studyPlanSections.get(nextSectionId)
+        assertTrue(nextSection?.isExpanded == true)
+        assertEquals(StudyPlanWidgetFeature.ContentStatus.LOADING, nextSection?.contentStatus)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetTest.kt
@@ -296,6 +296,32 @@ class StudyPlanWidgetTest {
     }
 
     @Test
+    fun `Not current section should be removed if no available activities loaded`() {
+        val currentSectionId = 0L
+        val notCurrent = 1L
+        val initialState = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                currentSectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    studyPlanSection = studyPlanSectionStub(currentSectionId),
+                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED,
+                    isExpanded = true
+                ),
+                notCurrent to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    studyPlanSection = studyPlanSectionStub(notCurrent),
+                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADING,
+                    isExpanded = false
+                )
+            )
+        )
+        val (state, _) =
+            reducer.reduce(
+                initialState,
+                StudyPlanWidgetFeature.LearningActivitiesFetchResult.Success(sectionId = notCurrent, emptyList())
+            )
+        assertTrue(state.studyPlanSections.containsKey(notCurrent).not())
+    }
+
+    @Test
     fun `New activities should added to activities map`() {
         val sectionId = 0L
         val activities = List(2) { index ->


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-786](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-786)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
After successful loading of learning activities for some section we must remove this section if no available learning activities were loaded. If it happens with the current section we also need to expand the next section because after removing the first section the next one becomes the current one and it must be expanded.