### PR TITLE
ALTAPPS-1088: Android fix toolbar symbols insert into codeEditor

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/code/util/CodeEditorKeyboardExtensionUtil.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/code/util/CodeEditorKeyboardExtensionUtil.kt
@@ -19,6 +19,10 @@ object CodeEditorKeyboardExtensionUtil {
         )
     }
 
+    fun interface OnToolbarSymbolClickListener {
+        fun onToolbarSymbolClick(symbol: String, resultCode: String)
+    }
+
     fun setupKeyboardExtension(
         context: Context,
         rootView: View,
@@ -26,12 +30,16 @@ object CodeEditorKeyboardExtensionUtil {
         codeLayout: CodeEditorLayout,
         codeToolbarAdapter: CodeToolbarAdapter,
         isToolbarEnabled: () -> Boolean = { true },
-        onToolbarSymbolClicked: ((String) -> Unit)? = null,
+        onToolbarSymbolClicked: OnToolbarSymbolClickListener? = null,
         codeEditorKeyboardListener: CodeEditorKeyboardListener? = null
     ) {
         codeToolbarAdapter.onSymbolClickListener = CodeToolbarAdapter.OnSymbolClickListener { symbol, offset ->
-            onToolbarSymbolClicked?.invoke(symbol)
+            // insert should be done first
             applySymbolTo(codeLayout, symbol, offset)
+            onToolbarSymbolClicked?.onToolbarSymbolClick(
+                symbol = symbol,
+                resultCode = codeLayout.text
+            )
         }
 
         codeLayout.codeToolbarAdapter = codeToolbarAdapter

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/code/view/widget/CodeEditorLayout.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/code/view/widget/CodeEditorLayout.kt
@@ -28,7 +28,7 @@ constructor(
             codeEditor.theme = value
         }
 
-    val text: CharSequence
+    val text: String
         get() = codeEditor.text.toString()
 
     var langExtension: String
@@ -72,7 +72,7 @@ constructor(
     }
 
     fun setTextIfChanged(text: String) {
-        if (this.text.toString() != text) {
+        if (this.text != text) {
             codeEditor.setText(text)
         }
     }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz_code/view/fragment/CodeStepQuizFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz_code/view/fragment/CodeStepQuizFragment.kt
@@ -99,7 +99,11 @@ class CodeStepQuizFragment :
             recyclerView = keyboardExtensionViewBinding.stepQuizCodeKeyboardExtensionRecycler,
             codeLayout = viewBinding.stepQuizCodeEmbeddedEditor.codeStepLayout,
             codeToolbarAdapter = requireNotNull(codeToolbarAdapter),
-            onToolbarSymbolClicked = ::onKeyboardExtensionSymbolClicked,
+            onToolbarSymbolClicked = { symbol, _ ->
+                logAnalyticEventMessage(
+                    StepQuizFeature.Message.CodeEditorClickedInputAccessoryButtonEventMessage(symbol)
+                )
+            },
             codeEditorKeyboardListener = { isKeyboardShown, toolbarHeight ->
                 if (isResumed) {
                     onKeyboardStateChanged(isKeyboardShown)
@@ -177,7 +181,8 @@ class CodeStepQuizFragment :
         onRetryButtonClicked()
     }
 
-    override fun onKeyboardExtensionSymbolClicked(symbol: String) {
+    override fun onKeyboardExtensionSymbolClicked(symbol: String, code: String) {
+        syncReplyState(config.createReply(code))
         logAnalyticEventMessage(
             StepQuizFeature.Message.CodeEditorClickedInputAccessoryButtonEventMessage(symbol)
         )

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz_fullscreen_code/dialog/CodeStepQuizFullScreenDialogFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz_fullscreen_code/dialog/CodeStepQuizFullScreenDialogFragment.kt
@@ -189,7 +189,8 @@ class CodeStepQuizFullScreenDialogFragment : DialogFragment() {
     }
 
     private fun initViewPager() {
-        val pagerAdapter = CodeStepQuizFullScreenPagerAdapter(requireContext())
+        val pagerAdapter =
+            CodeStepQuizFullScreenPagerAdapter(requireContext())
 
         viewBinding.fullScreenCodeViewPager.adapter = pagerAdapter
         viewBinding.fullScreenCodeTabs.setupWithViewPager(viewBinding.fullScreenCodeViewPager)
@@ -285,8 +286,8 @@ class CodeStepQuizFullScreenDialogFragment : DialogFragment() {
                 // We show the keyboard extension only when "Code" tab is opened
                 viewBinding.fullScreenCodeViewPager.currentItem == CODE_TAB
             },
-            onToolbarSymbolClicked = { symbol ->
-                callback?.onKeyboardExtensionSymbolClicked(symbol)
+            onToolbarSymbolClicked = { symbol, resultCode ->
+                callback?.onKeyboardExtensionSymbolClicked(symbol, resultCode)
             },
             codeEditorKeyboardListener = { isKeyboardShown, toolbarHeight ->
                 with(codeLayout) {
@@ -325,14 +326,14 @@ class CodeStepQuizFullScreenDialogFragment : DialogFragment() {
     }
 
     private fun syncCodeStateWithParent(onSubmitClicked: Boolean = false) {
-        callback?.onSyncCodeStateWithParent(codeLayout.text.toString(), onSubmitClicked)
+        callback?.onSyncCodeStateWithParent(codeLayout.text, onSubmitClicked)
     }
 
     interface Callback {
         fun onSyncCodeStateWithParent(code: String, onSubmitClicked: Boolean = false)
         fun onResetCodeClick()
 
-        fun onKeyboardExtensionSymbolClicked(symbol: String)
+        fun onKeyboardExtensionSymbolClicked(symbol: String, code: String)
     }
 
     data class Params(


### PR DESCRIPTION
**YouTrack Issues**:
[ALTAPPS-1088](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1088)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Sync fullscreen code editor code before sending toolbar symbol analytics event