### PR TITLE
ALTAPPS-1029: Android fix android step quiz horizontal margin

### DIFF
--- a/androidHyperskillApp/src/main/res/layout/layout_fill_blanks_skeleton.xml
+++ b/androidHyperskillApp/src/main/res/layout/layout_fill_blanks_skeleton.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
     android:orientation="vertical">
 
     <include layout="@layout/view_divider_vertical" />

--- a/androidHyperskillApp/src/main/res/layout/layout_step_quiz_fill_blanks_binding.xml
+++ b/androidHyperskillApp/src/main/res/layout/layout_step_quiz_fill_blanks_binding.xml
@@ -3,18 +3,19 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/step_quiz_content_padding_top"
     android:layout_marginBottom="@dimen/step_quiz_content_padding_bottom"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintTop_toBottomOf="@+id/stepQuizHints"
-    app:layout_constraintBottom_toTopOf="@id/stepQuizStatistics">
+    app:layout_constraintBottom_toTopOf="@id/stepQuizStatistics"
+    app:layout_constraintVertical_bias="0">
 
     <LinearLayout
         android:id="@+id/stepQuizFillBlanksContainer"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:orientation="vertical">
 
         <include layout="@layout/view_divider_vertical" />

--- a/androidHyperskillApp/src/main/res/layout/layout_step_quiz_parsons.xml
+++ b/androidHyperskillApp/src/main/res/layout/layout_step_quiz_parsons.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
+    android:layout_marginHorizontal="@dimen/step_quiz_content_padding_horizontal"
     android:layout_marginTop="@dimen/step_quiz_content_padding_top"
     android:layout_marginBottom="@dimen/step_quiz_content_padding_bottom"
     app:layout_constraintBottom_toTopOf="@id/stepQuizStatistics"

--- a/androidHyperskillApp/src/main/res/layout/layout_step_quiz_sorting.xml
+++ b/androidHyperskillApp/src/main/res/layout/layout_step_quiz_sorting.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
+    android:layout_marginHorizontal="@dimen/step_quiz_content_padding_horizontal"
     android:layout_marginTop="@dimen/step_quiz_content_padding_top"
     android:layout_marginBottom="@dimen/step_quiz_content_padding_bottom"
     app:layout_constraintVertical_bias="0"

--- a/androidHyperskillApp/src/main/res/layout/layout_step_quiz_text.xml
+++ b/androidHyperskillApp/src/main/res/layout/layout_step_quiz_text.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
+    android:layout_marginHorizontal="@dimen/step_quiz_content_padding_horizontal"
     android:layout_marginTop="@dimen/step_quiz_content_padding_top"
     android:layout_marginBottom="@dimen/step_quiz_content_padding_bottom"
     app:layout_constraintBottom_toTopOf="@id/stepQuizStatistics"

--- a/androidHyperskillApp/src/main/res/values/dimens.xml
+++ b/androidHyperskillApp/src/main/res/values/dimens.xml
@@ -57,6 +57,7 @@
     <dimen name="item_choice_skeleton_height">21dp</dimen>
     <dimen name="step_quiz_content_padding_top">12dp</dimen>
     <dimen name="step_quiz_content_padding_bottom">20dp</dimen>
+    <dimen name="step_quiz_content_padding_horizontal">20dp</dimen>
     <dimen name="step_quiz_collapsible_block_header_height">48dp</dimen>
     <dimen name="step_quiz_description_padding_top">16dp</dimen>
     <dimen name="step_quiz_hints_top_margin">20dp</dimen>


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1029](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1029)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Add missing horizontal margin to step quizzes
- Fix fill-in-the-blanks layout relative to the hints
