### PR TITLE
ALTAPPS-968: Shared check for platform type when sending push token on app startup

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/main/injection/AppFeatureBuilder.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/main/injection/AppFeatureBuilder.kt
@@ -3,7 +3,6 @@ package org.hyperskill.app.main.injection
 import co.touchlab.kermit.Logger
 import org.hyperskill.app.auth.domain.interactor.AuthInteractor
 import org.hyperskill.app.core.domain.BuildVariant
-import org.hyperskill.app.core.domain.platform.Platform
 import org.hyperskill.app.core.injection.StateRepositoriesComponent
 import org.hyperskill.app.core.presentation.ActionDispatcherOptions
 import org.hyperskill.app.logging.presentation.wrapWithLogger
@@ -51,15 +50,13 @@ internal object AppFeatureBuilder {
         purchaseInteractor: PurchaseInteractor,
         currentSubscriptionStateRepository: CurrentSubscriptionStateRepository,
         subscriptionsInteractor: SubscriptionsInteractor,
-        platform: Platform,
         logger: Logger,
         buildVariant: BuildVariant
     ): Feature<State, Message, Action> {
         val appReducer = AppReducer(
             streakRecoveryReducer = streakRecoveryReducer,
             notificationClickHandlingReducer = clickedNotificationReducer,
-            welcomeOnboardingReducer = welcomeOnboardingReducer,
-            platformType = platform.platformType
+            welcomeOnboardingReducer = welcomeOnboardingReducer
         ).wrapWithLogger(buildVariant, logger, LOG_TAG)
 
         val appActionDispatcher = AppActionDispatcher(

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/main/injection/MainComponentImpl.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/main/injection/MainComponentImpl.kt
@@ -38,7 +38,6 @@ internal class MainComponentImpl(private val appGraph: AppGraph) : MainComponent
             purchaseInteractor = appGraph.buildPurchaseComponent().purchaseInteractor,
             currentSubscriptionStateRepository = appGraph.stateRepositoriesComponent.currentSubscriptionStateRepository,
             subscriptionsInteractor = appGraph.subscriptionDataComponent.subscriptionsInteractor,
-            platform = appGraph.commonComponent.platform,
             logger = appGraph.loggerComponent.logger,
             buildVariant = appGraph.commonComponent.buildKonfig.buildVariant
         )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/main/presentation/AppReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/main/presentation/AppReducer.kt
@@ -1,7 +1,6 @@
 package org.hyperskill.app.main.presentation
 
 import org.hyperskill.app.auth.domain.model.UserDeauthorized
-import org.hyperskill.app.core.domain.platform.PlatformType
 import org.hyperskill.app.main.presentation.AppFeature.Action
 import org.hyperskill.app.main.presentation.AppFeature.InternalAction
 import org.hyperskill.app.main.presentation.AppFeature.InternalMessage
@@ -28,8 +27,7 @@ private typealias ReducerResult = Pair<State, Set<Action>>
 internal class AppReducer(
     private val streakRecoveryReducer: StreakRecoveryReducer,
     private val notificationClickHandlingReducer: NotificationClickHandlingReducer,
-    private val welcomeOnboardingReducer: WelcomeOnboardingReducer,
-    private val platformType: PlatformType
+    private val welcomeOnboardingReducer: WelcomeOnboardingReducer
 ) : StateReducer<State, Message, Action> {
 
     companion object {
@@ -157,8 +155,7 @@ internal class AppReducer(
                         addAll(
                             getOnAuthorizedAppStartUpActions(
                                 profileId = message.profile.id,
-                                subscription = message.subscription,
-                                platformType = platformType
+                                subscription = message.subscription
                             )
                         )
                     } else {
@@ -323,21 +320,14 @@ internal class AppReducer(
 
     private fun getOnAuthorizedAppStartUpActions(
         profileId: Long,
-        subscription: Subscription?,
-        platformType: PlatformType
+        subscription: Subscription?
     ): Set<Action> =
         setOfNotNull(
             Action.IdentifyUserInSentry(userId = profileId),
             Action.IdentifyUserInPurchaseSdk(userId = profileId),
             subscription?.let(InternalAction::RefreshSubscriptionOnExpiration),
             Action.UpdateDailyLearningNotificationTime,
-            if (platformType == PlatformType.ANDROID) {
-                // Don't send push token on app startup for IOS
-                // because of custom token sending logic on IOS on app startup
-                Action.SendPushNotificationsToken
-            } else {
-                null
-            }
+            Action.SendPushNotificationsToken
         )
 
     private fun getNotAuthorizedAppStartUpActions(): Set<Action> =

--- a/shared/src/commonTest/kotlin/org/hyperskill/main/AppFeatureTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/main/AppFeatureTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertTrue
 import org.hyperskill.ResourceProviderStub
-import org.hyperskill.app.core.domain.platform.PlatformType
 import org.hyperskill.app.main.presentation.AppFeature
 import org.hyperskill.app.main.presentation.AppReducer
 import org.hyperskill.app.notification.click_handling.presentation.NotificationClickHandlingReducer
@@ -26,8 +25,7 @@ class AppFeatureTest {
     private val appReducer = AppReducer(
         streakRecoveryReducer = StreakRecoveryReducer(resourceProvider = ResourceProviderStub()),
         notificationClickHandlingReducer = NotificationClickHandlingReducer(),
-        welcomeOnboardingReducer = WelcomeOnboardingReducer(),
-        platformType = PlatformType.ANDROID
+        welcomeOnboardingReducer = WelcomeOnboardingReducer()
     )
 
     @Test


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-968](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-968)

**Checklist**

_Before Code Review:_

- [ ] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [ ] Sentry Performance Monitoring of screen loading is added for new screens;
- [ ] View analytics events are added for new screens;
- [ ] New analytics events are documented;
- [ ] All checks have been passed;
- [ ] Changes have been checked locally;
- [ ] Saved in the cache models serialization checked locally.

**Description**

- Removes check for `platformType == PlatformType.ANDROID` when sending push notification token on app startup