### PR TITLE
GitHub Actions: Bump macOS runner from 13 to 14

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -62,7 +62,7 @@ runs:
 
     - name: Setup Ruby
       if: ${{ inputs.setup-ruby == 'true' }}
-      uses: ruby/setup-ruby@v1.170.0
+      uses: ruby/setup-ruby@v1.171.0
       with:
         ruby-version: '3.3.0'
         bundler-cache: true

--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -49,7 +49,7 @@ runs:
       shell: bash
 
     - name: Setup Ruby
-      uses: ruby/setup-ruby@v1.170.0
+      uses: ruby/setup-ruby@v1.171.0
       with:
         ruby-version: '3.3.0'
         bundler-cache: true

--- a/.github/workflows/automerge_into_release.yml
+++ b/.github/workflows/automerge_into_release.yml
@@ -27,7 +27,7 @@ jobs:
   automerge:
     needs: files-changed
     name: Automerge
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
       - name: Checkout

--- a/.github/workflows/automerge_into_release.yml
+++ b/.github/workflows/automerge_into_release.yml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.170.0
+        uses: ruby/setup-ruby@v1.171.0
         with:
           ruby-version: "3.3.0"
           bundler-cache: true

--- a/.github/workflows/build_caches.yml
+++ b/.github/workflows/build_caches.yml
@@ -50,7 +50,7 @@ jobs:
     needs: files-changed
     if: ${{ github.event_name == 'workflow_dispatch' || needs.files-changed.outputs.ios == 'true' }}
     name: Build iOS Caches
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.170.0
+        uses: ruby/setup-ruby@v1.171.0
         with:
           ruby-version: '3.3.0'
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
     needs: files-changed
     if: ${{ needs.files-changed.outputs.ios == 'true' || needs.files-changed.outputs.shared == 'true' }}
     name: Run SwiftLint
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 10
     
     steps:
@@ -162,7 +162,7 @@ jobs:
   build-ios:
     needs: swiftlint
     name: Build iOS
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     
     steps:

--- a/.github/workflows/ios_beta_deployment.yml
+++ b/.github/workflows/ios_beta_deployment.yml
@@ -34,7 +34,7 @@ jobs:
   deployment:
     name: iOS Beta Deployment
     needs: gradle-wrapper-validation
-    runs-on: macos-13
+    runs-on: macos-14
     environment: ios_production
     timeout-minutes: 60
 

--- a/.github/workflows/ios_release_deployment.yml
+++ b/.github/workflows/ios_release_deployment.yml
@@ -30,7 +30,7 @@ jobs:
   deployment:
     name: iOS Release Deployment
     needs: gradle-wrapper-validation
-    runs-on: macos-13
+    runs-on: macos-14
     environment: ios_production
     timeout-minutes: 60
 

--- a/.github/workflows/ios_unit_testing.yml
+++ b/.github/workflows/ios_unit_testing.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     if: ${{ vars.IS_IOS_UNIT_TESTING_ENABLED == 'true' }}
     name: Run iOS unit tests
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
**Description**

1. Upgrades to the new [M1 macOS runner](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/)
2. Bumps ruby/setup-ruby from 1.170.0 to 1.171.0 ([Add support for macos-14 GitHub runners](https://github.com/ruby/setup-ruby/releases/tag/v1.171.0))