### PR TITLE
GitHub Actions: Bump actions/checkout from 4.1.1 to 4.1.4

### DIFF
--- a/.github/workflows/android_beta_deployment.yml
+++ b/.github/workflows/android_beta_deployment.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
 
       - name: Gradle Wrapper Validation
         uses: gradle/actions/wrapper-validation@v3
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
 
       - name: Setup CI
         id: setup

--- a/.github/workflows/android_deploy_to_firebase.yml
+++ b/.github/workflows/android_deploy_to_firebase.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
 
       - name: Setup CI
         id: setup

--- a/.github/workflows/android_deploy_to_firebase_manually.yml
+++ b/.github/workflows/android_deploy_to_firebase_manually.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
 
       - name: Gradle Wrapper Validation
         uses: gradle/actions/wrapper-validation@v3

--- a/.github/workflows/android_release_deployment.yml
+++ b/.github/workflows/android_release_deployment.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
         
       - name: Gradle Wrapper Validation
         uses: gradle/actions/wrapper-validation@v3
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.1.4
 
     - name: Setup CI
       id: setup

--- a/.github/workflows/automerge_into_release.yml
+++ b/.github/workflows/automerge_into_release.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/build_caches.yml
+++ b/.github/workflows/build_caches.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.1.4
 
     - name: Setup CI
       uses: ./.github/actions/setup-android
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
 
       - name: Setup CI
         id: setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
         
       - name: Gradle Wrapper Validation
         uses: gradle/actions/wrapper-validation@v3
@@ -64,7 +64,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.1.4
 
     - name: Setup CI
       uses: ./.github/actions/setup-android
@@ -91,7 +91,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.1.4
     
     - name: Setup CI
       uses: ./.github/actions/setup-android
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1.171.0
@@ -151,7 +151,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.1.4
 
     - name: Setup CI
       id: setup
@@ -175,7 +175,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.1.4
 
     - name: Setup CI
       id: setup
@@ -198,7 +198,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
 
       - name: Setup CI
         id: setup

--- a/.github/workflows/cleanup_pr_caches.yml
+++ b/.github/workflows/cleanup_pr_caches.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
 
       - name: Cleanup
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.1.4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/detect_changed_files_reusable_workflow.yml
+++ b/.github/workflows/detect_changed_files_reusable_workflow.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.1.4
 
     - name: Detect changes
       uses: dorny/paths-filter@v3.0.2

--- a/.github/workflows/gh_pages_analytics.yml
+++ b/.github/workflows/gh_pages_analytics.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
 
       - name: Setup CI
         uses: ./.github/actions/setup-android

--- a/.github/workflows/ios_beta_deployment.yml
+++ b/.github/workflows/ios_beta_deployment.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
 
       - name: Gradle Wrapper Validation
         uses: gradle/actions/wrapper-validation@v3
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
 
       - name: Setup CI
         id: setup

--- a/.github/workflows/ios_release_deployment.yml
+++ b/.github/workflows/ios_release_deployment.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
         
       - name: Gradle Wrapper Validation
         uses: gradle/actions/wrapper-validation@v3
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.1.4
 
     - name: Setup CI
       id: setup

--- a/.github/workflows/ios_unit_testing.yml
+++ b/.github/workflows/ios_unit_testing.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.1.4
       
     - name: Setup CI
       id: setup

--- a/.github/workflows/merge_main_into_develop.yml
+++ b/.github/workflows/merge_main_into_develop.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
**Description**
Bumps [actions/checkout](https://github.com/actions/checkout) from 4.1.1 to 4.1.4.
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v4.1.1...v4.1.4)