### PR TITLE
ALTAPPS-938, ALTAPPS-939: IOS show problem limit widget and hide go to web button on home screen

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Models/Constants/Strings.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Models/Constants/Strings.swift
@@ -217,8 +217,6 @@ enum Strings {
 
         static let solveUnlimited = sharedStrings.home_solve_unlimited.localized()
         static let repeatUnlimited = sharedStrings.home_repeat_unlimited.localized()
-
-        static let continueLearningInWebButton = sharedStrings.home_continue_learning_on_web_text.localized()
     }
 
     // MARK: - Topics widget -

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeAssembly.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeAssembly.swift
@@ -5,7 +5,12 @@ final class HomeAssembly: UIKitAssembly {
     func makeModule() -> UIViewController {
         let homeComponent = AppGraphBridge.sharedAppGraph.buildHomeComponent()
 
+        let problemsLimitComponent = AppGraphBridge.sharedAppGraph.buildProblemsLimitComponent(
+            screen: ProblemsLimitScreen.home
+        )
+
         let viewModel = HomeViewModel(
+            problemsLimitViewStateMapper: problemsLimitComponent.problemsLimitViewStateMapper,
             feature: homeComponent.homeFeature
         )
 

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/HomeViewModel.swift
@@ -6,9 +6,13 @@ final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage
     private var applicationWasInBackground = false
     private var shouldReloadContent = false
 
+    private let problemsLimitViewStateMapper: ProblemsLimitViewStateMapper
+
     var homeStateKs: HomeFeatureHomeStateKs { .init(state.homeState) }
     var gamificationToolbarStateKs: GamificationToolbarFeatureStateKs { .init(state.toolbarState) }
-
+    var problemsLimitViewStateKs: ProblemsLimitFeatureViewStateKs {
+        .init(problemsLimitViewStateMapper.mapState(state: state.problemsLimitState))
+    }
     var nextLearningActivityViewStateKs: NextLearningActivityWidgetFeatureViewStateKs {
         .init(
             NextLearningActivityWidgetViewStateMapper.shared.map(
@@ -17,10 +21,12 @@ final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage
         )
     }
 
-    override init(
+    init(
+        problemsLimitViewStateMapper: ProblemsLimitViewStateMapper,
         feature: Presentation_reduxFeature,
         mainScheduler: AnySchedulerOf<RunLoop> = .main
     ) {
+        self.problemsLimitViewStateMapper = problemsLimitViewStateMapper
         super.init(feature: feature, mainScheduler: mainScheduler)
 
         NotificationCenter.default.addObserver(
@@ -83,6 +89,14 @@ final class HomeViewModel: FeatureViewModel<HomeFeatureState, HomeFeatureMessage
         onNewMessage(
             HomeFeatureMessageGamificationToolbarMessage(
                 message: GamificationToolbarFeatureMessageClickedProgress()
+            )
+        )
+    }
+
+    func doReloadProblemsLimit() {
+        onNewMessage(
+            HomeFeatureMessageProblemsLimitMessage(
+                message: ProblemsLimitFeatureMessageInitialize(forceUpdate: true)
             )
         )
     }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/Views/HomeView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/Views/HomeView.swift
@@ -78,6 +78,12 @@ struct HomeView: View {
                 VStack(alignment: .leading, spacing: appearance.spacingBetweenContainers) {
                     HomeSubheadlineView()
 
+                    ProblemsLimitView(
+                        stateKs: viewModel.problemsLimitViewStateKs,
+                        onReloadButtonTap: viewModel.doReloadProblemsLimit
+                    )
+                    .padding(.top, LayoutInsets.smallInset)
+
                     ProblemOfDayAssembly(
                         problemOfDayState: data.problemOfDayState,
                         isFreemiumEnabled: data.isFreemiumEnabled,

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/Views/HomeView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Home/Views/HomeView.swift
@@ -106,17 +106,6 @@ struct HomeView: View {
                         onReloadButtonTap: viewModel.doReloadNextLearningActivity
                     )
                     .padding(.top)
-
-                    let shouldShowContinueInWebButton = data.problemOfDayState is HomeFeatureProblemOfDayStateEmpty ||
-                      data.problemOfDayState is HomeFeatureProblemOfDayStateSolved
-
-                    if shouldShowContinueInWebButton {
-                        Button(
-                            Strings.Home.continueLearningInWebButton,
-                            action: viewModel.doContinueLearningOnWebPresentation
-                        )
-                        .buttonStyle(OutlineButtonStyle())
-                    }
                 }
                 .padding([.horizontal, .bottom])
                 .pullToRefresh(

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/StepQuizAssembly.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/StepQuizAssembly.swift
@@ -29,12 +29,17 @@ final class StepQuizAssembly: Assembly {
             stepQuizTitleMapper: stepQuizComponent.stepQuizTitleMapper
         )
 
+        let problemsLimitComponent = AppGraphBridge.sharedAppGraph.buildProblemsLimitComponent(
+            screen: ProblemsLimitScreen.stepQuiz
+        )
+
         let viewModel = StepQuizViewModel(
             step: step,
             stepRoute: stepRoute,
             moduleOutput: moduleOutput,
             provideModuleInputCallback: provideModuleInputCallback,
             viewDataMapper: viewDataMapper,
+            problemsLimitViewStateMapper: problemsLimitComponent.problemsLimitViewStateMapper,
             feature: stepQuizComponent.stepQuizFeature
         )
 

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/StepQuizViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/StepQuizViewModel.swift
@@ -17,8 +17,12 @@ final class StepQuizViewModel: FeatureViewModel<
     private var updateChildQuizSubscription: AnyCancellable?
 
     private let stepQuizViewDataMapper: StepQuizViewDataMapper
+    private let problemsLimitViewStateMapper: ProblemsLimitViewStateMapper
 
     var stepQuizStateKs: StepQuizFeatureStepQuizStateKs { .init(state.stepQuizState) }
+    var problemsLimitViewStateKs: ProblemsLimitFeatureViewStateKs {
+        .init(problemsLimitViewStateMapper.mapState(state: state.problemsLimitState))
+    }
 
     @Published var isPracticingLoading = false
 
@@ -28,6 +32,7 @@ final class StepQuizViewModel: FeatureViewModel<
         moduleOutput: StepQuizOutputProtocol?,
         provideModuleInputCallback: @escaping (StepQuizInputProtocol?) -> Void,
         viewDataMapper: StepQuizViewDataMapper,
+        problemsLimitViewStateMapper: ProblemsLimitViewStateMapper,
         feature: Presentation_reduxFeature
     ) {
         self.step = step
@@ -35,6 +40,7 @@ final class StepQuizViewModel: FeatureViewModel<
         self.moduleOutput = moduleOutput
         self.provideModuleInputCallback = provideModuleInputCallback
         self.stepQuizViewDataMapper = viewDataMapper
+        self.problemsLimitViewStateMapper = problemsLimitViewStateMapper
 
         super.init(feature: feature)
 
@@ -115,6 +121,14 @@ final class StepQuizViewModel: FeatureViewModel<
         onNewMessage(
             StepQuizFeatureMessageRequestResetCodeResult(
                 isGranted: isGranted
+            )
+        )
+    }
+
+    func doReloadProblemsLimit() {
+        onNewMessage(
+            StepQuizFeatureMessageProblemsLimitMessage(
+                message: ProblemsLimitFeatureMessageInitialize(forceUpdate: true)
             )
         )
     }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/Views/StepQuizView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/Views/StepQuizView.swift
@@ -121,6 +121,11 @@ struct StepQuizView: View {
                     StepQuizStatsView(text: formattedStats)
                 }
 
+                StepQuizProblemsLimitView(
+                    stateKs: viewModel.problemsLimitViewStateKs,
+                    onReloadButtonTap: viewModel.doReloadProblemsLimit
+                )
+
                 buildQuizStatusView(state: state.stepQuizState, attemptLoadedState: attemptLoadedState)
 
                 if let feedbackHintText {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StudyPlan/StudyPlanViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StudyPlan/StudyPlanViewModel.swift
@@ -11,6 +11,7 @@ final class StudyPlanViewModel: FeatureViewModel<
 
     var studyPlanWidgetStateKs: StudyPlanWidgetViewStateKs { .init(state.studyPlanWidgetViewState) }
     var gamificationToolbarStateKs: GamificationToolbarFeatureStateKs { .init(state.toolbarState) }
+    var problemsLimitViewStateKs: ProblemsLimitFeatureViewStateKs { .init(state.problemsLimitViewState) }
 
     override func shouldNotifyStateDidChange(
         oldState: StudyPlanScreenFeature.ViewState,
@@ -83,6 +84,14 @@ final class StudyPlanViewModel: FeatureViewModel<
         onNewMessage(
             StudyPlanScreenFeatureMessageGamificationToolbarMessage(
                 message: GamificationToolbarFeatureMessageClickedProgress()
+            )
+        )
+    }
+
+    func doReloadProblemsLimit() {
+        onNewMessage(
+            StudyPlanScreenFeatureMessageProblemsLimitMessage(
+                message: ProblemsLimitFeatureMessageInitialize(forceUpdate: true)
             )
         )
     }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StudyPlan/Views/StudyPlanView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StudyPlan/Views/StudyPlanView.swift
@@ -79,6 +79,11 @@ struct StudyPlanView: View {
                             .padding(.bottom, appearance.trackTitleBottomPadding)
                     }
 
+                    ProblemsLimitView(
+                        stateKs: viewModel.problemsLimitViewStateKs,
+                        onReloadButtonTap: viewModel.doReloadProblemsLimit
+                    )
+
                     ForEach(data.sections, id: \.id) { section in
                         StudyPlanSectionView(
                             section: section,


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-938](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-938)
[#ALTAPPS-939](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-939)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [ ] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Revert changes of hiding problems limit widget
- Hide "Continue learning in web" button on home screnn