### PR TITLE
ALTAPPS-1220: iOS stick start practicing button to bottom in theory

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/Views/StepTheoryContentView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/Step/Views/StepTheoryContentView.swift
@@ -22,9 +22,6 @@ struct StepTheoryContentView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: appearance.interItemSpacing) {
                 StepHeaderView(timeToComplete: viewData.formattedTimeToComplete)
-
-                buildStartPracticingButton(isLocatedAtBeginning: true)
-
                 LatexView(
                     text: viewData.text,
                     configuration: .stepText(),
@@ -32,11 +29,10 @@ struct StepTheoryContentView: View {
                         isStepTextContentLoaded = true
                     }
                 )
-
-                buildStartPracticingButton(isLocatedAtBeginning: false)
             }
             .padding()
         }
+        .safeAreaInsetBottomCompatibility(footer)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(
@@ -57,17 +53,25 @@ extension StepTheoryContentView {
         let action: (Bool) -> Void
     }
 
-    @ViewBuilder
-    private func buildStartPracticingButton(isLocatedAtBeginning: Bool) -> some View {
+    @MainActor @ViewBuilder private var footer: some View {
         if let startPracticingButton, isStepTextContentLoaded {
             StepActionButton(
                 title: Strings.Step.startPracticing,
-                style: isLocatedAtBeginning ? .violetOutline : .violetFilled,
+                style: .violetFilled,
                 isLoading: startPracticingButton.isLoading,
                 onClick: {
-                    startPracticingButton.action(isLocatedAtBeginning)
+                    FeedbackGenerator(feedbackType: .selection).triggerFeedback()
+                    startPracticingButton.action(false)
                 }
             )
+            .padding()
+            .background(
+                TransparentBlurView()
+                    .edgesIgnoringSafeArea(.all)
+            )
+            .fixedSize(horizontal: false, vertical: true)
+        } else {
+            EmptyView()
         }
     }
 }


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1220](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1220)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

- Moves start practicing button to bottom safeAreaInset