### PR TITLE
ALTAPPS-1072: Shared protect app from errors due to cache models serialization

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@ _Before Code Review:_
 - [ ] View analytics events are added for new screens;
 - [ ] New analytics events are documented;
 - [ ] All checks have been passed;
-- [ ] Changes have been checked locally.
+- [ ] Changes have been checked locally;
+- [ ] Saved in the cache models serialization checked locally.
 
 **Description**

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/auth/remote/model/AuthResponse.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/auth/remote/model/AuthResponse.kt
@@ -2,7 +2,19 @@ package org.hyperskill.app.auth.remote.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.hyperskill.app.auth.remote.source.AuthRemoteDataSourceImpl
+import org.hyperskill.app.network.NetworkBuilder
 
+/**
+ * Represents a response for an auth request.
+ *
+ * Warning!
+ * This model is stored in the cache.
+ * Adding new field or modifying old ones,
+ * check that all fields will be deserialized from cache without an error.
+ * All the new optional fields must have default values.
+ * @see [NetworkBuilder.buildAuthorizedClient], [AuthRemoteDataSourceImpl]
+ */
 @Serializable
 data class AuthResponse(
     @SerialName("access_token") val accessToken: String,

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/devices/domain/model/Device.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/devices/domain/model/Device.kt
@@ -2,7 +2,18 @@ package org.hyperskill.app.devices.domain.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.hyperskill.app.devices.cache.CurrentDeviceCacheDataSourceImpl
 
+/**
+ * Represents a user's device.
+ *
+ * Warning!
+ * This model is stored in the cache.
+ * Adding new field or modifying old ones,
+ * check that all fields will be deserialized from cache without an error.
+ * All the new optional fields must have default values.
+ * @see [CurrentDeviceCacheDataSourceImpl]
+ */
 @Serializable
 data class Device(
     @SerialName("name")

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/model/Profile.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/model/Profile.kt
@@ -12,7 +12,7 @@ import org.hyperskill.app.profile.cache.CurrentProfileStateHolderImpl
  * This model is stored in the cache.
  * Adding new field or modifying old ones,
  * check that all fields will be deserialized from cache without an error.
- * All the optional fields must have default values.
+ * All the new optional fields must have default values.
  * @see [CurrentProfileStateHolderImpl]
  */
 @Serializable

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/model/Profile.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/model/Profile.kt
@@ -3,7 +3,18 @@ package org.hyperskill.app.profile.domain.model
 import kotlinx.datetime.TimeZone
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.hyperskill.app.profile.cache.CurrentProfileStateHolderImpl
 
+/**
+ * Represents a user profile.
+ *
+ * Warning!
+ * This model is stored in the cache.
+ * Adding new field or modifying old ones,
+ * check that all fields will be deserialized from cache without an error.
+ * All the optional fields must have default values.
+ * @see [CurrentProfileStateHolderImpl]
+ */
 @Serializable
 data class Profile(
     @SerialName("id")

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile_settings/domain/model/ProfileSettings.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile_settings/domain/model/ProfileSettings.kt
@@ -2,7 +2,18 @@ package org.hyperskill.app.profile_settings.domain.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.hyperskill.app.profile_settings.cache.ProfileSettingsCacheDataSourceImpl
 
+/**
+ * Represents profile settings.
+ *
+ * Warning!
+ * This model is stored in the cache.
+ * Adding new field or modifying old ones,
+ * check that all fields will be deserialized from cache without an error.
+ * All the new optional fields must have default values.
+ * @see [ProfileSettingsCacheDataSourceImpl]
+ */
 @Serializable
 data class ProfileSettings(
     @SerialName("theme")

--- a/shared/src/commonTest/kotlin/org/hyperskill/auth/AuthResponseSerializationTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/auth/AuthResponseSerializationTest.kt
@@ -1,0 +1,36 @@
+package org.hyperskill.auth
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.hyperskill.app.auth.remote.model.AuthResponse
+import org.hyperskill.app.network.injection.NetworkModule
+
+class AuthResponseSerializationTest {
+    companion object {
+        private const val TEST_JSON = """
+            {
+                "access_token": "some_access_toke",
+                "expires_in": "1000",
+                "refresh_token": "some_refresh_token",
+                "token_type": "some_token_type",
+                "scope": "some_scope"
+            }
+        """
+
+        private val EXPECTED_AUTH_RESPONSE: AuthResponse =
+            AuthResponse(
+                accessToken = "some_access_toke",
+                expiresIn = 1000,
+                refreshToken = "some_refresh_token",
+                tokenType = "some_token_type",
+                scope = "some_scope"
+            )
+    }
+
+    @Test
+    fun `Serialized AuthResponse should be deserialized normally`() {
+        val json = NetworkModule.provideJson()
+        val actualAuthResponse = json.decodeFromString(AuthResponse.serializer(), TEST_JSON)
+        assertEquals(EXPECTED_AUTH_RESPONSE, actualAuthResponse)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/hyperskill/device/DeviceSerializationTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/device/DeviceSerializationTest.kt
@@ -1,0 +1,35 @@
+package org.hyperskill.device
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.hyperskill.app.devices.domain.model.Device
+import org.hyperskill.app.devices.domain.model.DeviceType
+import org.hyperskill.app.network.injection.NetworkModule
+
+class DeviceSerializationTest {
+    companion object {
+        private const val TEST_JSON = """
+            {
+                "name": "Android 33",
+                "registration_id": "long_registration_id",
+                "active": true,
+                "type": "some_unknown_type"
+            }
+        """
+
+        private val EXPECTED_DEVICE: Device =
+            Device(
+                name = "Android 33",
+                registrationId = "long_registration_id",
+                isActive = true,
+                type = DeviceType.UNKNOWN
+            )
+    }
+
+    @Test
+    fun `Serialized device should be deserialized normally`() {
+        val json = NetworkModule.provideJson()
+        val actualDevice = json.decodeFromString(Device.serializer(), TEST_JSON)
+        assertEquals(EXPECTED_DEVICE, actualDevice)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/hyperskill/profile/ProfileSerializationTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/profile/ProfileSerializationTest.kt
@@ -1,4 +1,4 @@
-package org.hyperskill.profile.cache
+package org.hyperskill.profile
 
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/shared/src/commonTest/kotlin/org/hyperskill/profile/cache/ProfileSerializationTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/profile/cache/ProfileSerializationTest.kt
@@ -1,0 +1,84 @@
+package org.hyperskill.profile.cache
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.hyperskill.app.network.injection.NetworkModule
+import org.hyperskill.app.profile.domain.model.Gamification
+import org.hyperskill.app.profile.domain.model.Profile
+
+class ProfileSerializationTest {
+
+    companion object {
+        private const val TEST_JSON = """
+            {
+              "id": 12345678,
+              "avatar": "https://example.com/avatar.jpg",
+              "bio": "Just a bio",
+              "fullname": "John Doe",
+              "gamification": {
+                "hypercoins": 414,
+                "passed_projects": 0
+              },
+              "completed_tracks": [1, 2, 3, 4, 5],
+              "country": null,
+              "languages": null,
+              "experience": "5 years",
+              "github_username": "johndoe",
+              "linkedin_username": "johndoe",
+              "twitter_username": "johndoetwitter",
+              "reddit_username": "jdoe",
+              "facebook_username": "jdoefacebook",
+              "daily_step": null,
+              "is_guest": false,
+              "is_staff": true,
+              "track_id": null,
+              "track_title": null,
+              "project": null,
+              "is_beta": false,
+              "timezone": null,
+              "notification_hour": null,
+              "features": {
+                "feature1": true,
+                "feature2": false
+              }
+            }
+        """
+
+        private val EXPECTED_PROFILE: Profile =
+            Profile(
+                id = 12345678L,
+                avatar = "https://example.com/avatar.jpg",
+                bio = "Just a bio",
+                fullname = "John Doe",
+                gamification = Gamification(
+                    hypercoinsBalance = 414,
+                    passedProjectsCount = 0
+                ),
+                completedTracks = listOf(1L, 2L, 3L, 4L, 5L),
+                country = null,
+                languages = null,
+                experience = "5 years",
+                githubUsername = "johndoe",
+                linkedinUsername = "johndoe",
+                twitterUsername = "johndoetwitter",
+                redditUsername = "jdoe",
+                facebookUsername = "jdoefacebook",
+                dailyStep = null,
+                isGuest = false,
+                isStaff = true,
+                trackId = null,
+                trackTitle = null,
+                projectId = null,
+                isBeta = false,
+                timeZone = null,
+                notificationHour = null,
+                featuresMap = mapOf("feature1" to true, "feature2" to false)
+            )
+    }
+    @Test
+    fun `Serialized profile should be deserialized normally`() {
+        val json = NetworkModule.provideJson()
+        val actualModel = json.decodeFromString(Profile.serializer(), TEST_JSON)
+        assertEquals(EXPECTED_PROFILE, actualModel)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/hyperskill/profile_settings/ProfileSettingsSerializationTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/profile_settings/ProfileSettingsSerializationTest.kt
@@ -1,0 +1,25 @@
+package org.hyperskill.profile_settings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.hyperskill.app.network.injection.NetworkModule
+import org.hyperskill.app.profile_settings.domain.model.ProfileSettings
+import org.hyperskill.app.profile_settings.domain.model.Theme
+
+class ProfileSettingsSerializationTest {
+    companion object {
+        private const val TEST_JSON = """
+            {
+                "theme": "system"
+            }
+        """
+    }
+
+    @Test
+    fun `Serialized profileSettings should be deserialized normally`() {
+        val json = NetworkModule.provideJson()
+        val expectedProfileSettings = ProfileSettings(Theme.SYSTEM)
+        val actualProfileSettings = json.decodeFromString(ProfileSettings.serializer(), TEST_JSON)
+        assertEquals(expectedProfileSettings, actualProfileSettings)
+    }
+}


### PR DESCRIPTION
**YouTrack Issues**:
[ALTAPPS-1072](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1072)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Add docs and serialization test for: `Profile`,  `ProfileSettings`, `Device`, `AuthResponse` models
