### PR TITLE
GitHub Actions: Setup iOS disable dependents upgrade of git-crypt

### DIFF
--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -27,6 +27,7 @@ runs:
       shell: bash
       env:
         HOMEBREW_NO_INSTALL_CLEANUP: true
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: true
 
     # Generate git-crypt.key file from base64 file content and decrypt
     - name: git-crypt unlock secrets


### PR DESCRIPTION
**Description**
Disables dependents upgrade of `git-crypt` by setting `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK`