### PR TITLE
ALTAPPS-838: iOS fix streak recovery modal didn't appear for the first application run

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/PanModal/PanModalSwiftUIViewController.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/PanModal/PanModalSwiftUIViewController.swift
@@ -45,6 +45,10 @@ class PanModalSwiftUIViewController<Content: View>: PanModalPresentableViewContr
             make.width.equalToSuperview()
         }
         contentHostingController.didMove(toParent: self)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
 
         DispatchQueue.main.async {
             self.panModalSetNeedsLayoutUpdate()


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-838](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-838)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Fixes `PanModalSwiftUIViewController`