### PR TITLE
ALTAPPS-725: iOS fix stage implement step error placeholder

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/Views/StepView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/Views/StepView.swift
@@ -38,6 +38,7 @@ struct StepView: View {
         case .error:
             PlaceholderView(
                 configuration: .networkError(
+                    presentationMode: viewModel.isStageImplement ? .local : .fullscreen,
                     backgroundColor: .clear,
                     action: viewModel.doRetryLoadStep
                 )

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Views/SwiftUI/PlaceholderView/PlaceholderView+Configurations.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Views/SwiftUI/PlaceholderView/PlaceholderView+Configurations.swift
@@ -4,12 +4,14 @@ extension PlaceholderView.Configuration {
     static let defaultImageSize = CGSize(width: 122, height: 122)
 
     static func networkError(
+        presentationMode: PresentationMode = .fullscreen,
         titleText: String = Strings.Placeholder.networkErrorTitle,
         buttonText: String = Strings.Placeholder.networkErrorButtonText,
         backgroundColor: Color = Color(ColorPalette.surface),
         action: @escaping () -> Void
     ) -> Self {
         .init(
+            presentationMode: presentationMode,
             image: .init(name: Images.Placeholder.networkError, frame: .size(defaultImageSize)),
             title: .init(text: titleText),
             button: .init(text: buttonText, action: action),


### PR DESCRIPTION
Use local presentation mode for step error placeholder view when it's parent is stage implement.

**YouTrack Issues**:
[#ALTAPPS-725](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-725)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
Use `PlaceholderView.Configuration.PresentationMode.local` for step error placeholder view when it's parent is stage implement