### PR TITLE
ALTAPPS-1182: Shared support is_in_current_track in topics repetitions

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/data/repository/TopicsRepetitionsRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/data/repository/TopicsRepetitionsRepositoryImpl.kt
@@ -15,6 +15,6 @@ internal class TopicsRepetitionsRepositoryImpl(
     ): Result<List<TopicRepetition>> =
         topicsRepetitionsRemoteDataSource.getTopicsRepetitions(pageSize, page, isInCurrentTrack)
 
-    override suspend fun getTopicsRepetitionStatistics(): Result<TopicRepetitionStatistics> =
-        topicsRepetitionsRemoteDataSource.getTopicsRepetitionStatistics()
+    override suspend fun getTopicsRepetitionStatistics(isInCurrentTrack: Boolean): Result<TopicRepetitionStatistics> =
+        topicsRepetitionsRemoteDataSource.getTopicsRepetitionStatistics(isInCurrentTrack)
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/data/repository/TopicsRepetitionsRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/data/repository/TopicsRepetitionsRepositoryImpl.kt
@@ -5,11 +5,15 @@ import org.hyperskill.app.topics_repetitions.domain.model.TopicRepetition
 import org.hyperskill.app.topics_repetitions.domain.model.TopicRepetitionStatistics
 import org.hyperskill.app.topics_repetitions.domain.repository.TopicsRepetitionsRepository
 
-class TopicsRepetitionsRepositoryImpl(
+internal class TopicsRepetitionsRepositoryImpl(
     private val topicsRepetitionsRemoteDataSource: TopicsRepetitionsRemoteDataSource
 ) : TopicsRepetitionsRepository {
-    override suspend fun getTopicsRepetitions(pageSize: Int, page: Int): Result<List<TopicRepetition>> =
-        topicsRepetitionsRemoteDataSource.getTopicsRepetitions(pageSize, page)
+    override suspend fun getTopicsRepetitions(
+        pageSize: Int,
+        page: Int,
+        isInCurrentTrack: Boolean
+    ): Result<List<TopicRepetition>> =
+        topicsRepetitionsRemoteDataSource.getTopicsRepetitions(pageSize, page, isInCurrentTrack)
 
     override suspend fun getTopicsRepetitionStatistics(): Result<TopicRepetitionStatistics> =
         topicsRepetitionsRemoteDataSource.getTopicsRepetitionStatistics()

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/data/source/TopicsRepetitionsRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/data/source/TopicsRepetitionsRemoteDataSource.kt
@@ -5,5 +5,5 @@ import org.hyperskill.app.topics_repetitions.domain.model.TopicRepetitionStatist
 
 interface TopicsRepetitionsRemoteDataSource {
     suspend fun getTopicsRepetitions(pageSize: Int, page: Int, isInCurrentTrack: Boolean): Result<List<TopicRepetition>>
-    suspend fun getTopicsRepetitionStatistics(): Result<TopicRepetitionStatistics>
+    suspend fun getTopicsRepetitionStatistics(isInCurrentTrack: Boolean): Result<TopicRepetitionStatistics>
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/data/source/TopicsRepetitionsRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/data/source/TopicsRepetitionsRemoteDataSource.kt
@@ -4,6 +4,6 @@ import org.hyperskill.app.topics_repetitions.domain.model.TopicRepetition
 import org.hyperskill.app.topics_repetitions.domain.model.TopicRepetitionStatistics
 
 interface TopicsRepetitionsRemoteDataSource {
-    suspend fun getTopicsRepetitions(pageSize: Int, page: Int): Result<List<TopicRepetition>>
+    suspend fun getTopicsRepetitions(pageSize: Int, page: Int, isInCurrentTrack: Boolean): Result<List<TopicRepetition>>
     suspend fun getTopicsRepetitionStatistics(): Result<TopicRepetitionStatistics>
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/domain/interactor/TopicsRepetitionsInteractor.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/domain/interactor/TopicsRepetitionsInteractor.kt
@@ -7,8 +7,12 @@ import org.hyperskill.app.topics_repetitions.domain.repository.TopicsRepetitions
 class TopicsRepetitionsInteractor(
     private val topicsRepetitionsRepository: TopicsRepetitionsRepository
 ) {
-    suspend fun getTopicsRepetitions(pageSize: Int, page: Int = 1): Result<List<TopicRepetition>> =
-        topicsRepetitionsRepository.getTopicsRepetitions(pageSize, page)
+    suspend fun getTopicsRepetitions(
+        pageSize: Int,
+        page: Int = 1,
+        isInCurrentTrack: Boolean = true
+    ): Result<List<TopicRepetition>> =
+        topicsRepetitionsRepository.getTopicsRepetitions(pageSize, page, isInCurrentTrack)
 
     suspend fun getTopicsRepetitionStatistics(): Result<TopicRepetitionStatistics> =
         topicsRepetitionsRepository.getTopicsRepetitionStatistics()

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/domain/interactor/TopicsRepetitionsInteractor.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/domain/interactor/TopicsRepetitionsInteractor.kt
@@ -14,6 +14,6 @@ class TopicsRepetitionsInteractor(
     ): Result<List<TopicRepetition>> =
         topicsRepetitionsRepository.getTopicsRepetitions(pageSize, page, isInCurrentTrack)
 
-    suspend fun getTopicsRepetitionStatistics(): Result<TopicRepetitionStatistics> =
-        topicsRepetitionsRepository.getTopicsRepetitionStatistics()
+    suspend fun getTopicsRepetitionStatistics(isInCurrentTrack: Boolean = true): Result<TopicRepetitionStatistics> =
+        topicsRepetitionsRepository.getTopicsRepetitionStatistics(isInCurrentTrack)
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/domain/repository/TopicsRepetitionsRepository.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/domain/repository/TopicsRepetitionsRepository.kt
@@ -5,5 +5,5 @@ import org.hyperskill.app.topics_repetitions.domain.model.TopicRepetitionStatist
 
 interface TopicsRepetitionsRepository {
     suspend fun getTopicsRepetitions(pageSize: Int, page: Int, isInCurrentTrack: Boolean): Result<List<TopicRepetition>>
-    suspend fun getTopicsRepetitionStatistics(): Result<TopicRepetitionStatistics>
+    suspend fun getTopicsRepetitionStatistics(isInCurrentTrack: Boolean): Result<TopicRepetitionStatistics>
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/domain/repository/TopicsRepetitionsRepository.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/domain/repository/TopicsRepetitionsRepository.kt
@@ -4,6 +4,6 @@ import org.hyperskill.app.topics_repetitions.domain.model.TopicRepetition
 import org.hyperskill.app.topics_repetitions.domain.model.TopicRepetitionStatistics
 
 interface TopicsRepetitionsRepository {
-    suspend fun getTopicsRepetitions(pageSize: Int, page: Int): Result<List<TopicRepetition>>
+    suspend fun getTopicsRepetitions(pageSize: Int, page: Int, isInCurrentTrack: Boolean): Result<List<TopicRepetition>>
     suspend fun getTopicsRepetitionStatistics(): Result<TopicRepetitionStatistics>
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/remote/TopicsRepetitionsRemoteDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/remote/TopicsRepetitionsRemoteDataSourceImpl.kt
@@ -17,6 +17,11 @@ import org.hyperskill.app.topics_repetitions.remote.model.TopicsRepetitionsRespo
 internal class TopicsRepetitionsRemoteDataSourceImpl(
     private val httpClient: HttpClient
 ) : TopicsRepetitionsRemoteDataSource {
+
+    companion object {
+        private const val PARAM_IS_IN_CURRENT_TRACK = "is_in_current_track"
+    }
+
     override suspend fun getTopicsRepetitions(
         pageSize: Int,
         page: Int,
@@ -27,14 +32,15 @@ internal class TopicsRepetitionsRemoteDataSourceImpl(
                 contentType(ContentType.Application.Json)
                 parameterPageSize(pageSize)
                 parameterPage(page)
-                parameter("is_in_current_track", isInCurrentTrack)
+                parameter(PARAM_IS_IN_CURRENT_TRACK, isInCurrentTrack)
             }.body<TopicsRepetitionsResponse>().topicsRepetitions
         }
 
-    override suspend fun getTopicsRepetitionStatistics(): Result<TopicRepetitionStatistics> =
+    override suspend fun getTopicsRepetitionStatistics(isInCurrentTrack: Boolean): Result<TopicRepetitionStatistics> =
         kotlin.runCatching {
             httpClient.get("/api/topics-repetition/statistics") {
                 contentType(ContentType.Application.Json)
+                parameter(PARAM_IS_IN_CURRENT_TRACK, isInCurrentTrack)
             }.body<TopicsRepetitionStatisticsResponse>().topicsRepetitionStatistics.first()
         }
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/remote/TopicsRepetitionsRemoteDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/topics_repetitions/remote/TopicsRepetitionsRemoteDataSourceImpl.kt
@@ -3,6 +3,7 @@ package org.hyperskill.app.topics_repetitions.remote
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import io.ktor.client.request.parameter
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import org.hyperskill.app.network.remote.parameterPage
@@ -13,15 +14,20 @@ import org.hyperskill.app.topics_repetitions.domain.model.TopicRepetitionStatist
 import org.hyperskill.app.topics_repetitions.remote.model.TopicsRepetitionStatisticsResponse
 import org.hyperskill.app.topics_repetitions.remote.model.TopicsRepetitionsResponse
 
-class TopicsRepetitionsRemoteDataSourceImpl(
+internal class TopicsRepetitionsRemoteDataSourceImpl(
     private val httpClient: HttpClient
 ) : TopicsRepetitionsRemoteDataSource {
-    override suspend fun getTopicsRepetitions(pageSize: Int, page: Int): Result<List<TopicRepetition>> =
+    override suspend fun getTopicsRepetitions(
+        pageSize: Int,
+        page: Int,
+        isInCurrentTrack: Boolean
+    ): Result<List<TopicRepetition>> =
         kotlin.runCatching {
             httpClient.get("/api/topics-repetition") {
                 contentType(ContentType.Application.Json)
                 parameterPageSize(pageSize)
                 parameterPage(page)
+                parameter("is_in_current_track", isInCurrentTrack)
             }.body<TopicsRepetitionsResponse>().topicsRepetitions
         }
 


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1182](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1182)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

- Use `is_in_current_track` param in `/api/topics-repetition` and `/api/topics-repetition/statistics`