### PR TITLE
GitHub Actions: Disable concurrency for beta deployments

### DIFF
--- a/.github/workflows/android_beta_deployment.yml
+++ b/.github/workflows/android_beta_deployment.yml
@@ -6,10 +6,6 @@ on:
       - "release/**"
       - "hotfix/**"
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
-
 defaults:
   run:
     shell: bash

--- a/.github/workflows/ios_beta_deployment.yml
+++ b/.github/workflows/ios_beta_deployment.yml
@@ -6,10 +6,6 @@ on:
       - "release/**"
       - "hotfix/**"
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
-
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
**Description**

1. Disables concurrency (cancel in progress) for `iOS Beta Deployment` and `Android Beta Deployment`
2. If automerge merged smh into current release branch, active beta deployment will not be cancelled