### PR TITLE
ALTAPPS-1104: iOS remove elements with the attribute data-mobile-hidden

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/ContentProcessor/Processing/ContentProcessingInjection.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/ContentProcessor/Processing/ContentProcessingInjection.swift
@@ -99,6 +99,23 @@ final class ClickableImagesInjection: ContentProcessingInjection {
     }
 }
 
+/// Removes all elements that are marked as hidden on mobile devices.
+final class DataMobileHiddenElementsInjection: ContentProcessingInjection {
+    var headScript: String {
+        """
+        <script type="text/javascript">
+        addEventListener('DOMContentLoaded', () => {
+            document
+                .querySelectorAll('[data-mobile-hidden="true"]')
+                .forEach(element =>
+                    element.parentNode.removeChild(element)
+                );
+        });
+        </script>
+        """
+    }
+}
+
 /// Disable images callout on long tap
 final class WebkitImagesCalloutDisableInjection: ContentProcessingInjection {
     var headScript: String {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/ContentProcessor/Processing/ContentProcessor.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/ContentProcessor/Processing/ContentProcessor.swift
@@ -16,7 +16,8 @@ final class ContentProcessor: ContentProcessorProtocol {
         MetaViewportInjection(),
         HightlightJSInjection(),
         WebkitImagesCalloutDisableInjection(),
-        WebScriptInjection()
+        WebScriptInjection(),
+        DataMobileHiddenElementsInjection()
     ]
 
     static let defaultRules: [ContentProcessingRule] = [


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1104](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1104)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

- Adds `DataMobileHiddenElementsInjection` that removes all elements that are marked as hidden on mobile devices