### PR TITLE
ALTAPPS-922: Android app crash just after setting reminder from dialog

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/core/extensions/NotificationExtensions.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/core/extensions/NotificationExtensions.kt
@@ -36,7 +36,7 @@ fun NotificationManagerCompat.isChannelNotificationsEnabled(channelId: String): 
 fun NotificationManagerCompat.checkNotificationChannelAvailability(
     context: Context,
     notificationChannel: HyperskillNotificationChannel,
-    onError: () -> Unit
+    onError: () -> Unit = {}
 ): Boolean =
     when {
         !areNotificationsEnabled() -> {

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/dialog/RequestDailyStudyReminderDialogFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/dialog/RequestDailyStudyReminderDialogFragment.kt
@@ -4,27 +4,20 @@ import android.app.Dialog
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import ru.nobird.android.view.base.ui.extension.argument
 
 class RequestDailyStudyReminderDialogFragment : DialogFragment() {
 
     companion object {
         const val TAG: String = "RequestDailyStudyReminderDialogFragment"
 
-        fun newInstance(title: String, message: String): RequestDailyStudyReminderDialogFragment =
-            RequestDailyStudyReminderDialogFragment().apply {
-                this.title = title
-                this.message = message
-            }
+        fun newInstance(): RequestDailyStudyReminderDialogFragment =
+            RequestDailyStudyReminderDialogFragment()
     }
-
-    private var title: String by argument()
-    private var message: String by argument()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
         MaterialAlertDialogBuilder(requireContext())
-            .setTitle(title)
-            .setMessage(message)
+            .setTitle(org.hyperskill.app.R.string.after_daily_step_completed_dialog_title)
+            .setMessage(org.hyperskill.app.R.string.after_daily_step_completed_dialog_text)
             .setPositiveButton(org.hyperskill.app.R.string.ok) { dialog, _ ->
                 (parentFragment as Callback).onPermissionResult(isGranted = true)
                 dialog.dismiss()

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/dialog/RequestDailyStudyReminderDialogFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/dialog/RequestDailyStudyReminderDialogFragment.kt
@@ -1,0 +1,41 @@
+package org.hyperskill.app.android.step_quiz.view.dialog
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import ru.nobird.android.view.base.ui.extension.argument
+
+class RequestDailyStudyReminderDialogFragment : DialogFragment() {
+
+    companion object {
+        const val TAG: String = "RequestDailyStudyReminderDialogFragment"
+
+        fun newInstance(title: String, message: String): RequestDailyStudyReminderDialogFragment =
+            RequestDailyStudyReminderDialogFragment().apply {
+                this.title = title
+                this.message = message
+            }
+    }
+
+    private var title: String by argument()
+    private var message: String by argument()
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(title)
+            .setMessage(message)
+            .setPositiveButton(org.hyperskill.app.R.string.ok) { dialog, _ ->
+                (parentFragment as Callback).onPermissionResult(isGranted = true)
+                dialog.dismiss()
+            }
+            .setNegativeButton(org.hyperskill.app.R.string.later) { dialog, _ ->
+                (parentFragment as Callback).onPermissionResult(isGranted = false)
+                dialog.dismiss()
+            }
+            .show()
+
+    interface Callback {
+        fun onPermissionResult(isGranted: Boolean)
+    }
+}

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/fragment/DefaultStepQuizFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/fragment/DefaultStepQuizFragment.kt
@@ -311,7 +311,7 @@ abstract class DefaultStepQuizFragment :
                         requestResetCodeActionPermission(action)
                     }
                     StepQuizUserPermissionRequest.SEND_DAILY_STUDY_REMINDERS -> {
-                        requestSendDailyStudyRemindersPermission(action)
+                        requestSendDailyStudyRemindersPermission()
                     }
                 }
             }
@@ -351,13 +351,9 @@ abstract class DefaultStepQuizFragment :
             .show()
     }
 
-    private fun requestSendDailyStudyRemindersPermission(
-        action: StepQuizFeature.Action.ViewAction.RequestUserPermission
-    ) {
-        RequestDailyStudyReminderDialogFragment.newInstance(
-            title = userPermissionRequestTextMapper?.getTitle(action.userPermissionRequest) ?: "",
-            message = userPermissionRequestTextMapper?.getMessage(action.userPermissionRequest) ?: ""
-        ).showIfNotExists(childFragmentManager, RequestDailyStudyReminderDialogFragment.TAG)
+    private fun requestSendDailyStudyRemindersPermission() {
+        RequestDailyStudyReminderDialogFragment.newInstance()
+            .showIfNotExists(childFragmentManager, RequestDailyStudyReminderDialogFragment.TAG)
     }
 
     override fun onPermissionResult(isGranted: Boolean) {

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/fragment/DefaultStepQuizFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/fragment/DefaultStepQuizFragment.kt
@@ -388,13 +388,10 @@ abstract class DefaultStepQuizFragment :
                 isGranted = true
             )
         )
-        NotificationManagerCompat.from(requireContext()).checkNotificationChannelAvailability(
-            requireContext(),
-            HyperskillNotificationChannel.DailyReminder
-        ) {
-            if (isResumed) {
-                viewBinding.root.snackbar(org.hyperskill.app.R.string.common_error)
-            }
+        val context = context
+        if (context != null) {
+            NotificationManagerCompat.from(context)
+                .checkNotificationChannelAvailability(context, HyperskillNotificationChannel.DailyReminder)
         }
         platformNotificationComponent.dailyStudyReminderNotificationDelegate.scheduleDailyNotification()
     }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/fragment/DefaultStepQuizFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/fragment/DefaultStepQuizFragment.kt
@@ -376,8 +376,17 @@ abstract class DefaultStepQuizFragment :
     }
 
     private fun onNotificationPermissionResult(result: NotificationPermissionDelegate.Result) {
-        if (result == NotificationPermissionDelegate.Result.GRANTED) {
-            onNotificationPermissionGranted()
+        when (result) {
+            NotificationPermissionDelegate.Result.GRANTED -> {
+                onNotificationPermissionGranted()
+            }
+            NotificationPermissionDelegate.Result.DENIED,
+            NotificationPermissionDelegate.Result.DONT_ASK -> {
+                StepQuizFeature.Message.RequestUserPermissionResult(
+                    userPermissionRequest = StepQuizUserPermissionRequest.SEND_DAILY_STUDY_REMINDERS,
+                    isGranted = false
+                )
+            }
         }
     }
 


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-922](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-922)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Wrap dailyStudyReminder request dialog with DialogFragment to make it cancelled with the parent fragment
- Make safe access to the context in the callback
