### PR TITLE
ALTAPPS-847: iOS update features initial data loading

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/AppViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/AppViewModel.swift
@@ -22,8 +22,6 @@ final class AppViewModel: FeatureViewModel<AppFeatureState, AppFeatureMessage, A
 
         super.init(feature: feature)
 
-        onNewMessage(AppFeatureMessageInitialize(pushNotificationData: pushNotificationData, forceUpdate: false))
-
         self.objectWillChangeSubscription = objectWillChange.sink { [weak self] _ in
             self?.mainScheduler.schedule { [weak self] in
                 guard let strongSelf = self else {
@@ -56,8 +54,8 @@ final class AppViewModel: FeatureViewModel<AppFeatureState, AppFeatureMessage, A
         AppFeatureStateKs(oldState) != AppFeatureStateKs(newState)
     }
 
-    func doRetryLoadApp() {
-        onNewMessage(AppFeatureMessageInitialize(pushNotificationData: pushNotificationData, forceUpdate: true))
+    func doLoadApp(forceUpdate: Bool = false) {
+        onNewMessage(AppFeatureMessageInitialize(pushNotificationData: pushNotificationData, forceUpdate: forceUpdate))
     }
 
     // MARK: Private API

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/ViewControllers/AppViewController.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/ViewControllers/AppViewController.swift
@@ -39,6 +39,8 @@ final class AppViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        viewModel.doLoadApp()
         updateProgressHUDStyle()
     }
 
@@ -258,7 +260,7 @@ extension AppViewController: AppViewControllerProtocol {
 
 extension AppViewController: AppViewDelegate {
     func appViewPlaceholderActionButtonTapped(_ view: AppView) {
-        viewModel.doRetryLoadApp()
+        viewModel.doLoadApp(forceUpdate: true)
     }
 
     func appView(

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Onboarding/OnboardingView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Onboarding/OnboardingView.swift
@@ -39,18 +39,14 @@ struct OnboardingView: View {
     @ViewBuilder
     private func buildBody() -> some View {
         switch viewModel.stateKs {
-        case .idle:
-            ProgressView()
-                .onAppear {
-                    viewModel.loadOnboarding()
-                }
-        case .loading:
+        case .idle, .loading:
             ProgressView()
         case .networkError:
             PlaceholderView(
-                configuration: .networkError(backgroundColor: .clear) {
-                    viewModel.loadOnboarding(forceUpdate: true)
-                }
+                configuration: .networkError(
+                    backgroundColor: .clear,
+                    action: viewModel.doRetryLoadOnboarding
+                )
             )
         case .content:
             VStack(alignment: .center, spacing: LayoutInsets.largeInset) {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Onboarding/OnboardingViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Onboarding/OnboardingViewModel.swift
@@ -10,6 +10,11 @@ final class OnboardingViewModel: FeatureViewModel<
 
     var stateKs: OnboardingFeatureStateKs { .init(state) }
 
+    init(feature: Presentation_reduxFeature) {
+        super.init(feature: feature)
+        onNewMessage(OnboardingFeatureMessageInitialize(forceUpdate: false))
+    }
+
     override func shouldNotifyStateDidChange(
         oldState: OnboardingFeatureState,
         newState: OnboardingFeatureState
@@ -17,8 +22,8 @@ final class OnboardingViewModel: FeatureViewModel<
         OnboardingFeatureStateKs(oldState) != OnboardingFeatureStateKs(newState)
     }
 
-    func loadOnboarding(forceUpdate: Bool = false) {
-        onNewMessage(OnboardingFeatureMessageInitialize(forceUpdate: forceUpdate))
+    func doRetryLoadOnboarding() {
+        onNewMessage(OnboardingFeatureMessageInitialize(forceUpdate: true))
     }
 
     func doSignPresentation() {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/ProfileSettings/ProfileSettingsView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/ProfileSettings/ProfileSettingsView.swift
@@ -47,19 +47,10 @@ struct ProfileSettingsView: View {
     @ViewBuilder
     private func buildBody() -> some View {
         switch viewModel.stateKs {
-        case .idle:
-            ProgressView()
-                .onAppear {
-                    viewModel.loadProfileSettings()
-                }
-        case .loading:
+        case .idle, .loading:
             ProgressView()
         case .error:
-            PlaceholderView(
-                configuration: .networkError {
-                    viewModel.loadProfileSettings(forceUpdate: true)
-                }
-            )
+            PlaceholderView(configuration: .networkError(action: viewModel.doRetryLoadProfileSettings))
         case .content(let content):
             if content.isLoadingMagicLink {
                 let _ = ProgressHUD.show()

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/ProfileSettings/ProfileSettingsViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/ProfileSettings/ProfileSettingsViewModel.swift
@@ -25,6 +25,8 @@ final class ProfileSettingsViewModel: FeatureViewModel<
     ) {
         self.applicationThemeService = applicationThemeService
         super.init(feature: feature)
+
+        onNewMessage(ProfileSettingsFeatureMessageInitMessage(forceUpdate: false))
     }
 
     override func shouldNotifyStateDidChange(
@@ -34,8 +36,8 @@ final class ProfileSettingsViewModel: FeatureViewModel<
         ProfileSettingsFeatureStateKs(oldState) != ProfileSettingsFeatureStateKs(newState)
     }
 
-    func loadProfileSettings(forceUpdate: Bool = false) {
-        onNewMessage(ProfileSettingsFeatureMessageInitMessage(forceUpdate: forceUpdate))
+    func doRetryLoadProfileSettings() {
+        onNewMessage(ProfileSettingsFeatureMessageInitMessage(forceUpdate: true))
     }
 
     func doThemeChange(newTheme: ApplicationTheme) {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StageImplement/StageImplementViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StageImplement/StageImplementViewModel.swift
@@ -18,7 +18,12 @@ final class StageImplementViewModel: FeatureViewModel<
     ) {
         self.projectID = projectID
         self.stageID = stageID
+
         super.init(feature: feature)
+
+        onNewMessage(
+            StageImplementFeatureMessageInitialize(projectId: projectID, stageId: stageID, forceUpdate: false)
+        )
     }
 
     override func shouldNotifyStateDidChange(
@@ -28,9 +33,9 @@ final class StageImplementViewModel: FeatureViewModel<
         StageImplementFeatureViewStateKs(oldState) != StageImplementFeatureViewStateKs(newState)
     }
 
-    func doLoadStageImplement(forceUpdate: Bool = false) {
+    func doRetryLoadStageImplement() {
         onNewMessage(
-            StageImplementFeatureMessageInitialize(projectId: projectID, stageId: stageID, forceUpdate: forceUpdate)
+            StageImplementFeatureMessageInitialize(projectId: projectID, stageId: stageID, forceUpdate: true)
         )
     }
 

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StageImplement/Views/StageImplementView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StageImplement/Views/StageImplementView.swift
@@ -29,21 +29,10 @@ struct StageImplementView: View {
     @ViewBuilder
     private func buildBody() -> some View {
         switch viewModel.stateKs {
-        case .idle:
-            ProgressView()
-                .onAppear {
-                    viewModel.doLoadStageImplement()
-                }
-        case .loading:
+        case .idle, .loading:
             ProgressView()
         case .networkError:
-            PlaceholderView(
-                configuration: .networkError(
-                    action: {
-                        viewModel.doLoadStageImplement(forceUpdate: true)
-                    }
-                )
-            )
+            PlaceholderView(configuration: .networkError(action: viewModel.doRetryLoadStageImplement))
         case .content(let data):
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/StepViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/StepViewModel.swift
@@ -21,7 +21,10 @@ final class StepViewModel: FeatureViewModel<StepFeatureState, StepFeatureMessage
     ) {
         self.stepRoute = stepRoute
         self.viewDataMapper = viewDataMapper
+
         super.init(feature: feature)
+
+        onNewMessage(StepFeatureMessageInitialize(forceUpdate: false))
     }
 
     override func shouldNotifyStateDidChange(oldState: StepFeatureState, newState: StepFeatureState) -> Bool {
@@ -46,8 +49,8 @@ final class StepViewModel: FeatureViewModel<StepFeatureState, StepFeatureMessage
         return shouldNotify
     }
 
-    func loadStep(forceUpdate: Bool = false) {
-        onNewMessage(StepFeatureMessageInitialize(forceUpdate: forceUpdate))
+    func doRetryLoadStep() {
+        onNewMessage(StepFeatureMessageInitialize(forceUpdate: true))
     }
 
     func makeViewData(_ step: Step) -> StepViewData {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/Views/StepView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/Views/StepView.swift
@@ -33,20 +33,13 @@ struct StepView: View {
     @ViewBuilder
     private func buildBody() -> some View {
         switch viewModel.stateKs {
-        case .idle:
-            ProgressView()
-                .onAppear {
-                    viewModel.loadStep()
-                }
-        case .loading:
+        case .idle, .loading:
             ProgressView()
         case .error:
             PlaceholderView(
                 configuration: .networkError(
                     backgroundColor: .clear,
-                    action: {
-                        viewModel.loadStep(forceUpdate: true)
-                    }
+                    action: viewModel.doRetryLoadStep
                 )
             )
         case .data(let data):

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/StepQuizViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/StepQuizViewModel.swift
@@ -51,7 +51,10 @@ final class StepQuizViewModel: FeatureViewModel<
         self.problemsLimitViewStateMapper = problemsLimitViewStateMapper
         self.notificationService = notificationService
         self.notificationsRegistrationService = notificationsRegistrationService
+
         super.init(feature: feature)
+
+        onNewMessage(StepQuizFeatureMessageInitWithStep(step: step, forceUpdate: false))
     }
 
     override func shouldNotifyStateDidChange(oldState: StepQuizFeatureState, newState: StepQuizFeatureState) -> Bool {
@@ -76,8 +79,8 @@ final class StepQuizViewModel: FeatureViewModel<
         provideModuleInputCallback(self)
     }
 
-    func loadAttempt(forceUpdate: Bool = false) {
-        onNewMessage(StepQuizFeatureMessageInitWithStep(step: step, forceUpdate: forceUpdate))
+    func doRetryLoadAttempt() {
+        onNewMessage(StepQuizFeatureMessageInitWithStep(step: step, forceUpdate: true))
     }
 
     func syncReply(_ reply: Reply) {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/Views/StepQuizView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/Views/StepQuizView.swift
@@ -24,10 +24,6 @@ struct StepQuizView: View {
                 viewModel.startListening()
                 viewModel.onViewAction = handleViewAction(_:)
 
-                if viewModel.stepQuizStateKs == .idle {
-                    viewModel.loadAttempt()
-                }
-
                 viewModel.doProvideModuleInput()
             }
             .onDisappear {
@@ -44,9 +40,7 @@ struct StepQuizView: View {
             PlaceholderView(
                 configuration: .networkError(
                     backgroundColor: .clear,
-                    action: {
-                        viewModel.loadAttempt(forceUpdate: true)
-                    }
+                    action: viewModel.doRetryLoadAttempt
                 )
             )
         } else {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizHints/StepQuizHintsViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizHints/StepQuizHintsViewModel.swift
@@ -13,6 +13,8 @@ final class StepQuizHintsViewModel: FeatureViewModel<
     init(stepID: Int64, feature: Presentation_reduxFeature) {
         self.stepID = stepID
         super.init(feature: feature)
+
+        onNewMessage(StepQuizHintsFeatureMessageInitWithStepId(stepId: stepID))
     }
 
     override func shouldNotifyStateDidChange(
@@ -20,10 +22,6 @@ final class StepQuizHintsViewModel: FeatureViewModel<
         newState: StepQuizHintsFeatureViewState
     ) -> Bool {
         StepQuizHintsFeatureViewStateKs(oldState) != StepQuizHintsFeatureViewStateKs(newState)
-    }
-
-    func loadHintsIDs() {
-        onNewMessage(StepQuizHintsFeatureMessageInitWithStepId(stepId: stepID))
     }
 
     func onHintReactionButtonTap(reaction: ReactionType) {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizHints/Views/StepQuizHintsView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizHints/Views/StepQuizHintsView.swift
@@ -34,7 +34,6 @@ struct StepQuizHintsView: View {
         case .idle:
             SkeletonRoundedView()
                 .frame(height: appearance.skeletonInitialHeight)
-                .onAppear(perform: viewModel.loadHintsIDs)
         case .initialLoading, .hintLoading:
             SkeletonRoundedView()
                 .frame(height: appearance.skeletonHintHeight)

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/TopicsRepetitionsViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/TopicsRepetitionsViewModel.swift
@@ -8,6 +8,11 @@ final class TopicsRepetitionsViewModel: FeatureViewModel<
 > {
     var stateKs: TopicsRepetitionsFeatureStateKs { .init(state) }
 
+    init(feature: Presentation_reduxFeature) {
+        super.init(feature: feature)
+        onNewMessage(TopicsRepetitionsFeatureMessageInitialize(forceUpdate: false))
+    }
+
     override func shouldNotifyStateDidChange(
         oldState: TopicsRepetitionsFeatureState,
         newState: TopicsRepetitionsFeatureState
@@ -15,8 +20,8 @@ final class TopicsRepetitionsViewModel: FeatureViewModel<
         TopicsRepetitionsFeatureStateKs(oldState) != TopicsRepetitionsFeatureStateKs(newState)
     }
 
-    func doLoadContent(forceUpdate: Bool = false) {
-        onNewMessage(TopicsRepetitionsFeatureMessageInitialize(forceUpdate: forceUpdate))
+    func doRetryLoadTopicsRepetitions() {
+        onNewMessage(TopicsRepetitionsFeatureMessageInitialize(forceUpdate: true))
     }
 
     func doLoadNextTopics() {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/Views/TopicsRepetitionsView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/TopicsRepetitions/Views/TopicsRepetitionsView.swift
@@ -44,18 +44,14 @@ struct TopicsRepetitionsView: View {
     @ViewBuilder
     private func buildBody() -> some View {
         switch viewModel.stateKs {
-        case .idle:
-            buildSkeletons()
-                .onAppear {
-                    viewModel.doLoadContent()
-                }
-        case .loading:
+        case .idle, .loading:
             buildSkeletons()
         case .networkError:
             PlaceholderView(
-                configuration: .networkError(backgroundColor: appearance.backgroundColor) {
-                    viewModel.doLoadContent(forceUpdate: true)
-                }
+                configuration: .networkError(
+                    backgroundColor: appearance.backgroundColor,
+                    action: viewModel.doRetryLoadTopicsRepetitions
+                )
             )
         case .content(let state):
             ScrollView {


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-847](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-847)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
Updates initial data loading for features - moves to view model init.

Tab bar modules (Home, Study Plan, Profile) don't change, because for those screens we want to load data when a tab bar item is active.