### PR TITLE
ALTAPPS-1148: Shared navigate user back to step after the subscription purchase

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/paywall/fragment/PaywallFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/paywall/fragment/PaywallFragment.kt
@@ -77,8 +77,8 @@ class PaywallFragment : Fragment() {
             ViewAction.CompletePaywall -> {
                 requireAppRouter().sendResult(PAYWALL_COMPLETED, Any())
             }
-            ViewAction.StudyPlan -> {
-                requireRouter().backTo(MainScreen(initialTab = Tabs.STUDY_PLAN))
+            ViewAction.NavigateTo.Back -> {
+                requireRouter().exit()
             }
             is ViewAction.ShowMessage -> {
                 Toast.makeText(

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/fragment/DefaultStepQuizFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/fragment/DefaultStepQuizFragment.kt
@@ -23,6 +23,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.hyperskill.app.android.HyperskillApp
 import org.hyperskill.app.android.R
 import org.hyperskill.app.android.core.extensions.argument
+import org.hyperskill.app.android.core.view.ui.dialog.dismissDialogFragmentIfExists
 import org.hyperskill.app.android.core.view.ui.fragment.parentOfType
 import org.hyperskill.app.android.core.view.ui.navigation.requireRouter
 import org.hyperskill.app.android.databinding.FragmentStepQuizBinding
@@ -289,6 +290,9 @@ abstract class DefaultStepQuizFragment :
                 ProblemsLimitReachedBottomSheet
                     .newInstance(action.modalData)
                     .showIfNotExists(childFragmentManager, ProblemsLimitReachedBottomSheet.TAG)
+            }
+            StepQuizFeature.Action.ViewAction.HideProblemOnboardingModal -> {
+                childFragmentManager.dismissDialogFragmentIfExists(ProblemsLimitReachedBottomSheet.TAG)
             }
             is StepQuizFeature.Action.ViewAction.ShowProblemOnboardingModal -> {
                 ProblemOnboardingBottomSheetDialogFragment.newInstance(action.modalType)

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/fragment/DefaultStepQuizFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/fragment/DefaultStepQuizFragment.kt
@@ -291,7 +291,7 @@ abstract class DefaultStepQuizFragment :
                     .newInstance(action.modalData)
                     .showIfNotExists(childFragmentManager, ProblemsLimitReachedBottomSheet.TAG)
             }
-            StepQuizFeature.Action.ViewAction.HideProblemOnboardingModal -> {
+            StepQuizFeature.Action.ViewAction.HideProblemsLimitReachedModal -> {
                 childFragmentManager.dismissDialogFragmentIfExists(ProblemsLimitReachedBottomSheet.TAG)
             }
             is StepQuizFeature.Action.ViewAction.ShowProblemOnboardingModal -> {

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/Views/StepQuizView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/Views/StepQuizView.swift
@@ -302,6 +302,8 @@ struct StepQuizView: View {
             presentProblemsLimitReachedModal(
                 modalData: showProblemsLimitReachedModalViewAction.modalData
             )
+        case .hideProblemOnboardingModal:
+            #warning("TODO: ALTAPPS-1148")
         case .showProblemOnboardingModal(let showProblemOnboardingModalViewAction):
             presentProblemOnboardingModal(modalType: showProblemOnboardingModalViewAction.modalType)
         case .navigateTo(let viewActionNavigateTo):

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/Views/StepQuizView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/Views/StepQuizView.swift
@@ -302,8 +302,6 @@ struct StepQuizView: View {
             presentProblemsLimitReachedModal(
                 modalData: showProblemsLimitReachedModalViewAction.modalData
             )
-        case .hideProblemOnboardingModal:
-            #warning("TODO: ALTAPPS-1148")
         case .showProblemOnboardingModal(let showProblemOnboardingModalViewAction):
             presentProblemOnboardingModal(modalType: showProblemOnboardingModalViewAction.modalType)
         case .navigateTo(let viewActionNavigateTo):
@@ -344,6 +342,8 @@ struct StepQuizView: View {
             }
         case .openUrl(let data):
             WebControllerManager.shared.presentWebControllerWithURLString(data.url, controllerType: .inAppSafari)
+        case .hideProblemsLimitReachedModal:
+            #warning("TODO: ALTAPPS-1148")
         }
     }
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/paywall/presentation/PaywallFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/paywall/presentation/PaywallFeature.kt
@@ -71,8 +71,6 @@ object PaywallFeature {
 
             object ClosePaywall : ViewAction
 
-            object StudyPlan : ViewAction
-
             data class ShowMessage(
                 val messageKind: MessageKind
             ) : ViewAction
@@ -80,6 +78,8 @@ object PaywallFeature {
             data class OpenUrl(val url: String) : ViewAction
 
             sealed interface NavigateTo : ViewAction {
+                object Back : NavigateTo
+
                 object BackToProfileSettings : NavigateTo
             }
         }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/paywall/presentation/PaywallReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/paywall/presentation/PaywallReducer.kt
@@ -175,7 +175,7 @@ internal class PaywallReducer(
             PaywallTransitionSource.PROFILE_SETTINGS ->
                 Action.ViewAction.NavigateTo.BackToProfileSettings
             PaywallTransitionSource.PROBLEMS_LIMIT_MODAL ->
-                Action.ViewAction.StudyPlan
+                Action.ViewAction.NavigateTo.Back
         }
 
     private fun handleClickedTermsOfServiceAndPrivacyPolicy(state: State): ReducerResult =

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/injection/StepQuizComponentImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/injection/StepQuizComponentImpl.kt
@@ -61,6 +61,7 @@ internal class StepQuizComponentImpl(
             resourceProvider = appGraph.commonComponent.resourceProvider,
             logger = appGraph.loggerComponent.logger,
             buildVariant = appGraph.commonComponent.buildKonfig.buildVariant,
-            platform = appGraph.commonComponent.platform
+            platform = appGraph.commonComponent.platform,
+            currentSubscriptionStateRepository = appGraph.stateRepositoriesComponent.currentSubscriptionStateRepository
         )
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/injection/StepQuizFeatureBuilder.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/injection/StepQuizFeatureBuilder.kt
@@ -21,6 +21,7 @@ import org.hyperskill.app.step_quiz_hints.presentation.StepQuizHintsActionDispat
 import org.hyperskill.app.step_quiz_hints.presentation.StepQuizHintsFeature
 import org.hyperskill.app.step_quiz_hints.presentation.StepQuizHintsReducer
 import org.hyperskill.app.subscriptions.domain.interactor.SubscriptionsInteractor
+import org.hyperskill.app.subscriptions.domain.repository.CurrentSubscriptionStateRepository
 import ru.nobird.app.core.model.safeCast
 import ru.nobird.app.presentation.redux.dispatcher.transform
 import ru.nobird.app.presentation.redux.dispatcher.wrapWithActionDispatcher
@@ -45,7 +46,8 @@ internal object StepQuizFeatureBuilder {
         resourceProvider: ResourceProvider,
         logger: Logger,
         buildVariant: BuildVariant,
-        platform: Platform
+        platform: Platform,
+        currentSubscriptionStateRepository: CurrentSubscriptionStateRepository
     ): Feature<StepQuizFeature.State, StepQuizFeature.Message, StepQuizFeature.Action> {
         val stepQuizReducer = StepQuizReducer(
             stepRoute = stepRoute,
@@ -57,6 +59,7 @@ internal object StepQuizFeatureBuilder {
             stepQuizReplyValidator = stepQuizReplyValidator,
             subscriptionsInteractor = subscriptionsInteractor,
             currentProfileStateRepository = currentProfileStateRepository,
+            currentSubscriptionStateRepository = currentSubscriptionStateRepository,
             urlPathProcessor = urlPathProcessor,
             analyticInteractor = analyticInteractor,
             sentryInteractor = sentryInteractor,

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizActionDispatcher.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizActionDispatcher.kt
@@ -258,7 +258,7 @@ internal class StepQuizActionDispatcher(
             profile.features.isMobileOnlySubscriptionEnabled &&
             subscription.isFreemium
 
-    // TODO: Extract ProblemsLimitReachedModal into a separate feature
+    // TODO: ALTAPPS-1171: Extract ProblemsLimitReachedModal into a separate feature
     private suspend fun getProblemsLimitReachedModalData(
         profile: Profile,
         subscription: Subscription

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizActionDispatcher.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizActionDispatcher.kt
@@ -1,6 +1,8 @@
 package org.hyperskill.app.step_quiz.presentation
 
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import org.hyperskill.app.SharedResources
 import org.hyperskill.app.analytic.domain.interactor.AnalyticInteractor
@@ -53,15 +55,11 @@ internal class StepQuizActionDispatcher(
     init {
         currentSubscriptionStateRepository
             .changes
-            .onEach { subscription ->
+            .map { it.isProblemsLimitReached }
+            .distinctUntilChanged()
+            .onEach { isProblemsLimitReached ->
                 onNewMessage(
-                    InternalMessage.UpdateProblemsLimitResult(
-                        isProblemsLimitReached = subscription.isProblemsLimitReached,
-                        problemsLimitReachedModalData = getProblemsLimitReachedModalData(
-                            profile = currentProfileStateRepository.getState().getOrElse { return@onEach },
-                            subscription
-                        )
-                    )
+                    InternalMessage.ProblemsLimitChanged(isProblemsLimitReached)
                 )
             }
             .launchIn(actionScope)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizActionDispatcher.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizActionDispatcher.kt
@@ -1,5 +1,7 @@
 package org.hyperskill.app.step_quiz.presentation
 
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import org.hyperskill.app.SharedResources
 import org.hyperskill.app.analytic.domain.interactor.AnalyticInteractor
 import org.hyperskill.app.core.domain.platform.Platform
@@ -30,6 +32,7 @@ import org.hyperskill.app.subscriptions.domain.interactor.SubscriptionsInteracto
 import org.hyperskill.app.subscriptions.domain.model.Subscription
 import org.hyperskill.app.subscriptions.domain.model.isFreemium
 import org.hyperskill.app.subscriptions.domain.model.isProblemsLimitReached
+import org.hyperskill.app.subscriptions.domain.repository.CurrentSubscriptionStateRepository
 import ru.nobird.app.presentation.redux.dispatcher.CoroutineActionDispatcher
 
 internal class StepQuizActionDispatcher(
@@ -43,8 +46,27 @@ internal class StepQuizActionDispatcher(
     private val sentryInteractor: SentryInteractor,
     private val onboardingInteractor: OnboardingInteractor,
     private val resourceProvider: ResourceProvider,
-    private val platform: Platform
+    private val platform: Platform,
+    currentSubscriptionStateRepository: CurrentSubscriptionStateRepository
 ) : CoroutineActionDispatcher<Action, Message>(config.createConfig()) {
+
+    init {
+        currentSubscriptionStateRepository
+            .changes
+            .onEach { subscription ->
+                onNewMessage(
+                    InternalMessage.ProblemsLimitChanged(
+                        isProblemsLimitReached = subscription.isProblemsLimitReached,
+                        problemsLimitReachedModalData = getProblemsLimitReachedModalData(
+                            profile = currentProfileStateRepository.getState().getOrElse { return@onEach },
+                            subscription
+                        )
+                    )
+                )
+            }
+            .launchIn(actionScope)
+    }
+
     override suspend fun doSuspendableAction(action: Action) {
         when (action) {
             is Action.FetchAttempt ->
@@ -200,21 +222,13 @@ internal class StepQuizActionDispatcher(
                 getSubmissionState(attempt.id, action.step.id, currentProfile.id)
                     .getOrThrow()
 
-            val isProblemsLimitReached = currentSubscription.isProblemsLimitReached
-            val problemsLimitReachedModalData = if (isProblemsLimitReached) {
-                getProblemsLimitReachedModalData(
-                    currentSubscription,
-                    isSubscriptionPurchaseEnabled(currentProfile, currentSubscription)
-                )
-            } else {
-                null
-            }
+            val problemsLimitReachedModalData = getProblemsLimitReachedModalData(currentProfile, currentSubscription)
 
             Message.FetchAttemptSuccess(
                 step = action.step,
                 attempt = attempt,
                 submissionState = submissionState,
-                isProblemsLimitReached = isProblemsLimitReached,
+                isProblemsLimitReached = currentSubscription.isProblemsLimitReached,
                 problemsLimitReachedModalData = problemsLimitReachedModalData,
                 problemsOnboardingFlags = onboardingInteractor.getProblemsOnboardingFlags()
             )
@@ -236,19 +250,24 @@ internal class StepQuizActionDispatcher(
                 }
             }
 
-    internal fun isSubscriptionPurchaseEnabled(
-        currentProfile: Profile,
-        currentSubscription: Subscription
+    private fun isSubscriptionPurchaseEnabled(
+        profile: Profile,
+        subscription: Subscription
     ): Boolean =
         platform.isSubscriptionPurchaseEnabled &&
-            currentProfile.features.isMobileOnlySubscriptionEnabled &&
-            currentSubscription.isFreemium
+            profile.features.isMobileOnlySubscriptionEnabled &&
+            subscription.isFreemium
 
+    // TODO: Extract ProblemsLimitReachedModal into a separate feature
     private suspend fun getProblemsLimitReachedModalData(
-        subscription: Subscription,
-        isSubscriptionPurchaseEnabled: Boolean
+        profile: Profile,
+        subscription: Subscription
     ): StepQuizFeature.ProblemsLimitReachedModalData? {
+        if (!subscription.isProblemsLimitReached) return null
+
         val stepsLimitTotal = subscription.stepsLimitTotal ?: return null
+
+        val isSubscriptionPurchaseEnabled = isSubscriptionPurchaseEnabled(profile, subscription)
 
         return if (currentProfileStateRepository.isFreemiumWrongSubmissionChargeLimitsEnabled()) {
             StepQuizFeature.ProblemsLimitReachedModalData(
@@ -303,18 +322,10 @@ internal class StepQuizActionDispatcher(
         subscriptionsInteractor.chargeProblemsLimits(action.chargeStrategy)
 
         val subscription = subscriptionsInteractor.getCurrentSubscription().getOrElse { return }
-        val problemsLimitReachedModalData =
-            if (subscription.isProblemsLimitReached) {
-                getProblemsLimitReachedModalData(
-                    subscription = subscription,
-                    isSubscriptionPurchaseEnabled = isSubscriptionPurchaseEnabled(currentProfile, subscription)
-                )
-            } else {
-                null
-            }
+        val problemsLimitReachedModalData = getProblemsLimitReachedModalData(currentProfile, subscription)
 
         onNewMessage(
-            InternalMessage.UpdateProblemsLimitResult(
+            InternalMessage.ProblemsLimitChanged(
                 isProblemsLimitReached = subscription.isProblemsLimitReached,
                 problemsLimitReachedModalData = problemsLimitReachedModalData
             )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizActionDispatcher.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizActionDispatcher.kt
@@ -55,7 +55,7 @@ internal class StepQuizActionDispatcher(
             .changes
             .onEach { subscription ->
                 onNewMessage(
-                    InternalMessage.ProblemsLimitChanged(
+                    InternalMessage.UpdateProblemsLimitResult(
                         isProblemsLimitReached = subscription.isProblemsLimitReached,
                         problemsLimitReachedModalData = getProblemsLimitReachedModalData(
                             profile = currentProfileStateRepository.getState().getOrElse { return@onEach },
@@ -325,7 +325,7 @@ internal class StepQuizActionDispatcher(
         val problemsLimitReachedModalData = getProblemsLimitReachedModalData(currentProfile, subscription)
 
         onNewMessage(
-            InternalMessage.ProblemsLimitChanged(
+            InternalMessage.UpdateProblemsLimitResult(
                 isProblemsLimitReached = subscription.isProblemsLimitReached,
                 problemsLimitReachedModalData = problemsLimitReachedModalData
             )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizFeature.kt
@@ -151,7 +151,7 @@ object StepQuizFeature {
     }
 
     internal sealed interface InternalMessage : Message {
-        data class ProblemsLimitChanged(
+        data class UpdateProblemsLimitResult(
             val isProblemsLimitReached: Boolean,
             val problemsLimitReachedModalData: ProblemsLimitReachedModalData?
         ) : InternalMessage

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizFeature.kt
@@ -151,7 +151,7 @@ object StepQuizFeature {
     }
 
     internal sealed interface InternalMessage : Message {
-        data class UpdateProblemsLimitResult(
+        data class ProblemsLimitChanged(
             val isProblemsLimitReached: Boolean,
             val problemsLimitReachedModalData: ProblemsLimitReachedModalData?
         ) : InternalMessage
@@ -199,6 +199,8 @@ object StepQuizFeature {
             data class ShowProblemsLimitReachedModal(val modalData: ProblemsLimitReachedModalData) : ViewAction
 
             data class ShowProblemOnboardingModal(val modalType: ProblemOnboardingModal) : ViewAction
+
+            object HideProblemOnboardingModal : ViewAction
 
             data class StepQuizHintsViewAction(
                 val viewAction: StepQuizHintsFeature.Action.ViewAction

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizFeature.kt
@@ -198,9 +198,9 @@ object StepQuizFeature {
 
             data class ShowProblemsLimitReachedModal(val modalData: ProblemsLimitReachedModalData) : ViewAction
 
-            data class ShowProblemOnboardingModal(val modalType: ProblemOnboardingModal) : ViewAction
+            object HideProblemsLimitReachedModal : ViewAction
 
-            object HideProblemOnboardingModal : ViewAction
+            data class ShowProblemOnboardingModal(val modalType: ProblemOnboardingModal) : ViewAction
 
             data class StepQuizHintsViewAction(
                 val viewAction: StepQuizHintsFeature.Action.ViewAction

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizFeature.kt
@@ -156,6 +156,8 @@ object StepQuizFeature {
             val problemsLimitReachedModalData: ProblemsLimitReachedModalData?
         ) : InternalMessage
 
+        data class ProblemsLimitChanged(val isProblemsLimitReached: Boolean) : InternalMessage
+
         object CreateMagicLinkForUnsupportedQuizError : InternalMessage
         data class CreateMagicLinkForUnsupportedQuizSuccess(val url: String) : InternalMessage
     }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizReducer.kt
@@ -436,7 +436,7 @@ internal class StepQuizReducer(
             ) to if (isProblemsLimitReached && message.problemsLimitReachedModalData != null) {
                 setOf(Action.ViewAction.ShowProblemsLimitReachedModal(message.problemsLimitReachedModalData))
             } else {
-                setOf(Action.ViewAction.HideProblemOnboardingModal)
+                setOf(Action.ViewAction.HideProblemsLimitReachedModal)
             }
         } else {
             null

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizReducer.kt
@@ -218,8 +218,8 @@ internal class StepQuizReducer(
                     null
                 }
             }
-            is InternalMessage.UpdateProblemsLimitResult ->
-                handleUpdateProblemsLimitResult(state, message)
+            is InternalMessage.ProblemsLimitChanged ->
+                handleUpdateProblemsLimitChanged(state, message)
             is Message.ProblemsLimitReachedModalGoToHomeScreenClicked ->
                 state to setOf(
                     Action.ViewAction.NavigateTo.Home,
@@ -421,9 +421,9 @@ internal class StepQuizReducer(
         ) to stepQuizActions + stepQuizHintsActions
     }
 
-    private fun handleUpdateProblemsLimitResult(
+    private fun handleUpdateProblemsLimitChanged(
         state: State,
-        message: InternalMessage.UpdateProblemsLimitResult
+        message: InternalMessage.ProblemsLimitChanged
     ): StepQuizReducerResult? =
         if (state.stepQuizState is StepQuizState.AttemptLoaded) {
             val isProblemsLimitReached =
@@ -433,10 +433,10 @@ internal class StepQuizReducer(
                 stepQuizState = state.stepQuizState.copy(
                     isProblemsLimitReached = isProblemsLimitReached
                 )
-            ) to buildSet {
-                if (isProblemsLimitReached && message.problemsLimitReachedModalData != null) {
-                    add(Action.ViewAction.ShowProblemsLimitReachedModal(message.problemsLimitReachedModalData))
-                }
+            ) to if (isProblemsLimitReached && message.problemsLimitReachedModalData != null) {
+                setOf(Action.ViewAction.ShowProblemsLimitReachedModal(message.problemsLimitReachedModalData))
+            } else {
+                setOf(Action.ViewAction.HideProblemOnboardingModal)
             }
         } else {
             null

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizReducer.kt
@@ -218,7 +218,7 @@ internal class StepQuizReducer(
                     null
                 }
             }
-            is InternalMessage.ProblemsLimitChanged ->
+            is InternalMessage.UpdateProblemsLimitResult ->
                 handleUpdateProblemsLimitChanged(state, message)
             is Message.ProblemsLimitReachedModalGoToHomeScreenClicked ->
                 state to setOf(
@@ -423,7 +423,7 @@ internal class StepQuizReducer(
 
     private fun handleUpdateProblemsLimitChanged(
         state: State,
-        message: InternalMessage.ProblemsLimitChanged
+        message: InternalMessage.UpdateProblemsLimitResult
     ): StepQuizReducerResult? =
         if (state.stepQuizState is StepQuizState.AttemptLoaded) {
             val isProblemsLimitReached =

--- a/shared/src/commonTest/kotlin/org/hyperskill/step_quiz/StepQuizTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/step_quiz/StepQuizTest.kt
@@ -227,7 +227,7 @@ class StepQuizTest {
 
         val (actualState, actualActions) = reducer.reduce(
             initialState,
-            StepQuizFeature.InternalMessage.ProblemsLimitChanged(
+            StepQuizFeature.InternalMessage.UpdateProblemsLimitResult(
                 isProblemsLimitReached = true,
                 problemsLimitReachedModalData = StepQuizFeature.ProblemsLimitReachedModalData(
                     title = "",
@@ -282,7 +282,7 @@ class StepQuizTest {
 
         val (actualState, actualActions) = reducer.reduce(
             initialState,
-            StepQuizFeature.InternalMessage.ProblemsLimitChanged(
+            StepQuizFeature.InternalMessage.UpdateProblemsLimitResult(
                 isProblemsLimitReached = true,
                 problemsLimitReachedModalData = StepQuizFeature.ProblemsLimitReachedModalData(
                     title = "",

--- a/shared/src/commonTest/kotlin/org/hyperskill/step_quiz/StepQuizTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/step_quiz/StepQuizTest.kt
@@ -227,7 +227,7 @@ class StepQuizTest {
 
         val (actualState, actualActions) = reducer.reduce(
             initialState,
-            StepQuizFeature.InternalMessage.UpdateProblemsLimitResult(
+            StepQuizFeature.InternalMessage.ProblemsLimitChanged(
                 isProblemsLimitReached = true,
                 problemsLimitReachedModalData = StepQuizFeature.ProblemsLimitReachedModalData(
                     title = "",
@@ -282,7 +282,7 @@ class StepQuizTest {
 
         val (actualState, actualActions) = reducer.reduce(
             initialState,
-            StepQuizFeature.InternalMessage.UpdateProblemsLimitResult(
+            StepQuizFeature.InternalMessage.ProblemsLimitChanged(
                 isProblemsLimitReached = true,
                 problemsLimitReachedModalData = StepQuizFeature.ProblemsLimitReachedModalData(
                     title = "",

--- a/shared/src/commonTest/kotlin/org/hyperskill/step_quiz/StepQuizTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/step_quiz/StepQuizTest.kt
@@ -304,7 +304,11 @@ class StepQuizTest {
         )
 
         assertEquals(expectedState, actualState)
-        assertTrue(actualActions.isEmpty())
+        assertTrue {
+            actualActions.none {
+                it is StepQuizFeature.Action.ViewAction.ShowProblemsLimitReachedModal
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
**YouTrack Issues**:

[#ALTAPPS-1148](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1148)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Navigate back after subscription purchase from problems limit bottom sheet
- Subscribe on subscripitn changes to hide problems limit bottom sheet comming back to the step screen with bought subscription
