### PR TITLE
ALTAPPS-1025: iOS invalidate fill blanks layout on device orientation change

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizFillBlanks/Views/FillBlanksQuizViewWrapper.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizFillBlanks/Views/FillBlanksQuizViewWrapper.swift
@@ -15,7 +15,9 @@ struct FillBlanksQuizViewWrapper: UIViewRepresentable {
         coordinator.onInputDidChange = nil
         coordinator.onDidSelectComponent = nil
         coordinator.onDidDeselectComponent = nil
+        coordinator.onDeviceOrientationDidChange = nil
         coordinator.collectionViewAdapter.delegate = nil
+        NotificationCenter.default.removeObserver(coordinator)
     }
 
     func makeUIView(context: Context) -> FillBlanksQuizView {
@@ -52,6 +54,13 @@ struct FillBlanksQuizViewWrapper: UIViewRepresentable {
 
             uiView.invalidateCollectionViewLayout()
         }
+        context.coordinator.onDeviceOrientationDidChange = { [weak uiView] in
+            guard let uiView else {
+                return
+            }
+
+            uiView.invalidateCollectionViewLayout()
+        }
         context.coordinator.onDidSelectComponent = onDidSelectComponent
         context.coordinator.onDidDeselectComponent = onDidDeselectComponent
     }
@@ -70,9 +79,19 @@ extension FillBlanksQuizViewWrapper {
         var onDidSelectComponent: ((IndexPath) -> Void)?
         var onDidDeselectComponent: ((IndexPath) -> Void)?
 
+        var onDeviceOrientationDidChange: (() -> Void)?
+
         override init() {
             super.init()
+
             collectionViewAdapter.delegate = self
+
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleDeviceOrientationDidChange),
+                name: UIDevice.orientationDidChangeNotification,
+                object: nil
+            )
         }
 
         func fillBlanksQuizCollectionViewAdapter(
@@ -95,6 +114,11 @@ extension FillBlanksQuizViewWrapper {
             didDeselectComponentAt indexPath: IndexPath
         ) {
             onDidDeselectComponent?(indexPath)
+        }
+
+        @objc
+        private func handleDeviceOrientationDidChange() {
+            onDeviceOrientationDidChange?()
         }
     }
 }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Systems/AppAppearance.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Systems/AppAppearance.swift
@@ -3,6 +3,7 @@ import UIKit
 enum AppAppearance {
     static func themeApplication(window: UIWindow) {
         window.tintColor = ColorPalette.primary
+        KeyboardManager.setToolbarTintColor(window.tintColor)
         themeNavigationBar()
     }
 

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Systems/KeyboardManager.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Systems/KeyboardManager.swift
@@ -27,6 +27,10 @@ enum KeyboardManager {
         IQKeyboardManager.shared.enableAutoToolbar = enableAutoToolbar
     }
 
+    static func setToolbarTintColor(_ toolbarTintColor: UIColor?) {
+        IQKeyboardManager.shared.toolbarTintColor = toolbarTintColor
+    }
+
     static func reloadLayoutIfNeeded() {
         IQKeyboardManager.shared.reloadLayoutIfNeeded()
     }


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1025](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1025)

**Checklist**

_Before Code Review:_

- [ ] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [ ] Sentry Performance Monitoring of screen loading is added for new screens;
- [ ] View analytics events are added for new screens;
- [ ] New analytics events are documented;
- [ ] All checks have been passed;
- [ ] Changes have been checked locally.

**Description**

Fixes an issue with fill blanks collection view layout, not updates on device orientation change