### PR TITLE
ALTAPPS-1158: Shared fix track selection details screen crashes

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/progress_screen/presentation/ProgressScreenActionDispatcher.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/progress_screen/presentation/ProgressScreenActionDispatcher.kt
@@ -139,8 +139,8 @@ internal class ProgressScreenActionDispatcher(
         trackId: Long,
         forceLoadFromRemote: Boolean
     ): Result<TrackWithProgress?> =
-        coroutineScope {
-            kotlin.runCatching {
+        kotlin.runCatching {
+            coroutineScope {
                 val trackDeferred = async {
                     trackInteractor.getTrack(trackId, forceLoadFromRemote)
                 }
@@ -149,7 +149,7 @@ internal class ProgressScreenActionDispatcher(
                 }
                 TrackWithProgress(
                     track = trackDeferred.await().getOrThrow(),
-                    trackProgress = trackProgressDeferred.await().getOrThrow() ?: return@runCatching null
+                    trackProgress = trackProgressDeferred.await().getOrThrow() ?: return@coroutineScope null
                 )
             }
         }
@@ -158,8 +158,8 @@ internal class ProgressScreenActionDispatcher(
         projectId: Long,
         forceLoadFromRemote: Boolean
     ): Result<ProjectWithProgress?> =
-        coroutineScope {
-            kotlin.runCatching {
+        kotlin.runCatching {
+            coroutineScope {
                 val projectDeferred = async {
                     projectsRepository.getProject(projectId, forceLoadFromRemote)
                 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/project_selection/details/domain/interactor/ProjectSelectionDetailsInteractor.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/project_selection/details/domain/interactor/ProjectSelectionDetailsInteractor.kt
@@ -25,8 +25,8 @@ internal class ProjectSelectionDetailsInteractor(
         projectId: Long,
         forceLoadFromNetwork: Boolean
     ): Result<ProjectSelectionDetailsFeature.ContentData> =
-        coroutineScope {
-            kotlin.runCatching {
+        kotlin.runCatching {
+            coroutineScope {
                 val trackDeferred = async { trackRepository.getTrack(trackId, forceLoadFromNetwork) }
                 val projectDeferred = async { projectsRepository.getProject(projectId, forceLoadFromNetwork) }
 


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1158](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1158)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

1. Fixes crash related with `TrackSelectionDetailsActionDispatcher` and it's `InternalAction.FetchAdditionalInfo` action handling