### PR TITLE
iOS: Update dependencies

### DIFF
--- a/iosHyperskillApp/Podfile
+++ b/iosHyperskillApp/Podfile
@@ -36,7 +36,7 @@ target "iosHyperskillApp" do
   # ContentProcessor
   pod "Kanna", "5.3.0"
   pod "STRegex", "2.1.1"
-  pod "SnapKit", "5.6.0"
+  pod "SnapKit", "5.7.1"
   pod "Atributika", "4.10.1"
 
   # CodeEditor

--- a/iosHyperskillApp/Podfile
+++ b/iosHyperskillApp/Podfile
@@ -15,8 +15,8 @@ target "iosHyperskillApp" do
   pod "RevenueCat", "4.41.1"
 
   # Firebase
-  pod "Firebase/CoreOnly", "10.17.0"
-  pod "Firebase/Messaging", "10.17.0"
+  pod "Firebase/CoreOnly", "10.24.0"
+  pod "Firebase/Messaging", "10.24.0"
 
   # Analytics
   pod "AppsFlyerFramework", "6.14.2"

--- a/iosHyperskillApp/Podfile
+++ b/iosHyperskillApp/Podfile
@@ -28,7 +28,7 @@ target "iosHyperskillApp" do
   pod "IQKeyboardManagerSwift", "6.5.9"
   pod "SVProgressHUD", "2.3.1"
   pod "SkeletonUI", "1.0.11"
-  pod "lottie-ios", "4.3.3"
+  pod "lottie-ios", "4.4.3"
 
   pod "PanModal", :git => "https://github.com/ivan-magda/PanModal.git", :branch => "remove-presenting-appearance-transitions"
   pod "CombineSchedulers", :git => "https://github.com/ivan-magda/combine-schedulers.git", :branch => "main"

--- a/iosHyperskillApp/Podfile
+++ b/iosHyperskillApp/Podfile
@@ -12,7 +12,7 @@ target "iosHyperskillApp" do
   pod "SwiftLint", "0.54.0"
   pod "Sentry", "8.17.2"
 
-  pod "RevenueCat", "4.38.1"
+  pod "RevenueCat", "4.41.1"
 
   # Firebase
   pod "Firebase/CoreOnly", "10.17.0"

--- a/iosHyperskillApp/Podfile
+++ b/iosHyperskillApp/Podfile
@@ -26,7 +26,7 @@ target "iosHyperskillApp" do
   pod "GoogleSignIn", "7.1.0"
 
   pod "IQKeyboardManagerSwift", "6.5.9"
-  pod "SVProgressHUD", "2.2.5"
+  pod "SVProgressHUD", "2.3.1"
   pod "SkeletonUI", "1.0.11"
   pod "lottie-ios", "4.3.3"
 

--- a/iosHyperskillApp/Podfile
+++ b/iosHyperskillApp/Podfile
@@ -23,7 +23,7 @@ target "iosHyperskillApp" do
   pod "AmplitudeSwift", "1.4.5"
 
   # Social SDKs
-  pod "GoogleSignIn", "6.2.4"
+  pod "GoogleSignIn", "7.1.0"
 
   pod "IQKeyboardManagerSwift", "6.5.9"
   pod "SVProgressHUD", "2.2.5"

--- a/iosHyperskillApp/Podfile
+++ b/iosHyperskillApp/Podfile
@@ -34,7 +34,7 @@ target "iosHyperskillApp" do
   pod "CombineSchedulers", :git => "https://github.com/ivan-magda/combine-schedulers.git", :branch => "main"
 
   # ContentProcessor
-  pod "Kanna", "5.2.7"
+  pod "Kanna", "5.3.0"
   pod "STRegex", "2.1.1"
   pod "SnapKit", "5.6.0"
   pod "Atributika", "4.10.1"

--- a/iosHyperskillApp/Podfile.lock
+++ b/iosHyperskillApp/Podfile.lock
@@ -86,7 +86,7 @@ PODS:
     - Nuke (~> 10.5)
   - PanModal (1.2.7)
   - PromisesObjC (2.3.1)
-  - RevenueCat (4.38.1)
+  - RevenueCat (4.41.1)
   - Sentry (8.17.2):
     - Sentry/Core (= 8.17.2)
     - SentryPrivate (= 8.17.2)
@@ -116,7 +116,7 @@ DEPENDENCIES:
   - lottie-ios (= 4.3.3)
   - NukeUI (from `https://github.com/kean/NukeUI.git`, tag `0.8.3`)
   - PanModal (from `https://github.com/ivan-magda/PanModal.git`, branch `remove-presenting-appearance-transitions`)
-  - RevenueCat (= 4.38.1)
+  - RevenueCat (= 4.41.1)
   - Sentry (= 8.17.2)
   - shared (from `../shared`)
   - SkeletonUI (= 1.0.11)
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   NukeUI: 3c7ec7b299dd99707afdc783b436f39768b4493b
   PanModal: 3e16ead1a907fb06f4df3f13492fd00149fa4974
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
-  RevenueCat: f1b4bce353e676260eddc65a34c9fdf595adf2f4
+  RevenueCat: 1e7be26ae57d83bfd4191c9c4f1a01b3b409b215
   Sentry: 64a9f9c3637af913adcf53deced05bbe452d1410
   SentryPrivate: 024c6fed507ac39ae98e6d087034160f942920d5
   shared: 210f065b47c10083f8ccc49e665dec6d32c5b2d3
@@ -235,6 +235,6 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: c9ced0c1f9501abad699fbec362cc4af308e6e20
+PODFILE CHECKSUM: d362db5f0fae52bb3689fd80471a5714023ece84
 
 COCOAPODS: 1.15.2

--- a/iosHyperskillApp/Podfile.lock
+++ b/iosHyperskillApp/Podfile.lock
@@ -81,7 +81,7 @@ PODS:
   - GTMSessionFetcher/Core (3.4.1)
   - Highlightr (2.1.0)
   - IQKeyboardManagerSwift (6.5.9)
-  - Kanna (5.2.7)
+  - Kanna (5.3.0)
   - lottie-ios (4.4.3)
   - nanopb (2.30910.0):
     - nanopb/decode (= 2.30910.0)
@@ -122,7 +122,7 @@ DEPENDENCIES:
   - GoogleSignIn (= 7.1.0)
   - Highlightr (from `https://github.com/raspu/Highlightr.git`, branch `master`)
   - IQKeyboardManagerSwift (= 6.5.9)
-  - Kanna (= 5.2.7)
+  - Kanna (= 5.3.0)
   - lottie-ios (= 4.4.3)
   - NukeUI (from `https://github.com/kean/NukeUI.git`, tag `0.8.3`)
   - PanModal (from `https://github.com/ivan-magda/PanModal.git`, branch `remove-presenting-appearance-transitions`)
@@ -227,7 +227,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 8000756fc1c19d2e5697b90311f7832d2e33f6cd
   Highlightr: 683f05d5223cade533a78528a35c9f06e4caddf8
   IQKeyboardManagerSwift: 6e839c575c4aa1078d58a596e41244e77abe918f
-  Kanna: 01cfbddc127f5ff0963692f285fcbc8a9d62d234
+  Kanna: 6ecbd674bcbef2766a2acf80e99d1174440c5b9c
   lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
   Nuke: 279f17a599fd1c83cf51de5e0e1f2db143a287b0
@@ -245,6 +245,6 @@ SPEC CHECKSUMS:
   SVProgressHUD: 4837c74bdfe2e51e8821c397825996a8d7de6e22
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: 4895900b7afe53c85897af4e9b28acb0067ef7e2
+PODFILE CHECKSUM: 943b9a4c9bb61623e988d694af1b98ac0359c105
 
 COCOAPODS: 1.15.2

--- a/iosHyperskillApp/Podfile.lock
+++ b/iosHyperskillApp/Podfile.lock
@@ -103,7 +103,7 @@ PODS:
   - SentryPrivate (8.17.2)
   - shared (1.0)
   - SkeletonUI (1.0.11)
-  - SnapKit (5.6.0)
+  - SnapKit (5.7.1)
   - STRegex (2.1.1)
   - SVGKit (3.1.1):
     - CocoaLumberjack (~> 3.0)
@@ -130,7 +130,7 @@ DEPENDENCIES:
   - Sentry (= 8.17.2)
   - shared (from `../shared`)
   - SkeletonUI (= 1.0.11)
-  - SnapKit (= 5.6.0)
+  - SnapKit (= 5.7.1)
   - STRegex (= 2.1.1)
   - SVGKit (from `https://github.com/SVGKit/SVGKit.git`, branch `3.x`)
   - SVProgressHUD (= 2.3.1)
@@ -239,12 +239,12 @@ SPEC CHECKSUMS:
   SentryPrivate: 024c6fed507ac39ae98e6d087034160f942920d5
   shared: 210f065b47c10083f8ccc49e665dec6d32c5b2d3
   SkeletonUI: a5514a3877d39f28229c852a567660d0f7542330
-  SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
+  SnapKit: d612e99e678a2d3b95bf60b0705ed0a35c03484a
   STRegex: d49e88d0fe58538d3175fdd989bc1243b9be2a07
   SVGKit: 9bc0f0982df559e65b96f2150ff9c15a61e453ac
   SVProgressHUD: 4837c74bdfe2e51e8821c397825996a8d7de6e22
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: 943b9a4c9bb61623e988d694af1b98ac0359c105
+PODFILE CHECKSUM: 8f24d65a7649cacd54958b5876e959828eef321e
 
 COCOAPODS: 1.15.2

--- a/iosHyperskillApp/Podfile.lock
+++ b/iosHyperskillApp/Podfile.lock
@@ -82,7 +82,7 @@ PODS:
   - Highlightr (2.1.0)
   - IQKeyboardManagerSwift (6.5.9)
   - Kanna (5.2.7)
-  - lottie-ios (4.3.3)
+  - lottie-ios (4.4.3)
   - nanopb (2.30910.0):
     - nanopb/decode (= 2.30910.0)
     - nanopb/encode (= 2.30910.0)
@@ -123,7 +123,7 @@ DEPENDENCIES:
   - Highlightr (from `https://github.com/raspu/Highlightr.git`, branch `master`)
   - IQKeyboardManagerSwift (= 6.5.9)
   - Kanna (= 5.2.7)
-  - lottie-ios (= 4.3.3)
+  - lottie-ios (= 4.4.3)
   - NukeUI (from `https://github.com/kean/NukeUI.git`, tag `0.8.3`)
   - PanModal (from `https://github.com/ivan-magda/PanModal.git`, branch `remove-presenting-appearance-transitions`)
   - RevenueCat (= 4.41.1)
@@ -228,7 +228,7 @@ SPEC CHECKSUMS:
   Highlightr: 683f05d5223cade533a78528a35c9f06e4caddf8
   IQKeyboardManagerSwift: 6e839c575c4aa1078d58a596e41244e77abe918f
   Kanna: 01cfbddc127f5ff0963692f285fcbc8a9d62d234
-  lottie-ios: 25e7b2675dad5c3ddad369ac9baab03560c5bfdd
+  lottie-ios: fcb5e73e17ba4c983140b7d21095c834b3087418
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
   Nuke: 279f17a599fd1c83cf51de5e0e1f2db143a287b0
   NukeUI: 3c7ec7b299dd99707afdc783b436f39768b4493b
@@ -245,6 +245,6 @@ SPEC CHECKSUMS:
   SVProgressHUD: 4837c74bdfe2e51e8821c397825996a8d7de6e22
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: 6a12659596e5ad93739c0cb84f557044f30e5050
+PODFILE CHECKSUM: 4895900b7afe53c85897af4e9b28acb0067ef7e2
 
 COCOAPODS: 1.15.2

--- a/iosHyperskillApp/Podfile.lock
+++ b/iosHyperskillApp/Podfile.lock
@@ -2,11 +2,11 @@ PODS:
   - AmplitudeSwift (1.4.5):
     - AnalyticsConnector (~> 1.0.1)
   - AnalyticsConnector (1.0.3)
-  - AppAuth (1.6.2):
-    - AppAuth/Core (= 1.6.2)
-    - AppAuth/ExternalUserAgent (= 1.6.2)
-  - AppAuth/Core (1.6.2)
-  - AppAuth/ExternalUserAgent (1.6.2):
+  - AppAuth (1.7.5):
+    - AppAuth/Core (= 1.7.5)
+    - AppAuth/ExternalUserAgent (= 1.7.5)
+  - AppAuth/Core (1.7.5)
+  - AppAuth/ExternalUserAgent (1.7.5):
     - AppAuth/Core
   - AppsFlyerFramework (6.14.2):
     - AppsFlyerFramework/Main (= 6.14.2)
@@ -46,10 +46,10 @@ PODS:
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleSignIn (6.2.4):
-    - AppAuth (~> 1.5)
-    - GTMAppAuth (~> 1.3)
-    - GTMSessionFetcher/Core (< 3.0, >= 1.1)
+  - GoogleSignIn (7.1.0):
+    - AppAuth (< 2.0, >= 1.7.3)
+    - GTMAppAuth (< 5.0, >= 4.1.1)
+    - GTMSessionFetcher/Core (~> 3.3)
   - GoogleUtilities/AppDelegateSwizzler (7.13.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
@@ -75,10 +75,10 @@ PODS:
   - GoogleUtilities/UserDefaults (7.13.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GTMAppAuth (1.3.1):
-    - AppAuth/Core (~> 1.6)
-    - GTMSessionFetcher/Core (< 3.0, >= 1.5)
-  - GTMSessionFetcher/Core (2.3.0)
+  - GTMAppAuth (4.1.1):
+    - AppAuth/Core (~> 1.7)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3)
+  - GTMSessionFetcher/Core (3.4.1)
   - Highlightr (2.1.0)
   - IQKeyboardManagerSwift (6.5.9)
   - Kanna (5.2.7)
@@ -117,7 +117,7 @@ DEPENDENCIES:
   - CombineSchedulers (from `https://github.com/ivan-magda/combine-schedulers.git`, branch `main`)
   - Firebase/CoreOnly (= 10.24.0)
   - Firebase/Messaging (= 10.24.0)
-  - GoogleSignIn (= 6.2.4)
+  - GoogleSignIn (= 7.1.0)
   - Highlightr (from `https://github.com/raspu/Highlightr.git`, branch `master`)
   - IQKeyboardManagerSwift (= 6.5.9)
   - Kanna (= 5.2.7)
@@ -207,7 +207,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   AmplitudeSwift: 4daa595b157c73b9bc5f225f9b8faead90d044b3
   AnalyticsConnector: a53214d38ae22734c6266106c0492b37832633a9
-  AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
+  AppAuth: 501c04eda8a8d11f179dbe8637b7a91bb7e5d2fa
   AppsFlyerFramework: b3de9a49c6af8a8e38c44603e468b5e207f22466
   Atributika: 47e778507cfb3cd2c996278b0285221a62e97d71
   CocoaLumberjack: f8d89a516e7710fdb2e9b8f1560b16ec6040eef0
@@ -219,10 +219,10 @@ SPEC CHECKSUMS:
   FirebaseMessaging: 4d52717dd820707cc4eadec5eb981b4832ec8d5d
   Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
-  GoogleSignIn: 5651ce3a61e56ca864160e79b484cd9ed3f49b7a
+  GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
   GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152
-  GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
-  GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
+  GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
+  GTMSessionFetcher: 8000756fc1c19d2e5697b90311f7832d2e33f6cd
   Highlightr: 683f05d5223cade533a78528a35c9f06e4caddf8
   IQKeyboardManagerSwift: 6e839c575c4aa1078d58a596e41244e77abe918f
   Kanna: 01cfbddc127f5ff0963692f285fcbc8a9d62d234
@@ -243,6 +243,6 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: 19961bf4e3671b9fcf03cd1f26539f30b59b23c5
+PODFILE CHECKSUM: 7f8a0ca9a731edc65f42faa83ed57cf9116247b3
 
 COCOAPODS: 1.15.2

--- a/iosHyperskillApp/Podfile.lock
+++ b/iosHyperskillApp/Podfile.lock
@@ -107,7 +107,9 @@ PODS:
   - STRegex (2.1.1)
   - SVGKit (3.1.1):
     - CocoaLumberjack (~> 3.0)
-  - SVProgressHUD (2.2.5)
+  - SVProgressHUD (2.3.1):
+    - SVProgressHUD/Core (= 2.3.1)
+  - SVProgressHUD/Core (2.3.1)
   - SwiftLint (0.54.0)
 
 DEPENDENCIES:
@@ -131,7 +133,7 @@ DEPENDENCIES:
   - SnapKit (= 5.6.0)
   - STRegex (= 2.1.1)
   - SVGKit (from `https://github.com/SVGKit/SVGKit.git`, branch `3.x`)
-  - SVProgressHUD (= 2.2.5)
+  - SVProgressHUD (= 2.3.1)
   - SwiftLint (= 0.54.0)
 
 SPEC REPOS:
@@ -240,9 +242,9 @@ SPEC CHECKSUMS:
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
   STRegex: d49e88d0fe58538d3175fdd989bc1243b9be2a07
   SVGKit: 9bc0f0982df559e65b96f2150ff9c15a61e453ac
-  SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
+  SVProgressHUD: 4837c74bdfe2e51e8821c397825996a8d7de6e22
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: 7f8a0ca9a731edc65f42faa83ed57cf9116247b3
+PODFILE CHECKSUM: 6a12659596e5ad93739c0cb84f557044f30e5050
 
 COCOAPODS: 1.15.2

--- a/iosHyperskillApp/Podfile.lock
+++ b/iosHyperskillApp/Podfile.lock
@@ -16,57 +16,65 @@ PODS:
     - CocoaLumberjack/Core (= 3.8.2)
   - CocoaLumberjack/Core (3.8.2)
   - CombineSchedulers (0.8.0)
-  - Firebase/CoreOnly (10.17.0):
-    - FirebaseCore (= 10.17.0)
-  - Firebase/Messaging (10.17.0):
+  - Firebase/CoreOnly (10.24.0):
+    - FirebaseCore (= 10.24.0)
+  - Firebase/Messaging (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 10.17.0)
-  - FirebaseCore (10.17.0):
+    - FirebaseMessaging (~> 10.24.0)
+  - FirebaseCore (10.24.0):
     - FirebaseCoreInternal (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.17.0):
+    - GoogleUtilities/Environment (~> 7.12)
+    - GoogleUtilities/Logger (~> 7.12)
+  - FirebaseCoreInternal (10.24.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseInstallations (10.17.0):
+  - FirebaseInstallations (10.24.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (10.17.0):
+  - FirebaseMessaging (10.24.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
-    - GoogleDataTransport (~> 9.2)
+    - GoogleDataTransport (~> 9.3)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Reachability (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
-    - nanopb (< 2.30910.0, >= 2.30908.0)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
   - Gifu (3.3.1)
-  - GoogleDataTransport (9.2.5):
+  - GoogleDataTransport (9.4.1):
     - GoogleUtilities/Environment (~> 7.7)
-    - nanopb (< 2.30910.0, >= 2.30908.0)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleSignIn (6.2.4):
     - AppAuth (~> 1.5)
     - GTMAppAuth (~> 1.3)
     - GTMSessionFetcher/Core (< 3.0, >= 1.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.11.6):
+  - GoogleUtilities/AppDelegateSwizzler (7.13.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.11.6):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Environment (7.13.0):
+    - GoogleUtilities/Privacy
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.11.6):
+  - GoogleUtilities/Logger (7.13.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (7.11.6):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (7.13.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.11.6)"
-  - GoogleUtilities/Reachability (7.11.6):
+  - "GoogleUtilities/NSData+zlib (7.13.0)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (7.13.0)
+  - GoogleUtilities/Reachability (7.13.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.11.6):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/UserDefaults (7.13.0):
     - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
   - GTMAppAuth (1.3.1):
     - AppAuth/Core (~> 1.6)
     - GTMSessionFetcher/Core (< 3.0, >= 1.5)
@@ -75,17 +83,17 @@ PODS:
   - IQKeyboardManagerSwift (6.5.9)
   - Kanna (5.2.7)
   - lottie-ios (4.3.3)
-  - nanopb (2.30909.0):
-    - nanopb/decode (= 2.30909.0)
-    - nanopb/encode (= 2.30909.0)
-  - nanopb/decode (2.30909.0)
-  - nanopb/encode (2.30909.0)
+  - nanopb (2.30910.0):
+    - nanopb/decode (= 2.30910.0)
+    - nanopb/encode (= 2.30910.0)
+  - nanopb/decode (2.30910.0)
+  - nanopb/encode (2.30910.0)
   - Nuke (10.7.1)
   - NukeUI (0.8.1):
     - Gifu (~> 3.0)
     - Nuke (~> 10.5)
   - PanModal (1.2.7)
-  - PromisesObjC (2.3.1)
+  - PromisesObjC (2.4.0)
   - RevenueCat (4.41.1)
   - Sentry (8.17.2):
     - Sentry/Core (= 8.17.2)
@@ -107,8 +115,8 @@ DEPENDENCIES:
   - AppsFlyerFramework (= 6.14.2)
   - Atributika (= 4.10.1)
   - CombineSchedulers (from `https://github.com/ivan-magda/combine-schedulers.git`, branch `main`)
-  - Firebase/CoreOnly (= 10.17.0)
-  - Firebase/Messaging (= 10.17.0)
+  - Firebase/CoreOnly (= 10.24.0)
+  - Firebase/Messaging (= 10.24.0)
   - GoogleSignIn (= 6.2.4)
   - Highlightr (from `https://github.com/raspu/Highlightr.git`, branch `master`)
   - IQKeyboardManagerSwift (= 6.5.9)
@@ -204,26 +212,26 @@ SPEC CHECKSUMS:
   Atributika: 47e778507cfb3cd2c996278b0285221a62e97d71
   CocoaLumberjack: f8d89a516e7710fdb2e9b8f1560b16ec6040eef0
   CombineSchedulers: 80f670c732b4754eb011cd1147d9a08654b1c463
-  Firebase: f4ac0b02927af9253ae094d23deecf0890da7374
-  FirebaseCore: 534544dd98cabcf4bf8598d88ec683b02319a528
-  FirebaseCoreInternal: 2cf9202e226e3f78d2bf6d56c472686b935bfb7f
-  FirebaseInstallations: 9387bf15abfc69a714f54e54f74a251264fdb79b
-  FirebaseMessaging: 1367b28c0c83a63072af4a711328fcc2e6899902
+  Firebase: 91fefd38712feb9186ea8996af6cbdef41473442
+  FirebaseCore: 11dc8a16dfb7c5e3c3f45ba0e191a33ac4f50894
+  FirebaseCoreInternal: bcb5acffd4ea05e12a783ecf835f2210ce3dc6af
+  FirebaseInstallations: 8f581fca6478a50705d2bd2abd66d306e0f5736e
+  FirebaseMessaging: 4d52717dd820707cc4eadec5eb981b4832ec8d5d
   Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
-  GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
+  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleSignIn: 5651ce3a61e56ca864160e79b484cd9ed3f49b7a
-  GoogleUtilities: 202e7a9f5128accd11160fb9c19612de1911aa19
+  GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
   Highlightr: 683f05d5223cade533a78528a35c9f06e4caddf8
   IQKeyboardManagerSwift: 6e839c575c4aa1078d58a596e41244e77abe918f
   Kanna: 01cfbddc127f5ff0963692f285fcbc8a9d62d234
   lottie-ios: 25e7b2675dad5c3ddad369ac9baab03560c5bfdd
-  nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
+  nanopb: 438bc412db1928dac798aa6fd75726007be04262
   Nuke: 279f17a599fd1c83cf51de5e0e1f2db143a287b0
   NukeUI: 3c7ec7b299dd99707afdc783b436f39768b4493b
   PanModal: 3e16ead1a907fb06f4df3f13492fd00149fa4974
-  PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RevenueCat: 1e7be26ae57d83bfd4191c9c4f1a01b3b409b215
   Sentry: 64a9f9c3637af913adcf53deced05bbe452d1410
   SentryPrivate: 024c6fed507ac39ae98e6d087034160f942920d5
@@ -235,6 +243,6 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
 
-PODFILE CHECKSUM: d362db5f0fae52bb3689fd80471a5714023ece84
+PODFILE CHECKSUM: 19961bf4e3671b9fcf03cd1f26539f30b59b23c5
 
 COCOAPODS: 1.15.2

--- a/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
+++ b/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
@@ -260,6 +260,7 @@
 		2C7271282B6B92AD005628B0 /* PaywallFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7271272B6B92AD005628B0 /* PaywallFooterView.swift */; };
 		2C76136A2B99CBA500AE3204 /* ManageSubscriptionFeatureViewStateKsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7613692B99CBA500AE3204 /* ManageSubscriptionFeatureViewStateKsExtensions.swift */; };
 		2C772E7D28ABB4E500A58758 /* AppleIDSocialAuthSDKProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C772E7C28ABB4E500A58758 /* AppleIDSocialAuthSDKProvider.swift */; };
+		2C77E8B32BDBD80A0046E5D1 /* HTMLExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C77E8B22BDBD80A0046E5D1 /* HTMLExtractorTests.swift */; };
 		2C7802C5285C93F900082547 /* StepQuizActionButtonState+SubmissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7802C4285C93F900082547 /* StepQuizActionButtonState+SubmissionStatus.swift */; };
 		2C7822612942F9CF0067200F /* StreakBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7822602942F9CF0067200F /* StreakBarButtonItem.swift */; };
 		2C792324287B759500A3F61D /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C792323287B759500A3F61D /* StringExtensions.swift */; };
@@ -989,6 +990,7 @@
 		2C7271272B6B92AD005628B0 /* PaywallFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallFooterView.swift; sourceTree = "<group>"; };
 		2C7613692B99CBA500AE3204 /* ManageSubscriptionFeatureViewStateKsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionFeatureViewStateKsExtensions.swift; sourceTree = "<group>"; };
 		2C772E7C28ABB4E500A58758 /* AppleIDSocialAuthSDKProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIDSocialAuthSDKProvider.swift; sourceTree = "<group>"; };
+		2C77E8B22BDBD80A0046E5D1 /* HTMLExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLExtractorTests.swift; sourceTree = "<group>"; };
 		2C7802C4285C93F900082547 /* StepQuizActionButtonState+SubmissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StepQuizActionButtonState+SubmissionStatus.swift"; sourceTree = "<group>"; };
 		2C7822602942F9CF0067200F /* StreakBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreakBarButtonItem.swift; sourceTree = "<group>"; };
 		2C792323287B759500A3F61D /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
@@ -3655,6 +3657,7 @@
 		2CE7B48D2AB0A07300DCBE4D /* ContentProcessor */ = {
 			isa = PBXGroup;
 			children = (
+				2C77E8B22BDBD80A0046E5D1 /* HTMLExtractorTests.swift */,
 				2CE7B48E2AB0A09100DCBE4D /* HTMLStringTests.swift */,
 			);
 			path = ContentProcessor;
@@ -4572,6 +4575,7 @@
 				2C1F587E280D2F9200372A37 /* URLExtensionsTests.swift in Sources */,
 				2CA542272ACAE32A00EF24B5 /* IntrospectScrollViewTests.swift in Sources */,
 				2CE7B48F2AB0A09100DCBE4D /* HTMLStringTests.swift in Sources */,
+				2C77E8B32BDBD80A0046E5D1 /* HTMLExtractorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/ViewControllers/AppViewController.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/App/ViewControllers/AppViewController.swift
@@ -39,9 +39,7 @@ final class AppViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         viewModel.doLoadApp()
-        updateProgressHUDStyle()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -52,20 +50,6 @@ final class AppViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         viewModel.stopListening()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        view.performBlockIfAppearanceChanged(from: previousTraitCollection) {
-            updateProgressHUDStyle()
-        }
-    }
-
-    // MARK: Private API
-
-    private func updateProgressHUDStyle() {
-        ProgressHUD.updateStyle(isDark: view.isDarkInterfaceStyle)
     }
 }
 

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Services/Auth/Social/SDKs/GoogleSocialAuthSDKProvider.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Services/Auth/Social/SDKs/GoogleSocialAuthSDKProvider.swift
@@ -37,13 +37,14 @@ final class GoogleSocialAuthSDKProvider: SocialAuthSDKProvider {
             GIDSignIn.sharedInstance.signOut()
         }
 
+        GIDSignIn.sharedInstance.configuration = GIDConfiguration(
+            clientID: GoogleServiceInfo.authClientID,
+            serverClientID: GoogleServiceInfo.authServerClientID
+        )
+
         GIDSignIn.sharedInstance.signIn(
-            with: GIDConfiguration(
-                clientID: GoogleServiceInfo.authClientID,
-                serverClientID: GoogleServiceInfo.authServerClientID
-            ),
-            presenting: currentPresentedViewController
-        ) { user, error in
+            withPresenting: currentPresentedViewController
+        ) { result, error in
             if let error {
                 #if DEBUG
                 print("GoogleSocialAuthSDKProvider :: error = \(error.localizedDescription)")
@@ -53,13 +54,15 @@ final class GoogleSocialAuthSDKProvider: SocialAuthSDKProvider {
                 } else {
                     completion(.failure(.connectionError(originalError: error)))
                 }
-            } else if let serverAuthCode = user?.serverAuthCode {
+            } else if let serverAuthCode = result?.serverAuthCode {
                 #if DEBUG
                 print("GoogleSocialAuthSDKProvider :: success serverAuthCode = \(serverAuthCode)")
                 #endif
                 completion(.success(SocialAuthSDKResponse(authorizationCode: serverAuthCode)))
             } else {
+                #if DEBUG
                 print("GoogleSocialAuthSDKProvider :: error missing serverAuthCode")
+                #endif
                 completion(
                     .failure(.accessDenied(originalError: GoogleSocialAuthSDKProviderErrorReason.noServerAuthCode))
                 )

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Systems/ProgressHUD.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Systems/ProgressHUD.swift
@@ -7,12 +7,8 @@ enum ProgressHUD {
         SVProgressHUD.setMinimumDismissTimeInterval(0.5)
         SVProgressHUD.setGraceTimeInterval(0)
         SVProgressHUD.setDefaultMaskType(SVProgressHUDMaskType.clear)
-        SVProgressHUD.setDefaultStyle(SVProgressHUDStyle.light)
+        SVProgressHUD.setDefaultStyle(SVProgressHUDStyle.automatic)
         SVProgressHUD.setHapticsEnabled(true)
-    }
-
-    static func updateStyle(isDark: Bool) {
-        SVProgressHUD.setDefaultStyle(isDark ? .dark : .light)
     }
 
     static func setHapticsEnabled(_ isEnabled: Bool) {

--- a/iosHyperskillApp/iosHyperskillAppTests/FrameworksTests/ContentProcessor/HTMLExtractorTests.swift
+++ b/iosHyperskillApp/iosHyperskillAppTests/FrameworksTests/ContentProcessor/HTMLExtractorTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+
+@testable import iosHyperskillApp
+
+final class HTMLExtractorTests: XCTestCase {
+    func testThatHTMLExtractorNotCrashesWhenParsingStringWithWhitespacesAndNewlines() {
+        // Given
+        let characterSet = CharacterSet.whitespacesAndNewlines
+        var characters = [Character]()
+        for plane: UInt8 in 0...16 where characterSet.hasMember(inPlane: plane) {
+            for unicode in UInt32(plane) << 16 ..< UInt32(plane + 1) << 16 {
+                if let uniChar = UnicodeScalar(unicode), characterSet.contains(uniChar) {
+                    characters.append(Character(uniChar))
+                }
+            }
+        }
+        let strings = characters.map { String($0) }
+
+        let extractorType: HTMLExtractorProtocol.Type = HTMLExtractor.self
+
+        // When
+        let results = strings.map { string in
+            extractorType.extractAllTagsAttribute(tag: "a", attribute: "href", from: string)
+        }
+
+        // Then
+        results.forEach { result in
+            XCTAssertEqual(result, [])
+        }
+    }
+
+    func testThatHTMLExtractorAPIIsSafe() {
+        let content = """
+                    <html>
+                    <head>
+                        <title>test title</title>
+                    </head>
+                    <body>
+                        <a href="https://www.google.com/">google</a>
+                        <img alt="" src="https://ucarecdn.com/57ea9a4e-b8a9-4d14-9748-d1851cc58247/" width="70" />
+                        <p><img alt="" src="https://ucarecdn.com/983dc5db-6cc1-45bd-9f9b-5d787a3be48c/" /></p>
+                    </body>
+                    </html>
+                    """
+
+        let extractorType: HTMLExtractorProtocol.Type = HTMLExtractor.self
+
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                let links = extractorType.extractAllTagsAttribute(tag: "a", attribute: "href", from: content)
+
+                XCTAssertTrue(links.count == 1)
+                XCTAssertEqual(links, ["https://www.google.com/"])
+            }
+
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                let contents = extractorType.extractAllTagsContent(tag: "title", from: content)
+
+                XCTAssertTrue(contents.count == 1)
+                XCTAssertEqual(contents, ["test title"])
+            }
+
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                let images = extractorType.extractAllTags(tag: "img", from: content)
+
+                XCTAssertTrue(images.count == 2)
+                XCTAssertEqual(
+                    images[0],
+                    "<img alt=\"\" src=\"https://ucarecdn.com/57ea9a4e-b8a9-4d14-9748-d1851cc58247/\" width=\"70\">"
+                )
+                XCTAssertEqual(
+                    images[1],
+                    "<img alt=\"\" src=\"https://ucarecdn.com/983dc5db-6cc1-45bd-9f9b-5d787a3be48c/\">"
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Description**

1. [Bump RevenueCat from 4.38.1 to 4.41.1](https://github.com/hyperskill/mobile-app/commit/69c5329c9efa80e50cbc736fda631012b47108b5)
2. [Bump Firebase from 10.17.0 to 10.24.0](https://github.com/hyperskill/mobile-app/commit/dba4a1197608d4b6b93b77dab20704a5f7fa01d2)
3. [Bump GoogleSignIn from 6.2.4 to 7.1.0](https://github.com/hyperskill/mobile-app/commit/020c83c25e3d16b255c2e3bb67cf85f1cfddfb29)
4. [Bump SVProgressHUD from 2.2.5 to 2.3.1](https://github.com/hyperskill/mobile-app/commit/e3f3566d02f71b87249f7768918e277e937e304f)
5. [Bump lottie-ios from 4.3.3 to 4.4.3](https://github.com/hyperskill/mobile-app/commit/f6b188382338ce450da9ecccd3ab88ca37a6cd4c)
6. [Bump Kanna from 5.2.7 to 5.3.0](https://github.com/hyperskill/mobile-app/commit/dc3cb6e1ae081100f103b028f64071c54b754648)
7. [Bump SnapKit from 5.6.0 to 5.7.1](https://github.com/hyperskill/mobile-app/commit/39b26ae8933920f9ec83dd6fde1f8439dd7c6c92)