### PR TITLE
ALTAPPS-949: iOS StepQuizCodeEditorView use language name from shared

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCode/ViewData/StepQuizCodeViewData.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCode/ViewData/StepQuizCodeViewData.swift
@@ -3,6 +3,7 @@ import Foundation
 struct StepQuizCodeViewData {
     let language: CodeLanguage?
     let languageStringValue: String?
+    let languageHumanReadableName: String?
 
     var code: String?
     let codeTemplate: String?

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCode/ViewData/StepQuizCodeViewDataMapper.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCode/ViewData/StepQuizCodeViewDataMapper.swift
@@ -23,6 +23,7 @@ class StepQuizCodeViewDataMapper {
             }
             return nil
         }()
+        let languageHumanReadableName = step.displayLanguage ?? language?.humanReadableName
 
         let codeTemplate: String? = {
             guard let languageStringValue = languageStringValue else {
@@ -43,6 +44,7 @@ class StepQuizCodeViewDataMapper {
         return StepQuizCodeViewData(
             language: language,
             languageStringValue: languageStringValue,
+            languageHumanReadableName: languageHumanReadableName,
             code: reply?.code ?? codeTemplate,
             codeTemplate: codeTemplate,
             samples: samples,

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCode/Views/StepQuizCodeEditorView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCode/Views/StepQuizCodeEditorView.swift
@@ -15,6 +15,7 @@ struct StepQuizCodeEditorView: View {
     let codeTemplate: String?
 
     let language: CodeLanguage?
+    let languageHumanReadableName: String?
 
     let onExpandButtonTap: () -> Void
 
@@ -33,8 +34,8 @@ struct StepQuizCodeEditorView: View {
                     .font(.headline)
                     .foregroundColor(.primaryText)
 
-                if let languageName = language?.humanReadableName {
-                    Text("(\(languageName))")
+                if let languageHumanReadableName {
+                    Text("(\(languageHumanReadableName))")
                         .font(.subheadline)
                         .foregroundColor(.tertiaryText)
                 }
@@ -91,6 +92,7 @@ struct StepQuizCodeEditorView: View {
         code: .constant(CodeLanguageSamples.sample(for: .java)),
         codeTemplate: nil,
         language: .java,
+        languageHumanReadableName: CodeLanguage.java.humanReadableName,
         onExpandButtonTap: {},
         onInputAccessoryButtonTap: { _ in }
     )
@@ -101,6 +103,7 @@ struct StepQuizCodeEditorView: View {
         code: .constant(CodeLanguageSamples.sample(for: .java)),
         codeTemplate: nil,
         language: .java,
+        languageHumanReadableName: CodeLanguage.java.humanReadableName,
         onExpandButtonTap: {},
         onInputAccessoryButtonTap: { _ in }
     )

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCode/Views/StepQuizCodeView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCode/Views/StepQuizCodeView.swift
@@ -21,6 +21,7 @@ struct StepQuizCodeView: View {
                 ),
                 codeTemplate: viewData.codeTemplate,
                 language: viewData.language,
+                languageHumanReadableName: viewData.languageHumanReadableName,
                 onExpandButtonTap: viewModel.doFullScreenCodeEditorPresentation,
                 onInputAccessoryButtonTap: viewModel.logClickedInputAccessoryButton(symbol:)
             )

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCodeFullScreen/StepQuizCodeFullScreenAssembly.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCodeFullScreen/StepQuizCodeFullScreenAssembly.swift
@@ -50,6 +50,7 @@ extension StepQuizCodeFullScreenAssembly {
             codeQuizViewData: StepQuizCodeViewData(
                 language: .kotlin,
                 languageStringValue: "kotlin",
+                languageHumanReadableName: CodeLanguage.kotlin.humanReadableName,
                 code: "fun main() {\n    // put your code here\n}",
                 codeTemplate: "fun main() {\n    // put your code here\n}",
                 samples: [

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizPyCharm/StepQuizPyCharmView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizPyCharm/StepQuizPyCharmView.swift
@@ -16,6 +16,7 @@ struct StepQuizPyCharmView: View {
                 ),
                 codeTemplate: viewData.codeTemplate,
                 language: viewData.language,
+                languageHumanReadableName: viewData.languageHumanReadableName,
                 onExpandButtonTap: viewModel.doFullScreenCodeEditorPresentation,
                 onInputAccessoryButtonTap: viewModel.logClickedInputAccessoryButton(symbol:)
             )

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizPyCharm/StepQuizPyCharmViewDataMapper.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizPyCharm/StepQuizPyCharmViewDataMapper.swift
@@ -12,6 +12,7 @@ final class StepQuizPyCharmViewDataMapper: StepQuizCodeViewDataMapper {
             }
             return nil
         }()
+        let languageHumanReadableName = step.displayLanguage ?? language?.humanReadableName
 
         let codeTemplate = blockOptions.files?.first(where: { $0.isVisible })?.text
         let code: String? = {
@@ -24,6 +25,7 @@ final class StepQuizPyCharmViewDataMapper: StepQuizCodeViewDataMapper {
         return StepQuizCodeViewData(
             language: language,
             languageStringValue: languageStringValue,
+            languageHumanReadableName: languageHumanReadableName,
             code: code,
             codeTemplate: codeTemplate,
             samples: [],

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizSQL/StepQuizSQLViewDataMapper.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizSQL/StepQuizSQLViewDataMapper.swift
@@ -6,6 +6,7 @@ final class StepQuizSQLViewDataMapper: StepQuizCodeViewDataMapper {
         StepQuizCodeViewData(
             language: .sql,
             languageStringValue: CodeLanguage.sql.rawValue,
+            languageHumanReadableName: CodeLanguage.sql.humanReadableName,
             code: reply?.solveSql,
             codeTemplate: nil,
             samples: [],

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizSQL/Views/StepQuizSQLView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizSQL/Views/StepQuizSQLView.swift
@@ -16,6 +16,7 @@ struct StepQuizSQLView: View {
                 ),
                 codeTemplate: viewData.codeTemplate,
                 language: viewData.language,
+                languageHumanReadableName: viewData.languageHumanReadableName,
                 onExpandButtonTap: viewModel.doFullScreenCodeEditorPresentation,
                 onInputAccessoryButtonTap: viewModel.logClickedInputAccessoryButton(symbol:)
             )


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-949](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-949)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
Uses code language name from `shared` in `StepQuizCodeEditorView`