### PR TITLE
ALTAPPS-992: Show permission settings screen if permission dialog is not showed

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification_onboarding/fragment/NotificationsOnboardingFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/notification_onboarding/fragment/NotificationsOnboardingFragment.kt
@@ -1,15 +1,21 @@
 package org.hyperskill.app.android.notification_onboarding.fragment
 
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.compose.ui.platform.ComposeView
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import com.google.accompanist.themeadapter.material.MdcTheme
 import org.hyperskill.app.android.HyperskillApp
+import org.hyperskill.app.android.core.extensions.startAppNotificationSettingsIntent
 import org.hyperskill.app.android.core.view.ui.navigation.requireAppRouter
 import org.hyperskill.app.android.notification.permission.NotificationPermissionDelegate
 import org.hyperskill.app.android.notification_onboarding.ui.NotificationsOnboardingScreen
@@ -17,13 +23,16 @@ import org.hyperskill.app.core.view.handleActions
 import org.hyperskill.app.notifications_onboarding.presentation.NotificationsOnboardingFeature.Action.ViewAction
 import org.hyperskill.app.notifications_onboarding.presentation.NotificationsOnboardingFeature.Message
 import org.hyperskill.app.notifications_onboarding.presentation.NotificationsOnboardingViewModel
+import ru.nobird.android.view.base.ui.extension.argument
 
 class NotificationsOnboardingFragment : Fragment() {
 
     companion object {
         const val NOTIFICATIONS_ONBOARDING_FINISHED = "NOTIFICATIONS_ONBOARDING_FINISHED"
         fun newInstance(): NotificationsOnboardingFragment =
-            NotificationsOnboardingFragment()
+            NotificationsOnboardingFragment().apply {
+                waitForNotificationPermissionResult = false
+            }
     }
 
     private var viewModelFactory: ViewModelProvider.Factory? = null
@@ -31,19 +40,38 @@ class NotificationsOnboardingFragment : Fragment() {
         requireNotNull(viewModelFactory)
     }
 
-    private val notificationPermissionDelegate: NotificationPermissionDelegate =
-        NotificationPermissionDelegate(this)
+    private var notificationPermissionDelegate: NotificationPermissionDelegate? = null
+
+    private var waitForNotificationPermissionResult: Boolean by argument()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         injectComponent()
         notificationsOnboardingViewModel.handleActions(this, block = ::onAction)
+        notificationPermissionDelegate =
+            NotificationPermissionDelegate(this, ::onNotificationPermissionRequestResult)
     }
 
     private fun injectComponent() {
         val notificationOnboardingComponent =
             HyperskillApp.graph().buildPlatformNotificationOnboardingComponent()
         viewModelFactory = notificationOnboardingComponent.reduxViewModelFactory
+    }
+
+    @SuppressLint("InlinedApi")
+    override fun onResume() {
+        super.onResume()
+        if (waitForNotificationPermissionResult) {
+            waitForNotificationPermissionResult = false
+            notificationsOnboardingViewModel.onNewMessage(
+                Message.NotificationPermissionRequestResult(
+                    isPermissionGranted = ContextCompat.checkSelfPermission(
+                        requireContext(),
+                        Manifest.permission.POST_NOTIFICATIONS
+                    ) == PackageManager.PERMISSION_GRANTED
+                )
+            )
+        }
     }
 
     override fun onCreateView(
@@ -67,21 +95,43 @@ class NotificationsOnboardingFragment : Fragment() {
         notificationsOnboardingViewModel.onNewMessage(Message.ViewedEventMessage)
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        notificationPermissionDelegate = null
+    }
+
     private fun onAction(action: ViewAction) {
         when (action) {
             ViewAction.CompleteNotificationOnboarding -> {
                 requireAppRouter().sendResult(NOTIFICATIONS_ONBOARDING_FINISHED, Any())
             }
             ViewAction.RequestNotificationPermission -> {
-                notificationPermissionDelegate.requestNotificationPermission { result ->
-                    val isPermissionGranted = when (result) {
-                        NotificationPermissionDelegate.Result.GRANTED -> true
-                        NotificationPermissionDelegate.Result.DENIED,
-                        NotificationPermissionDelegate.Result.DONT_ASK -> false
+                notificationPermissionDelegate?.requestNotificationPermission()
+            }
+        }
+    }
+
+    private fun onNotificationPermissionRequestResult(result: NotificationPermissionDelegate.Result) {
+        when (result) {
+            NotificationPermissionDelegate.Result.GRANTED ->
+                notificationsOnboardingViewModel.onNewMessage(
+                    Message.NotificationPermissionRequestResult(true)
+                )
+            NotificationPermissionDelegate.Result.DENIED ->
+                notificationsOnboardingViewModel.onNewMessage(
+                    Message.NotificationPermissionRequestResult(false)
+                )
+            NotificationPermissionDelegate.Result.DONT_ASK -> {
+                this.waitForNotificationPermissionResult = true
+                requireContext().startAppNotificationSettingsIntent {
+                    this.waitForNotificationPermissionResult = false
+                    if (isResumed) {
+                        Toast.makeText(
+                            requireContext(),
+                            org.hyperskill.app.R.string.common_error,
+                            Toast.LENGTH_SHORT
+                        ).show()
                     }
-                    notificationsOnboardingViewModel.onNewMessage(
-                        Message.NotificationPermissionRequestResult(isPermissionGranted)
-                    )
                 }
             }
         }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/profile/view/fragment/ProfileFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/profile/view/fragment/ProfileFragment.kt
@@ -94,14 +94,14 @@ class ProfileFragment :
             if (!isChecked) {
                 onDailyLearningSwitchNotificationPermissionGranted(false)
             } else {
-                notificationPermissionDelegate?.requestNotificationPermission(::onNotificationPermissionResult)
+                notificationPermissionDelegate?.requestNotificationPermission()
             }
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         injectComponents()
-        notificationPermissionDelegate = NotificationPermissionDelegate(this)
+        notificationPermissionDelegate = NotificationPermissionDelegate(this, ::onNotificationPermissionResult)
     }
 
     private fun injectComponents() {

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step/view/delegate/StepDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step/view/delegate/StepDelegate.kt
@@ -27,7 +27,7 @@ class StepDelegate<TFragment>(
           TFragment : RequestDailyStudyReminderDialogFragment.Callback {
 
     private val notificationPermissionDelegate: NotificationPermissionDelegate =
-        NotificationPermissionDelegate(fragment)
+        NotificationPermissionDelegate(fragment, ::onNotificationPermissionResult)
 
     fun init(errorBinding: ErrorNoConnectionWithButtonBinding, onNewMessage: (StepFeature.Message) -> Unit) {
         onNewMessage(StepFeature.Message.ViewedEventMessage)
@@ -87,9 +87,7 @@ class StepDelegate<TFragment>(
 
     override fun onPermissionResult(isGranted: Boolean) {
         if (isGranted) {
-            notificationPermissionDelegate.requestNotificationPermission { result ->
-                onNotificationPermissionResult(result)
-            }
+            notificationPermissionDelegate.requestNotificationPermission()
         } else {
             onRequestDailyStudyRemindersPermissionResult(false)
         }


### PR DESCRIPTION
**YouTrack Issues**:
[ALTAPPS-992](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-992)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
In case the system disable the permission dialog - open the permissions settings screen, to allow a user to give the notification permission
