### PR TITLE
ALTAPPS-999: Shared update limits locally instead of loading from backend

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/freemium/domain/interactor/FreemiumInteractor.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/freemium/domain/interactor/FreemiumInteractor.kt
@@ -10,6 +10,10 @@ class FreemiumInteractor(
     private val currentSubscriptionStateRepository: CurrentSubscriptionStateRepository,
     private val currentProfileStateRepository: CurrentProfileStateRepository
 ) {
+    companion object {
+        private const val SOLVING_FIRST_STEP_ADDITIONAL_LIMIT_VALUE = 10
+    }
+
     suspend fun isFreemiumEnabled(): Result<Boolean> =
         currentSubscriptionStateRepository.getState().map { it.isFreemium }
 
@@ -41,7 +45,12 @@ class FreemiumInteractor(
             if (currentProfile.features.isFreemiumIncreaseLimitsForFirstStepCompletionEnabled &&
                 currentProfile.gamification.passedProblems == 0
             ) {
-                currentSubscriptionStateRepository.reloadState()
+                currentSubscriptionStateRepository.updateState {
+                    it.copy(
+                        stepsLimitTotal = it.stepsLimitTotal?.plus(SOLVING_FIRST_STEP_ADDITIONAL_LIMIT_VALUE),
+                        stepsLimitLeft = it.stepsLimitLeft?.plus(SOLVING_FIRST_STEP_ADDITIONAL_LIMIT_VALUE)
+                    )
+                }
                 currentProfileStateRepository.updateState {
                     it.copy(gamification = it.gamification.copy(passedProblems = it.gamification.passedProblems + 1))
                 }


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-999](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-999)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [ ] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
The problem of previous solution was necessity to do network request in scope of feature that could be destroyed before that request is done (for example tap back button right after solving problem and user will see not updated limits on study plan screen). The easiest solution I seen - hardcode increasing limits like it's done on [backend](https://github.com/hyperskill/alt/blob/251f0c2cd27b048d3a8936b2f6913d592a651512/apps/freemium/constants.py#L47)

Another argument is that updating of limits on backend happens asynchronously - it means that if we want to add loading from backend we can face with not actual state of subscription from backend right after solving problem.