### PR TITLE
ALTAPPS-638: iOS fix code editor not replaces symbols in selection

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/Model/Analyze/CodePlaygroundManager.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/Model/Analyze/CodePlaygroundManager.swift
@@ -433,12 +433,17 @@ final class CodePlaygroundManager {
             return
         }
 
-        let cursorPosition = textView.offset(from: textView.beginningOfDocument, to: selectedRange.start)
-        var text = textView.text ?? ""
-        text.insert(contentsOf: symbols, at: text.index(text.startIndex, offsetBy: cursorPosition))
-        textView.text = text
-        // Import here to update selectedTextRange before calling textViewDidChange #APPS-2352
-        textView.selectedTextRange = textRangeFrom(position: cursorPosition + symbols.count, textView: textView)
+        if selectedRange.isEmpty {
+            let cursorPosition = textView.offset(from: textView.beginningOfDocument, to: selectedRange.start)
+            var text = textView.text ?? ""
+            text.insert(contentsOf: symbols, at: text.index(text.startIndex, offsetBy: cursorPosition))
+            textView.text = text
+            // Import here to update selectedTextRange before calling textViewDidChange #APPS-2352
+            textView.selectedTextRange = textRangeFrom(position: cursorPosition + symbols.count, textView: textView)
+        } else {
+            textView.replace(selectedRange, withText: symbols)
+        }
+
         // Manually call textViewDidChange, because when manually setting the text of a UITextView with code,
         // the textViewDidChange: method does not get called.
         textView.delegate?.textViewDidChange?(textView)


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-638](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-638)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

- Fixes issue with code editor not replaces symbols in selection