### PR TITLE
ALTAPPS-885: Shared Darwin engine set timeoutIntervalForRequest

### DIFF
--- a/shared/src/iosMain/kotlin/org/hyperskill/app/network/PreconfiguredHttpClient.kt
+++ b/shared/src/iosMain/kotlin/org/hyperskill/app/network/PreconfiguredHttpClient.kt
@@ -8,4 +8,9 @@ import io.ktor.client.engine.darwin.Darwin
 internal actual fun PreconfiguredPlatformHttpClient(block: HttpClientConfig<*>.() -> Unit): HttpClient =
     HttpClient(Darwin) {
         apply(block)
+        engine {
+            configureSession {
+                timeoutIntervalForRequest = 10.0
+            }
+        }
     }


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-885](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-885)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Sets the default value for the `timeoutIntervalForRequest` of the Darwin engine