### PR TITLE
ALTAPPS-1233: Shared AmplitudeAnalyticEventMapper update getType for VIEW events

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/analytic/domain/processor/AmplitudeAnalyticEventMapper.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/analytic/domain/processor/AmplitudeAnalyticEventMapper.kt
@@ -2,6 +2,7 @@ package org.hyperskill.app.analytic.domain.processor
 
 import org.hyperskill.app.analytic.domain.model.AnalyticEvent
 import org.hyperskill.app.analytic.domain.model.amplitude.AmplitudeAnalyticEvent
+import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticAction
 import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticEvent
 import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticKeys
 
@@ -19,6 +20,10 @@ object AmplitudeAnalyticEventMapper {
     private fun getType(analyticEvent: HyperskillAnalyticEvent): String =
         buildString {
             append(analyticEvent.action.actionName)
+            if (analyticEvent.action == HyperskillAnalyticAction.VIEW) {
+                append(' ')
+                append(analyticEvent.route.path)
+            }
             if (analyticEvent.part != null) {
                 append(' ')
                 append(analyticEvent.part.partName)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/analytic/domain/processor/AmplitudeAnalyticEventMapper.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/analytic/domain/processor/AmplitudeAnalyticEventMapper.kt
@@ -5,8 +5,11 @@ import org.hyperskill.app.analytic.domain.model.amplitude.AmplitudeAnalyticEvent
 import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticAction
 import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticEvent
 import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticKeys
+import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticRoute
 
 object AmplitudeAnalyticEventMapper {
+    private const val VIEW_STEP_ROUTE_TYPE_NAME = "step"
+
     fun map(analyticEvent: AnalyticEvent): AmplitudeAnalyticEvent? =
         when (analyticEvent) {
             is HyperskillAnalyticEvent -> AmplitudeAnalyticEvent(
@@ -20,9 +23,9 @@ object AmplitudeAnalyticEventMapper {
     private fun getType(analyticEvent: HyperskillAnalyticEvent): String =
         buildString {
             append(analyticEvent.action.actionName)
-            if (analyticEvent.action == HyperskillAnalyticAction.VIEW) {
+            getTypeRoutePath(analyticEvent)?.let {
                 append(' ')
-                append(analyticEvent.route.path)
+                append(it)
             }
             if (analyticEvent.part != null) {
                 append(' ')
@@ -32,6 +35,38 @@ object AmplitudeAnalyticEventMapper {
                 append(' ')
                 append(analyticEvent.target.targetName)
             }
+        }
+
+    private fun getTypeRoutePath(analyticEvent: HyperskillAnalyticEvent): String? =
+        if (analyticEvent.action == HyperskillAnalyticAction.VIEW) {
+            when (analyticEvent.route) {
+                is HyperskillAnalyticRoute.Learn.Step,
+                is HyperskillAnalyticRoute.Learn.Daily,
+                is HyperskillAnalyticRoute.Projects.Stages.Implement,
+                is HyperskillAnalyticRoute.Repeat.Step,
+                is HyperskillAnalyticRoute.Repeat.Step.Theory ->
+                    VIEW_STEP_ROUTE_TYPE_NAME
+
+                is HyperskillAnalyticRoute.Repeat,
+                is HyperskillAnalyticRoute.AppLaunchFirstTime,
+                is HyperskillAnalyticRoute.Debug,
+                is HyperskillAnalyticRoute.Home,
+                is HyperskillAnalyticRoute.IosSpringBoard,
+                is HyperskillAnalyticRoute.Leaderboard,
+                is HyperskillAnalyticRoute.Login,
+                is HyperskillAnalyticRoute.Onboarding,
+                is HyperskillAnalyticRoute.Profile,
+                is HyperskillAnalyticRoute.Progress,
+                is HyperskillAnalyticRoute.Projects.SelectProjectDetails,
+                is HyperskillAnalyticRoute.Search,
+                is HyperskillAnalyticRoute.StudyPlan,
+                is HyperskillAnalyticRoute.Tracks,
+                HyperskillAnalyticRoute.Paywall,
+                HyperskillAnalyticRoute.None ->
+                    analyticEvent.route.path
+            }
+        } else {
+            null
         }
 
     private fun getParams(analyticEvent: HyperskillAnalyticEvent): Map<String, Any> =

--- a/shared/src/commonTest/kotlin/org/hyperskill/analytic/domain/processor/AmplitudeAnalyticEventMapperTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/analytic/domain/processor/AmplitudeAnalyticEventMapperTest.kt
@@ -1,0 +1,89 @@
+package org.hyperskill.analytic.domain.processor
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.hyperskill.app.analytic.domain.model.amplitude.AmplitudeAnalyticEvent
+import org.hyperskill.app.analytic.domain.model.apps_flyer.AppsFlyerAnalyticEvent
+import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticAction
+import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticEvent
+import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticKeys
+import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticPart
+import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticRoute
+import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticTarget
+import org.hyperskill.app.analytic.domain.processor.AmplitudeAnalyticEventMapper
+
+class AmplitudeAnalyticEventMapperTest {
+    object TestViewHyperskillAnalyticEvent : HyperskillAnalyticEvent(
+        route = HyperskillAnalyticRoute.Debug(),
+        action = HyperskillAnalyticAction.VIEW
+    )
+
+    class TestClickHyperskillAnalyticEvent(
+        flag: Boolean
+    ) : HyperskillAnalyticEvent(
+        route = HyperskillAnalyticRoute.Debug(),
+        action = HyperskillAnalyticAction.CLICK,
+        part = HyperskillAnalyticPart.MAIN,
+        target = HyperskillAnalyticTarget.DEBUG,
+        context = mapOf(PARAM_FLAG to flag)
+    ) {
+        companion object {
+            const val PARAM_FLAG = "flag"
+        }
+    }
+
+    @Test
+    fun `map should return AmplitudeAnalyticEvent when HyperskillAnalyticEvent is provided`() {
+        val actual = AmplitudeAnalyticEventMapper.map(TestViewHyperskillAnalyticEvent)
+        assertNotNull(actual)
+    }
+
+    @Test
+    fun `map should return same AmplitudeAnalyticEvent when AmplitudeAnalyticEvent is provided`() {
+        val amplitudeEvent = AmplitudeAnalyticEvent(
+            name = "testName",
+            params = mapOf("key" to "value")
+        )
+
+        val actual = AmplitudeAnalyticEventMapper.map(amplitudeEvent)
+
+        assertEquals(amplitudeEvent, actual)
+    }
+
+    @Test
+    fun `map should return null when neither HyperskillAnalyticEvent nor AmplitudeAnalyticEvent is provided`() {
+        val otherEvent = AppsFlyerAnalyticEvent(name = "testName")
+
+        val result = AmplitudeAnalyticEventMapper.map(otherEvent)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `map should include path in name when HyperskillAnalyticEvent with VIEW action is provided`() {
+        val hyperskillEvent = TestViewHyperskillAnalyticEvent
+
+        val actual = AmplitudeAnalyticEventMapper.map(TestViewHyperskillAnalyticEvent)
+
+        assertTrue(actual!!.name.contains(hyperskillEvent.route.path))
+    }
+
+    @Test
+    fun `map should correctly transform TestClickHyperskillAnalyticEvent to AmplitudeAnalyticEvent`() {
+        val testClickEvent = TestClickHyperskillAnalyticEvent(flag = true)
+
+        val actual = AmplitudeAnalyticEventMapper.map(testClickEvent)!!
+
+        assertEquals("click main debug", actual.name)
+        assertEquals(
+            mapOf(
+                HyperskillAnalyticKeys.PARAM_ROUTE to "/debug",
+                TestClickHyperskillAnalyticEvent.PARAM_FLAG to true
+            ),
+            actual.params
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/org/hyperskill/analytic/domain/processor/AmplitudeAnalyticEventMapperTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/analytic/domain/processor/AmplitudeAnalyticEventMapperTest.kt
@@ -2,7 +2,6 @@ package org.hyperskill.analytic.domain.processor
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.hyperskill.app.analytic.domain.model.amplitude.AmplitudeAnalyticEvent
@@ -40,7 +39,7 @@ class AmplitudeAnalyticEventMapperTest {
     @Test
     fun `map should return AmplitudeAnalyticEvent when HyperskillAnalyticEvent is provided`() {
         val actual = AmplitudeAnalyticEventMapper.map(TestViewHyperskillAnalyticEvent())
-        assertNotNull(actual)
+        assertTrue(actual is AmplitudeAnalyticEvent)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/hyperskill/analytic/domain/processor/AmplitudeAnalyticEventMapperTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/analytic/domain/processor/AmplitudeAnalyticEventMapperTest.kt
@@ -16,8 +16,10 @@ import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticTar
 import org.hyperskill.app.analytic.domain.processor.AmplitudeAnalyticEventMapper
 
 class AmplitudeAnalyticEventMapperTest {
-    object TestViewHyperskillAnalyticEvent : HyperskillAnalyticEvent(
-        route = HyperskillAnalyticRoute.Debug(),
+    class TestViewHyperskillAnalyticEvent(
+        route: HyperskillAnalyticRoute = HyperskillAnalyticRoute.Debug()
+    ) : HyperskillAnalyticEvent(
+        route = route,
         action = HyperskillAnalyticAction.VIEW
     )
 
@@ -37,7 +39,7 @@ class AmplitudeAnalyticEventMapperTest {
 
     @Test
     fun `map should return AmplitudeAnalyticEvent when HyperskillAnalyticEvent is provided`() {
-        val actual = AmplitudeAnalyticEventMapper.map(TestViewHyperskillAnalyticEvent)
+        val actual = AmplitudeAnalyticEventMapper.map(TestViewHyperskillAnalyticEvent())
         assertNotNull(actual)
     }
 
@@ -64,9 +66,9 @@ class AmplitudeAnalyticEventMapperTest {
 
     @Test
     fun `map should include path in name when HyperskillAnalyticEvent with VIEW action is provided`() {
-        val hyperskillEvent = TestViewHyperskillAnalyticEvent
+        val hyperskillEvent = TestViewHyperskillAnalyticEvent()
 
-        val actual = AmplitudeAnalyticEventMapper.map(TestViewHyperskillAnalyticEvent)
+        val actual = AmplitudeAnalyticEventMapper.map(hyperskillEvent)
 
         assertTrue(actual!!.name.contains(hyperskillEvent.route.path))
     }
@@ -85,5 +87,38 @@ class AmplitudeAnalyticEventMapperTest {
             ),
             actual.params
         )
+    }
+
+    @Test
+    fun `map should correctly set name for view step screens`() {
+        val events = listOf(
+            TestViewHyperskillAnalyticEvent(
+                route = HyperskillAnalyticRoute.Learn.Step(1L)
+            ),
+            TestViewHyperskillAnalyticEvent(
+                route = HyperskillAnalyticRoute.Learn.Daily(1L)
+            ),
+            TestViewHyperskillAnalyticEvent(
+                route = HyperskillAnalyticRoute.Projects.Stages.Implement(
+                    projectId = 1L,
+                    stageId = 2L
+                )
+            ),
+            TestViewHyperskillAnalyticEvent(
+                route = HyperskillAnalyticRoute.Repeat.Step(1L)
+            ),
+            TestViewHyperskillAnalyticEvent(
+                route = HyperskillAnalyticRoute.Repeat.Step.Theory(1L)
+            )
+        )
+
+        events.forEach { event ->
+            val result = AmplitudeAnalyticEventMapper.map(event)!!
+            assertEquals(
+                "view step",
+                result.name,
+                "Event name should be 'view step' for VIEW action in step screens"
+            )
+        }
     }
 }


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1233](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1233)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

- Adds route path string to AmplitudeAnalyticEvent name for view events ([comment](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1233/Shared-Amplitude-analytic-tool-integration#focus=Comments-74-291687.0-0))