### PR TITLE
ALTAPPS-836: Shared fix gems are decreased but streak recovery cost is 0 for the first time

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/main/presentation/AppFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/main/presentation/AppFeature.kt
@@ -24,6 +24,7 @@ interface AppFeature {
         data class Ready(
             val isAuthorized: Boolean,
             val isMobileLeaderboardsEnabled: Boolean,
+            internal val streakRecoveryState: StreakRecoveryFeature.State = StreakRecoveryFeature.State(),
             internal val welcomeOnboardingState: WelcomeOnboardingFeature.State = WelcomeOnboardingFeature.State()
         ) : State
     }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/streak_recovery/presentation/StreakRecoveryFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/streak_recovery/presentation/StreakRecoveryFeature.kt
@@ -1,9 +1,12 @@
 package org.hyperskill.app.streak_recovery.presentation
 
+import kotlinx.serialization.Serializable
 import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticEvent
+import org.hyperskill.app.streaks.domain.model.Streak
 
 object StreakRecoveryFeature {
-    object State
+    @Serializable
+    data class State(val streak: Streak? = null)
 
     sealed interface Message {
         object Initialize : Message
@@ -21,7 +24,7 @@ object StreakRecoveryFeature {
 
     internal sealed interface FetchStreakResult : Message {
         data class Success(
-            val canRecoveryStreak: Boolean,
+            val streak: Streak,
             val recoveryPriceAmountLabel: String,
             val recoveryPriceGemsLabel: String,
             val modalText: String
@@ -62,10 +65,11 @@ object StreakRecoveryFeature {
     internal sealed interface InternalAction : Action {
         object FetchStreak : InternalAction
 
-        object RecoverStreak : InternalAction
+        data class RecoverStreak(val streak: Streak) : InternalAction
 
         object CancelStreakRecovery : InternalAction
 
+        data class CaptureSentryErrorMessage(val message: String) : InternalAction
         data class LogAnalyticEvent(val event: HyperskillAnalyticEvent) : InternalAction
     }
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/streak_recovery/presentation/StreakRecoveryReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/streak_recovery/presentation/StreakRecoveryReducer.kt
@@ -19,8 +19,8 @@ class StreakRecoveryReducer : StateReducer<State, Message, Action> {
                 state to setOf(InternalAction.FetchStreak)
             }
             is StreakRecoveryFeature.FetchStreakResult.Success -> {
-                if (message.canRecoveryStreak) {
-                    state to setOf(
+                if (message.streak.canBeRecovered) {
+                    state.copy(streak = message.streak) to setOf(
                         Action.ViewAction.ShowRecoveryStreakModal(
                             message.recoveryPriceAmountLabel,
                             message.recoveryPriceGemsLabel,
@@ -35,13 +35,22 @@ class StreakRecoveryReducer : StateReducer<State, Message, Action> {
                 null
             }
             Message.RestoreStreakClicked -> {
-                state to setOf(
-                    Action.ViewAction.ShowNetworkRequestStatus.Loading,
-                    InternalAction.RecoverStreak,
-                    InternalAction.LogAnalyticEvent(
-                        StreakRecoveryModalClickedRestoreStreakHyperskillAnalyticEvent()
+                if (state.streak != null) {
+                    state to setOf(
+                        Action.ViewAction.ShowNetworkRequestStatus.Loading,
+                        InternalAction.RecoverStreak(state.streak),
+                        InternalAction.LogAnalyticEvent(
+                            StreakRecoveryModalClickedRestoreStreakHyperskillAnalyticEvent()
+                        )
                     )
-                )
+                } else {
+                    state to setOf(
+                        InternalAction.LogAnalyticEvent(
+                            StreakRecoveryModalClickedRestoreStreakHyperskillAnalyticEvent()
+                        ),
+                        InternalAction.CaptureSentryErrorMessage("StreakRecovery: restore streak, no streak found")
+                    )
+                }
             }
             Message.NoThanksClicked -> {
                 state to setOf(
@@ -80,7 +89,7 @@ class StreakRecoveryReducer : StateReducer<State, Message, Action> {
                 )
             }
             Message.StreakRecoveryModalHiddenEventMessage -> {
-                state to setOf(
+                State() to setOf(
                     InternalAction.LogAnalyticEvent(StreakRecoveryModalHiddenHyperskillAnalyticEvent())
                 )
             }

--- a/shared/src/commonTest/kotlin/org/hyperskill/streak_recovery/StreakRecoveryTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/streak_recovery/StreakRecoveryTest.kt
@@ -4,6 +4,8 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 import org.hyperskill.app.streak_recovery.presentation.StreakRecoveryFeature
 import org.hyperskill.app.streak_recovery.presentation.StreakRecoveryReducer
+import org.hyperskill.app.streaks.domain.model.Streak
+import org.hyperskill.streaks.domain.model.stub
 
 class StreakRecoveryTest {
     private val streakRecoveryReducer = StreakRecoveryReducer()
@@ -11,8 +13,8 @@ class StreakRecoveryTest {
     @Test
     fun `Streak recovery modal should be shown if recovery is available`() {
         val (_, actions) = streakRecoveryReducer.reduce(
-            StreakRecoveryFeature.State,
-            StreakRecoveryFeature.FetchStreakResult.Success(true, "", "", "")
+            StreakRecoveryFeature.State(),
+            StreakRecoveryFeature.FetchStreakResult.Success(Streak.stub(canBeRecovered = true), "", "", "")
         )
         assertTrue {
             actions.any {
@@ -24,8 +26,8 @@ class StreakRecoveryTest {
     @Test
     fun `Streak recovery modal should NOT be shown if recovery is NOT available`() {
         val (_, actions) = streakRecoveryReducer.reduce(
-            StreakRecoveryFeature.State,
-            StreakRecoveryFeature.FetchStreakResult.Success(false, "", "", "")
+            StreakRecoveryFeature.State(),
+            StreakRecoveryFeature.FetchStreakResult.Success(Streak.stub(canBeRecovered = false), "", "", "")
         )
         assertTrue {
             actions.none {
@@ -37,7 +39,7 @@ class StreakRecoveryTest {
     @Test
     fun `Recover streak action should be dispatched if 'Restore streak' clicked`() {
         val (_, actions) = streakRecoveryReducer.reduce(
-            StreakRecoveryFeature.State,
+            StreakRecoveryFeature.State(Streak.stub(canBeRecovered = true)),
             StreakRecoveryFeature.Message.RestoreStreakClicked
         )
         assertTrue {
@@ -50,7 +52,7 @@ class StreakRecoveryTest {
     @Test
     fun `Cancel streak recovery action should be dispatched if 'No thanks' clicked`() {
         val (_, actions) = streakRecoveryReducer.reduce(
-            StreakRecoveryFeature.State,
+            StreakRecoveryFeature.State(),
             StreakRecoveryFeature.Message.NoThanksClicked
         )
         assertTrue {

--- a/shared/src/commonTest/kotlin/org/hyperskill/streaks/domain/model/StreakStub.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/streaks/domain/model/StreakStub.kt
@@ -1,0 +1,29 @@
+package org.hyperskill.streaks.domain.model
+
+import org.hyperskill.app.streaks.domain.model.HistoricalStreak
+import org.hyperskill.app.streaks.domain.model.Streak
+
+fun Streak.Companion.stub(
+    userId: Long = 0L,
+    currentStreak: Int = 0,
+    maxStreak: Int = 0,
+    isNewRecord: Boolean = false,
+    canFreeze: Boolean = false,
+    canBuyFreeze: Boolean = false,
+    canBeRecovered: Boolean = false,
+    recoveryPrice: Int = 0,
+    previousStreak: Int = 0,
+    history: List<HistoricalStreak> = emptyList()
+): Streak =
+    Streak(
+        userId = userId,
+        currentStreak = currentStreak,
+        maxStreak = maxStreak,
+        isNewRecord = isNewRecord,
+        canFreeze = canFreeze,
+        canBuyFreeze = canBuyFreeze,
+        canBeRecovered = canBeRecovered,
+        recoveryPrice = recoveryPrice,
+        previousStreak = previousStreak,
+        history = history
+    )


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-836](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-836)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [ ] Changes have been checked locally.

**Description**

- Fixes incorrect behavior on streak recovery `first-time offer` that costs `0` gems