### PR TITLE
ALTAPPS-1196: Add difference in analytical event for start practicing button

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_theory/view/fragment/StepTheoryFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_theory/view/fragment/StepTheoryFragment.kt
@@ -91,8 +91,16 @@ class StepTheoryFragment : Fragment(R.layout.fragment_step_theory), StepCompleti
             requireRouter().exit()
         }
 
-        setupStarPracticeButton(viewBinding.stepTheoryPracticeActionBeginning, isPracticingAvailable)
-        setupStarPracticeButton(viewBinding.stepTheoryPracticeActionEnd, isPracticingAvailable)
+        setupStarPracticeButton(
+            button = viewBinding.stepTheoryPracticeActionBeginning,
+            isPracticingAvailable = isPracticingAvailable,
+            isLocatedAtBeginning = true
+        )
+        setupStarPracticeButton(
+            button = viewBinding.stepTheoryPracticeActionEnd,
+            isPracticingAvailable = isPracticingAvailable,
+            isLocatedAtBeginning = false
+        )
 
         renderSecondsToComplete(step.secondsToComplete)
 
@@ -111,11 +119,15 @@ class StepTheoryFragment : Fragment(R.layout.fragment_step_theory), StepCompleti
         // setupCommentStatisticsRecyclerView()
     }
 
-    private fun setupStarPracticeButton(button: MaterialButton, isPracticingAvailable: Boolean) {
+    private fun setupStarPracticeButton(
+        button: MaterialButton,
+        isPracticingAvailable: Boolean,
+        isLocatedAtBeginning: Boolean
+    ) {
         button.isVisible = isPracticingAvailable
         button.setOnClickListener {
             parentOfType(StepCompletionHost::class.java)
-                ?.onNewMessage(StepCompletionFeature.Message.StartPracticingClicked)
+                ?.onNewMessage(StepCompletionFeature.Message.StartPracticingClicked(isLocatedAtBeginning))
         }
     }
 

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/StepViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/StepViewModel.swift
@@ -65,10 +65,10 @@ final class StepViewModel: FeatureViewModel<StepFeatureState, StepFeatureMessage
         viewDataMapper.mapStepToViewData(step)
     }
 
-    func doStartPracticing() {
+    func doStartPracticing(isLocatedAtBeginning: Bool) {
         onNewMessage(
             StepFeatureMessageStepCompletionMessage(
-                message: StepCompletionFeatureMessageStartPracticingClicked()
+                message: StepCompletionFeatureMessageStartPracticingClicked(isLocatedAtBeginning: isLocatedAtBeginning)
             )
         )
     }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/Views/StepTheoryContentView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/Views/StepTheoryContentView.swift
@@ -21,7 +21,7 @@ struct StepTheoryContentView: View {
             VStack(alignment: .leading, spacing: appearance.interItemSpacing) {
                 StepHeaderView(timeToComplete: viewData.formattedTimeToComplete)
 
-                buildStartPracticingButton(isFilled: false)
+                buildStartPracticingButton(isLocatedAtBeginning: true)
 
                 LatexView(
                     text: viewData.text,
@@ -31,7 +31,7 @@ struct StepTheoryContentView: View {
                     }
                 )
 
-                buildStartPracticingButton(isFilled: true)
+                buildStartPracticingButton(isLocatedAtBeginning: false)
             }
             .padding()
         }
@@ -43,32 +43,32 @@ struct StepTheoryContentView: View {
 extension StepTheoryContentView {
     struct StartPracticingButton {
         let isLoading: Bool
-        let action: () -> Void
+        let action: (Bool) -> Void
     }
 
     @ViewBuilder
-    private func buildStartPracticingButton(isFilled: Bool) -> some View {
+    private func buildStartPracticingButton(isLocatedAtBeginning: Bool) -> some View {
         if let startPracticingButton, isStepTextContentLoaded {
             StepActionButton(
                 title: Strings.Step.startPracticing,
-                style: isFilled ? .violetFilled : .violetOutline,
+                style: isLocatedAtBeginning ? .violetOutline : .violetFilled,
                 isLoading: startPracticingButton.isLoading,
-                onClick: startPracticingButton.action
+                onClick: {
+                    startPracticingButton.action(isLocatedAtBeginning)
+                }
             )
         }
     }
 }
 
 #if DEBUG
-struct StepTheoryContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        StepTheoryContentView(
-            viewData: .placeholder,
-            startPracticingButton: StepTheoryContentView.StartPracticingButton(
-                isLoading: false,
-                action: {}
-            )
+#Preview {
+    StepTheoryContentView(
+        viewData: .placeholder,
+        startPracticingButton: StepTheoryContentView.StartPracticingButton(
+            isLoading: false,
+            action: { _ in }
         )
-    }
+    )
 }
 #endif

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_completion/domain/analytic/StepCompletionClickedStartPracticingHyperskillAnalyticEvent.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_completion/domain/analytic/StepCompletionClickedStartPracticingHyperskillAnalyticEvent.kt
@@ -15,16 +15,27 @@ import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticTar
  *     "route": "/learn/step/1",
  *     "action": "click",
  *     "part": "actions",
- *     "target": "start_practicing"
+ *     "target": "start_practicing",
+ *     "context":
+ *     {
+ *         "is_located_at_beginning": true
+ *     }
  * }
  * ```
+ *
+ * @param route A step route where the event occurred.
+ * @param isLocatedAtBeginning A flag indicating whether the start practicing button is located at the beginning
+ * of the step screen.
+ *
  * @see HyperskillAnalyticEvent
  */
 class StepCompletionClickedStartPracticingHyperskillAnalyticEvent(
-    route: HyperskillAnalyticRoute
+    route: HyperskillAnalyticRoute,
+    isLocatedAtBeginning: Boolean
 ) : HyperskillAnalyticEvent(
-    route,
-    HyperskillAnalyticAction.CLICK,
-    HyperskillAnalyticPart.ACTIONS,
-    HyperskillAnalyticTarget.START_PRACTICING
+    route = route,
+    action = HyperskillAnalyticAction.CLICK,
+    part = HyperskillAnalyticPart.ACTIONS,
+    target = HyperskillAnalyticTarget.START_PRACTICING,
+    context = mapOf(StepCompletionHyperskillAnalyticParams.PARAM_IS_LOCATED_AT_BEGINNING to isLocatedAtBeginning)
 )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_completion/domain/analytic/StepCompletionHyperskillAnalyticParams.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_completion/domain/analytic/StepCompletionHyperskillAnalyticParams.kt
@@ -2,4 +2,5 @@ package org.hyperskill.app.step_completion.domain.analytic
 
 object StepCompletionHyperskillAnalyticParams {
     const val PARAM_STREAK = "streak"
+    const val PARAM_IS_LOCATED_AT_BEGINNING = "is_located_at_beginning"
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_completion/presentation/StepCompletionFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_completion/presentation/StepCompletionFeature.kt
@@ -62,7 +62,7 @@ object StepCompletionFeature {
     }
 
     sealed interface Message {
-        object StartPracticingClicked : Message
+        data class StartPracticingClicked(val isLocatedAtBeginning: Boolean) : Message
 
         object ContinuePracticingClicked : Message
 

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_completion/presentation/StepCompletionReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_completion/presentation/StepCompletionReducer.kt
@@ -38,7 +38,8 @@ class StepCompletionReducer(private val stepRoute: StepRoute) : StateReducer<Sta
                     state.copy(isPracticingLoading = true) to setOf(
                         Action.LogAnalyticEvent(
                             StepCompletionClickedStartPracticingHyperskillAnalyticEvent(
-                                route = stepRoute.analyticRoute
+                                route = stepRoute.analyticRoute,
+                                isLocatedAtBeginning = message.isLocatedAtBeginning
                             )
                         ),
                         when (state.startPracticingButtonAction) {

--- a/shared/src/commonTest/kotlin/org/hyperskill/step_completion/StepCompletionTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/step_completion/StepCompletionTest.kt
@@ -24,7 +24,7 @@ class StepCompletionTest {
             val reducer = StepCompletionReducer(stepRoute)
             val (_, actions) = reducer.reduce(
                 StepCompletionFeature.createState(Step.stub(stepId), stepRoute),
-                StepCompletionFeature.Message.StartPracticingClicked
+                StepCompletionFeature.Message.StartPracticingClicked(isLocatedAtBeginning = true)
             )
             assertTrue {
                 actions.contains(StepCompletionFeature.Action.ViewAction.NavigateTo.Back)


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1196](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1196)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] New analytics events are documented;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

- Adds `is_located_at_beginning` flag to the start practicing button click event