### PR TITLE
GitHub Actions: Fix deploy Android manually to Firebase App Distribution

### DIFF
--- a/.github/workflows/android_beta_deployment.yml
+++ b/.github/workflows/android_beta_deployment.yml
@@ -35,6 +35,7 @@ jobs:
     name: Deploy to Firebase App Distribution
     needs: gradle-wrapper-validation
     uses: ./.github/workflows/android_deploy_to_firebase.yml
+    secrets: inherit
 
   # Build and submit to the Google Play
   google-play-deployment:

--- a/.github/workflows/android_deploy_to_firebase_manually.yml
+++ b/.github/workflows/android_deploy_to_firebase_manually.yml
@@ -24,3 +24,4 @@ jobs:
     name: Deploy to Firebase App Distribution
     needs: gradle-wrapper-validation
     uses: ./.github/workflows/android_deploy_to_firebase.yml
+    secrets: inherit

--- a/androidHyperskillApp/fastlane/Fastfile
+++ b/androidHyperskillApp/fastlane/Fastfile
@@ -31,13 +31,13 @@ platform :android do
       gradle_path: gradle_path,
     )
 
-    firebase_app_distribution(
-      app: firebase_app_id,
-      firebase_cli_token: firebase_cli_token,
-      android_artifact_type: "APK",
-      release_notes_file: "fastlane/release-notes.txt",
-      groups: "all-android-testers",
-    )
+    # firebase_app_distribution(
+    #   app: firebase_app_id,
+    #   firebase_cli_token: firebase_cli_token,
+    #   android_artifact_type: "APK",
+    #   release_notes_file: "fastlane/release-notes.txt",
+    #   groups: "all-android-testers",
+    # )
   end
 
   desc "Deploy a new version to the Google Play"

--- a/androidHyperskillApp/fastlane/Fastfile
+++ b/androidHyperskillApp/fastlane/Fastfile
@@ -31,13 +31,13 @@ platform :android do
       gradle_path: gradle_path,
     )
 
-    # firebase_app_distribution(
-    #   app: firebase_app_id,
-    #   firebase_cli_token: firebase_cli_token,
-    #   android_artifact_type: "APK",
-    #   release_notes_file: "fastlane/release-notes.txt",
-    #   groups: "all-android-testers",
-    # )
+    firebase_app_distribution(
+      app: firebase_app_id,
+      firebase_cli_token: firebase_cli_token,
+      android_artifact_type: "APK",
+      release_notes_file: "fastlane/release-notes.txt",
+      groups: "all-android-testers",
+    )
   end
 
   desc "Deploy a new version to the Google Play"


### PR DESCRIPTION
**Description**

1. Fixes issue with #871
2. Adds `inherit` keyword to implicitly pass the secrets to reusable workflows