### PR TITLE
ALTAPPS-1152: Shared setup RevenueCat only when user is authorized

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/HyperskillApp.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/HyperskillApp.kt
@@ -56,7 +56,6 @@ class HyperskillApp : Application(), ImageLoaderFactory {
 
         setNightMode(appGraph)
         initSentry(appGraph)
-        initRevenueCat(appGraph)
         initChannels()
     }
 
@@ -84,9 +83,5 @@ class HyperskillApp : Application(), ImageLoaderFactory {
         AppCompatDelegate.setDefaultNightMode(
             profileSettings.theme.asNightMode()
         )
-    }
-
-    private fun initRevenueCat(appGraph: AppGraph) {
-        appGraph.buildPurchaseComponent().purchaseInteractor.setup()
     }
 }

--- a/shared/src/androidMain/kotlin/org/hyperskill/app/purchases/domain/AndroidPurchaseManager.kt
+++ b/shared/src/androidMain/kotlin/org/hyperskill/app/purchases/domain/AndroidPurchaseManager.kt
@@ -24,16 +24,21 @@ class AndroidPurchaseManager(
     private val application: Application,
     private val isDebugMode: Boolean
 ) : PurchaseManager {
-    override fun setup() {
-        if (!Purchases.isConfigured) {
-            Purchases.logLevel = if (isDebugMode) LogLevel.DEBUG else LogLevel.INFO
-            Purchases.configure(
-                PurchasesConfiguration.Builder(
+
+    override fun isConfigured(): Boolean =
+        Purchases.isConfigured
+
+    override fun configure(userId: Long) {
+        Purchases.logLevel = if (isDebugMode) LogLevel.DEBUG else LogLevel.INFO
+        Purchases.configure(
+            PurchasesConfiguration
+                .Builder(
                     context = application,
                     apiKey = BuildConfig.REVENUE_CAT_GOOGLE_API_KEY
-                ).build()
-            )
-        }
+                )
+                .appUserID(userId.toString())
+                .build()
+        )
     }
 
     override suspend fun login(userId: Long): Result<Unit> =

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/purchases/domain/interactor/PurchaseInteractor.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/purchases/domain/interactor/PurchaseInteractor.kt
@@ -11,16 +11,18 @@ class PurchaseInteractor(
         private const val MOBILE_ONLY_SUBSCRIPTION_PRODUCT_ID: String = "premium_mobile"
     }
 
-    fun setup() {
-        purchaseManager.setup()
-    }
-
     /**
      * Identifies user in the payment sdk with provided [userId].
      * Must be called just after login event.
      */
     suspend fun login(userId: Long): Result<Unit> =
-        purchaseManager.login(userId)
+        if (!purchaseManager.isConfigured()) {
+            runCatching {
+                purchaseManager.configure(userId)
+            }
+        } else {
+            purchaseManager.login(userId)
+        }
 
     suspend fun purchaseMobileOnlySubscription(
         platformPurchaseParams: PlatformPurchaseParams

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/purchases/domain/model/PurchaseManager.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/purchases/domain/model/PurchaseManager.kt
@@ -5,11 +5,12 @@ package org.hyperskill.app.purchases.domain.model
  */
 interface PurchaseManager {
 
+    fun isConfigured(): Boolean
+
     /**
-     * Setups the payment sdk.
-     * Must be called when the application is launched for the first time.
+     * Setups the payment sdk with provided [userId]
      */
-    fun setup()
+    fun configure(userId: Long)
 
     /**
      * Identifies user in the payment sdk with provided [userId].

--- a/shared/src/iosMain/kotlin/org/hyperskill/app/purchase/domain/model/IOSPurchaseManager.kt
+++ b/shared/src/iosMain/kotlin/org/hyperskill/app/purchase/domain/model/IOSPurchaseManager.kt
@@ -6,7 +6,12 @@ import org.hyperskill.app.purchases.domain.model.PurchaseResult
 
 // TODO: ALTAPPS-1110
 class IOSPurchaseManager : PurchaseManager {
-    override fun setup() {
+
+    override fun isConfigured(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun configure(userId: Long) {
         TODO("Not yet implemented")
     }
 


### PR DESCRIPTION
**YouTrack Issues**:
[ALTAPPS-1152](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1152)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Configure RevenueCat only with user id
