### PR TITLE
ALTAPPS-860: Shared bump gradle-versions-plugin from 0.39.0 to 0.47.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ plugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref
 plugin-dokkaBase = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
 plugin-android = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
 plugin-ktlint = { module = "org.jlleitschuh.gradle:ktlint-gradle", version = "10.2.0" }
-plugin-gradleVersionUpdates = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.39.0" }
+plugin-gradleVersionUpdates = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.47.0" }
 plugin-buildKonfig = { module = "com.codingfeline.buildkonfig:buildkonfig-gradle-plugin", version = "0.13.3" }
 plugin-mokoResources = { module = "dev.icerock.moko:resources-generator", version.ref = "mokoResources" }
 plugin-mokoKswift = { module = "dev.icerock.moko:kswift-gradle-plugin", version.ref = "mokoKswift" }


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-860](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-860)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
Bumps `gradle-versions-plugin` from `0.39.0` to `0.47.0`