### PR TITLE
ALTAPPS-890: Fix Android daily reminder

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification/local/DailyStudyReminderLocalNotificationDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification/local/DailyStudyReminderLocalNotificationDelegate.kt
@@ -54,19 +54,17 @@ class DailyStudyReminderLocalNotificationDelegate(
     }
 
     override fun getNextScheduledAt(): Long? =
-        getNextScheduledAtInternal()
+        if (!notificationInteractor.isDailyStudyRemindersEnabled()) {
+            null
+        } else {
+            getNextScheduledAtInternal()
+        }
 
     fun scheduleDailyNotification() {
-        getNextScheduledAtInternal()?.let { scheduledAt ->
-            scheduleNotificationAt(scheduledAt)
-        }
+        scheduleNotificationAt(getNextScheduledAtInternal())
     }
 
-    private fun getNextScheduledAtInternal(): Long? {
-        if (!notificationInteractor.isDailyStudyRemindersEnabled()) {
-            return null
-        }
-
+    private fun getNextScheduledAtInternal(): Long {
         val hour = notificationInteractor.getDailyStudyRemindersIntervalStartHour()
         val now = DateTimeHelper.nowUtc()
         val calendar = Calendar.getInstance()

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification/local/DailyStudyReminderLocalNotificationDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification/local/DailyStudyReminderLocalNotificationDelegate.kt
@@ -57,15 +57,16 @@ class DailyStudyReminderLocalNotificationDelegate(
         if (!notificationInteractor.isDailyStudyRemindersEnabled()) {
             null
         } else {
-            getNextScheduledAtInternal()
+            getNextScheduledAtInternal(notificationInteractor.getDailyStudyRemindersIntervalStartHour())
         }
 
-    fun scheduleDailyNotification() {
-        scheduleNotificationAt(getNextScheduledAtInternal())
+    fun scheduleDailyNotification(
+        selectedHour: Int = notificationInteractor.getDailyStudyRemindersIntervalStartHour()
+    ) {
+        scheduleNotificationAt(getNextScheduledAtInternal(selectedHour))
     }
 
-    private fun getNextScheduledAtInternal(): Long {
-        val hour = notificationInteractor.getDailyStudyRemindersIntervalStartHour()
+    private fun getNextScheduledAtInternal(hour: Int): Long {
         val now = DateTimeHelper.nowUtc()
         val calendar = Calendar.getInstance()
         calendar.set(Calendar.HOUR_OF_DAY, hour)

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/profile/view/fragment/ProfileFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/profile/view/fragment/ProfileFragment.kt
@@ -256,7 +256,7 @@ class ProfileFragment :
         profileViewModel.onNewMessage(
             ProfileFeature.Message.DailyStudyRemindersIntervalStartHourChanged(chosenInterval)
         )
-        platformNotificationComponent.dailyStudyReminderNotificationDelegate.scheduleDailyNotification()
+        platformNotificationComponent.dailyStudyReminderNotificationDelegate.scheduleDailyNotification(chosenInterval)
     }
 
     override fun onAction(action: ProfileFeature.Action.ViewAction) {


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-890](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-890)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
The root cause of this bug are race-conditions. The `ProfileFragment` send messages which should save the availability flag or reminder time in the settings, but these operations are asynchronous. So, `DailyStudyReminderLocalNotificationDelegate` access the data before they are updated via actionDispatcher. 
I've removed the `notificationInteractor` access from `DailyStudyReminderLocalNotificationDelegate` in case of notification planning from the `ProfileFragment`. 
