### PR TITLE
ALTAPPS-945: iOS make step quiz hint text copyable

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Models/Constants/Strings.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Models/Constants/Strings.swift
@@ -110,6 +110,7 @@ enum Strings {
             static let reportAlertTitle = sharedStrings.step_quiz_hints_report_alert_title.localized()
             static let reportAlertText = sharedStrings.step_quiz_hints_report_alert_text.localized()
             static let showMore = sharedStrings.step_quiz_hints_show_more_text.localized()
+            static let copy = sharedStrings.step_quiz_hints_copy.localized()
         }
 
         enum ProblemOfDaySolvedModal {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizHints/Views/StepQuizHintCardView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizHints/Views/StepQuizHintCardView.swift
@@ -63,6 +63,13 @@ struct StepQuizHintCardView: View {
             )
             .font(.subheadline)
             .foregroundColor(.primary)
+            // .textSelection(.enabled) is available only for iOS 15
+            // this is the simpliest solution
+            .contextMenu(ContextMenu(menuItems: {
+                Button("Copy", action: {
+                    UIPasteboard.general.string = hintText
+                })
+            }))
 
             if isDisplaingShortHintText {
                 ShowMoreButton {

--- a/shared/src/commonMain/resources/MR/base/strings.xml
+++ b/shared/src/commonMain/resources/MR/base/strings.xml
@@ -99,6 +99,7 @@
     <string name="step_quiz_hints_report_alert_title">Thank you for being active Hyperskill citizen!</string>
     <string name="step_quiz_hints_report_alert_text">Are you sure you want to report this hint for spoilers, abuse or spam?</string>
     <string name="step_quiz_hints_show_more_text">Show more</string>
+    <string name="step_quiz_hints_copy">Copy</string> <!-- Is used only on iOS -->
 
     <!-- Step quiz choice -->
     <string name="step_quiz_choice_single_choice_title">Select one option from the list</string>


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-945](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-945)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [ ] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Make step quiz hint text copyable on iOS