### PR TITLE
GitHub Actions: Bump ruby/setup-ruby from 1.171.0 to 1.175.1

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -62,7 +62,7 @@ runs:
 
     - name: Setup Ruby
       if: ${{ inputs.setup-ruby == 'true' }}
-      uses: ruby/setup-ruby@v1.171.0
+      uses: ruby/setup-ruby@v1.175.1
       with:
         ruby-version: '3.3.0'
         bundler-cache: true

--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -49,7 +49,7 @@ runs:
       shell: bash
 
     - name: Setup Ruby
-      uses: ruby/setup-ruby@v1.171.0
+      uses: ruby/setup-ruby@v1.175.1
       with:
         ruby-version: '3.3.0'
         bundler-cache: true

--- a/.github/workflows/automerge_into_release.yml
+++ b/.github/workflows/automerge_into_release.yml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.171.0
+        uses: ruby/setup-ruby@v1.175.1
         with:
           ruby-version: "3.3.0"
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@v4.1.4
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.171.0
+        uses: ruby/setup-ruby@v1.175.1
         with:
           ruby-version: '3.3.0'
           bundler-cache: true


### PR DESCRIPTION
**Description**

Bumps [ruby/setup-ruby](https://github.com/ruby/setup-ruby) from 1.171.0 to 1.175.1.
- [Release notes](https://github.com/ruby/setup-ruby/releases)
- [Commits](https://github.com/ruby/setup-ruby/compare/v1.171.0...v1.175.1)