### PR TITLE
ALTAPPS-637: iOS optimize shouldMakeTabLineAfter

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
+++ b/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
@@ -430,6 +430,7 @@
 		2CB2BDB32BEB8054009E2D83 /* CodePlaygroundGetCurrentTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB2BDB22BEB8054009E2D83 /* CodePlaygroundGetCurrentTokenTests.swift */; };
 		2CB2BDB52BEB81A1009E2D83 /* CodePlaygroundShouldMakeTabLineAfterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB2BDB42BEB81A1009E2D83 /* CodePlaygroundShouldMakeTabLineAfterTests.swift */; };
 		2CB2BDB72BEB8488009E2D83 /* CodePlaygroundGetChangesSubstringPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB2BDB62BEB8488009E2D83 /* CodePlaygroundGetChangesSubstringPerformanceTests.swift */; };
+		2CB2BDB92BEB934D009E2D83 /* CodePlaygroundShouldMakeTabLineAfterPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB2BDB82BEB934D009E2D83 /* CodePlaygroundShouldMakeTabLineAfterPerformanceTests.swift */; };
 		2CB2BF272AE91F38000A144F /* FillBlanksModeWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB2BF262AE91F38000A144F /* FillBlanksModeWrapper.swift */; };
 		2CB45762288EC29D007C2D77 /* StepQuizActionButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB45761288EC29D007C2D77 /* StepQuizActionButtons.swift */; };
 		2CB45764288ED6D4007C2D77 /* StepQuizActionButtonCodeQuizDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB45763288ED6D4007C2D77 /* StepQuizActionButtonCodeQuizDelegate.swift */; };
@@ -1170,6 +1171,7 @@
 		2CB2BDB22BEB8054009E2D83 /* CodePlaygroundGetCurrentTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePlaygroundGetCurrentTokenTests.swift; sourceTree = "<group>"; };
 		2CB2BDB42BEB81A1009E2D83 /* CodePlaygroundShouldMakeTabLineAfterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePlaygroundShouldMakeTabLineAfterTests.swift; sourceTree = "<group>"; };
 		2CB2BDB62BEB8488009E2D83 /* CodePlaygroundGetChangesSubstringPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePlaygroundGetChangesSubstringPerformanceTests.swift; sourceTree = "<group>"; };
+		2CB2BDB82BEB934D009E2D83 /* CodePlaygroundShouldMakeTabLineAfterPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePlaygroundShouldMakeTabLineAfterPerformanceTests.swift; sourceTree = "<group>"; };
 		2CB2BF262AE91F38000A144F /* FillBlanksModeWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillBlanksModeWrapper.swift; sourceTree = "<group>"; };
 		2CB45761288EC29D007C2D77 /* StepQuizActionButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizActionButtons.swift; sourceTree = "<group>"; };
 		2CB45763288ED6D4007C2D77 /* StepQuizActionButtonCodeQuizDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizActionButtonCodeQuizDelegate.swift; sourceTree = "<group>"; };
@@ -3327,6 +3329,7 @@
 				2CB2BDB62BEB8488009E2D83 /* CodePlaygroundGetChangesSubstringPerformanceTests.swift */,
 				2CB2BDB02BEB7F65009E2D83 /* CodePlaygroundGetChangesSubstringTests.swift */,
 				2CB2BDB22BEB8054009E2D83 /* CodePlaygroundGetCurrentTokenTests.swift */,
+				2CB2BDB82BEB934D009E2D83 /* CodePlaygroundShouldMakeTabLineAfterPerformanceTests.swift */,
 				2CB2BDB42BEB81A1009E2D83 /* CodePlaygroundShouldMakeTabLineAfterTests.swift */,
 			);
 			path = CodePlaygroundManager;
@@ -4651,6 +4654,7 @@
 				2CB2BDB12BEB7F65009E2D83 /* CodePlaygroundGetChangesSubstringTests.swift in Sources */,
 				2CB2BDB52BEB81A1009E2D83 /* CodePlaygroundShouldMakeTabLineAfterTests.swift in Sources */,
 				2C919E3727EF00950022A2F2 /* QueueTests.swift in Sources */,
+				2CB2BDB92BEB934D009E2D83 /* CodePlaygroundShouldMakeTabLineAfterPerformanceTests.swift in Sources */,
 				2CB2BDB72BEB8488009E2D83 /* CodePlaygroundGetChangesSubstringPerformanceTests.swift in Sources */,
 				2CF87DA929B71D500092FF83 /* IntrospectViewControllerTests.swift in Sources */,
 				2C1F587E280D2F9200372A37 /* URLExtensionsTests.swift in Sources */,

--- a/iosHyperskillApp/iosHyperskillApp.xcodeproj/xcshareddata/xcbaselines/2C919DEC27EEF5BC0022A2F2.xcbaseline/ADDDB70F-EE79-4C0E-9923-72C0A4A25AEF.plist
+++ b/iosHyperskillApp/iosHyperskillApp.xcodeproj/xcshareddata/xcbaselines/2C919DEC27EEF5BC0022A2F2.xcbaseline/ADDDB70F-EE79-4C0E-9923-72C0A4A25AEF.plist
@@ -217,6 +217,69 @@
 				</dict>
 			</dict>
 		</dict>
+		<key>CodePlaygroundShouldMakeTabLineAfterPerformanceTests</key>
+		<dict>
+			<key>testShouldMakeTabLineAfterOptimizedWithColon()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.000009</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testShouldMakeTabLineAfterOptimizedWithCurlyBrace()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.000026</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testShouldMakeTabLineAfterOptimizedWithIrrelevantSymbol()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.000012</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testShouldMakeTabLineAfterWithColon()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.000010</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testShouldMakeTabLineAfterWithCurlyBrace()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.000035</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testShouldMakeTabLineAfterWithIrrelevantSymbol()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.000029</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/Model/Analyze/CodePlaygroundManager.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/Model/Analyze/CodePlaygroundManager.swift
@@ -40,34 +40,40 @@ final class CodePlaygroundManager {
         symbol: Character,
         language: CodeLanguage
     ) -> (shouldMakeNewLine: Bool, paired: Bool) {
-        switch language {
-        case .python, .python3, .python31:
-            return symbol == ":"
-                ? (shouldMakeNewLine: true, paired: false)
-                : (shouldMakeNewLine: false, paired: false)
-        case .c,
-             .cValgrind,
-             .cpp11,
-             .cpp,
-             .java,
-             .java8,
-             .java9,
-             .java11,
-             .java17,
-             .cs,
-             .csMono,
-             .kotlin,
-             .swift,
-             .rust,
-             .javascript,
-             .scala,
-             .scala3,
-             .go,
-             .perl,
-             .php:
-            return symbol == "{"
-                ? (shouldMakeNewLine: true, paired: true)
-                : (shouldMakeNewLine: false, paired: false)
+        switch symbol {
+        case ":":
+            if case .python = language,
+               case .python3 = language,
+               case .python31 = language {
+                return (shouldMakeNewLine: true, paired: false)
+            }
+            return (shouldMakeNewLine: false, paired: false)
+        case "{":
+            switch language {
+            case .c,
+                    .cValgrind,
+                    .cpp,
+                    .cpp11,
+                    .java,
+                    .java8,
+                    .java9,
+                    .java11,
+                    .java17,
+                    .cs,
+                    .csMono,
+                    .kotlin,
+                    .swift,
+                    .rust,
+                    .javascript,
+                    .scala,
+                    .scala3,
+                    .go,
+                    .perl,
+                    .php:
+                return (shouldMakeNewLine: true, paired: true)
+            default:
+                return (shouldMakeNewLine: false, paired: false)
+            }
         default:
             return (shouldMakeNewLine: false, paired: false)
         }

--- a/iosHyperskillApp/iosHyperskillAppTests/FrameworksTests/CodeEditor/CodePlaygroundManager/CodePlaygroundShouldMakeTabLineAfterPerformanceTests.swift
+++ b/iosHyperskillApp/iosHyperskillAppTests/FrameworksTests/CodeEditor/CodePlaygroundManager/CodePlaygroundShouldMakeTabLineAfterPerformanceTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+
+@testable import iosHyperskillApp
+
+final class CodePlaygroundShouldMakeTabLineAfterPerformanceTests: XCTestCase {
+    func shouldMakeTabLineAfter(
+        symbol: Character,
+        language: CodeLanguage
+    ) -> (shouldMakeNewLine: Bool, paired: Bool) {
+        switch language {
+        case .python, .python3, .python31:
+            return symbol == ":"
+                ? (shouldMakeNewLine: true, paired: false)
+                : (shouldMakeNewLine: false, paired: false)
+        case .c,
+                .cValgrind,
+                .cpp11,
+                .cpp,
+                .java,
+                .java8,
+                .java9,
+                .java11,
+                .java17,
+                .cs,
+                .csMono,
+                .kotlin,
+                .swift,
+                .rust,
+                .javascript,
+                .scala,
+                .scala3,
+                .go,
+                .perl,
+                .php:
+            return symbol == "{"
+                ? (shouldMakeNewLine: true, paired: true)
+                : (shouldMakeNewLine: false, paired: false)
+        default:
+            return (shouldMakeNewLine: false, paired: false)
+        }
+    }
+
+    func shouldMakeTabLineAfterOptimized(
+        symbol: Character,
+        language: CodeLanguage
+    ) -> (shouldMakeNewLine: Bool, paired: Bool) {
+        switch symbol {
+        case ":":
+            if case .python = language,
+               case .python3 = language,
+               case .python31 = language {
+                return (shouldMakeNewLine: true, paired: false)
+            }
+            return (shouldMakeNewLine: false, paired: false)
+        case "{":
+            switch language {
+            case .c,
+                    .cValgrind,
+                    .cpp, .cpp11,
+                    .java,
+                    .java8,
+                    .java9,
+                    .java11,
+                    .java17,
+                    .cs,
+                    .csMono,
+                    .kotlin,
+                    .swift,
+                    .rust,
+                    .javascript,
+                    .scala,
+                    .scala3,
+                    .go,
+                    .perl,
+                    .php:
+                return (shouldMakeNewLine: true, paired: true)
+            default:
+                return (shouldMakeNewLine: false, paired: false)
+            }
+        default:
+            return (shouldMakeNewLine: false, paired: false)
+        }
+    }
+
+    // Testing with a language where ":" is significant.
+    func testShouldMakeTabLineAfterWithColon() {
+        measure {
+            let _ = shouldMakeTabLineAfter(symbol: ":", language: .python)
+        }
+    }
+
+    func testShouldMakeTabLineAfterOptimizedWithColon() {
+        measure {
+            let _ = shouldMakeTabLineAfterOptimized(symbol: ":", language: .python)
+        }
+    }
+
+    // Testing with a language where "{" is significant.
+    func testShouldMakeTabLineAfterWithCurlyBrace() {
+        measure {
+            let _ = shouldMakeTabLineAfter(symbol: "{", language: .swift)
+        }
+    }
+
+    func testShouldMakeTabLineAfterOptimizedWithCurlyBrace() {
+        measure {
+            let _ = shouldMakeTabLineAfterOptimized(symbol: "{", language: .swift)
+        }
+    }
+
+    // Testing with a symbol and language where no action is required.
+    func testShouldMakeTabLineAfterWithIrrelevantSymbol() {
+        measure {
+            let _ = shouldMakeTabLineAfter(symbol: ";", language: .java)
+        }
+    }
+
+    func testShouldMakeTabLineAfterOptimizedWithIrrelevantSymbol() {
+        measure {
+            let _ = shouldMakeTabLineAfterOptimized(symbol: ";", language: .java)
+        }
+    }
+}


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-637](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-637)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

- Optimizes `shouldMakeTabLineAfter(symbol:language:)`
- The optimized function groups languages by common behavior, reducing the complexity and potentially improving the compiler's ability to optimize the code