### PR TITLE
ALTAPPS-637: iOS CodePlaygroundManager optimize countTabSize(text:)

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
+++ b/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
@@ -203,6 +203,8 @@
 		2C52F9972B98711A001524B5 /* PaywallViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C52F9962B98711A001524B5 /* PaywallViewModel.swift */; };
 		2C52F99A2B9871E7001524B5 /* PaywallAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C52F9992B9871E7001524B5 /* PaywallAssembly.swift */; };
 		2C52F99C2B987397001524B5 /* PaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C52F99B2B987397001524B5 /* PaywallView.swift */; };
+		2C542E782BECB3B900B578AD /* CodePlaygroundManagerCountTabSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C542E772BECB3B900B578AD /* CodePlaygroundManagerCountTabSizeTests.swift */; };
+		2C542E7A2BECB4A200B578AD /* CodePlaygroundManagerCountTabSizePerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C542E792BECB4A200B578AD /* CodePlaygroundManagerCountTabSizePerformanceTests.swift */; };
 		2C54E4222A1F6672003406B9 /* TrackSelectionDetailsFeatureViewStateKsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C54E4212A1F6672003406B9 /* TrackSelectionDetailsFeatureViewStateKsExtensions.swift */; };
 		2C54E4262A1F7086003406B9 /* TrackSelectionDetailsDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C54E4252A1F7086003406B9 /* TrackSelectionDetailsDescriptionView.swift */; };
 		2C54E4282A1F717F003406B9 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C54E4272A1F717F003406B9 /* CardView.swift */; };
@@ -943,6 +945,8 @@
 		2C52F9962B98711A001524B5 /* PaywallViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewModel.swift; sourceTree = "<group>"; };
 		2C52F9992B9871E7001524B5 /* PaywallAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallAssembly.swift; sourceTree = "<group>"; };
 		2C52F99B2B987397001524B5 /* PaywallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallView.swift; sourceTree = "<group>"; };
+		2C542E772BECB3B900B578AD /* CodePlaygroundManagerCountTabSizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePlaygroundManagerCountTabSizeTests.swift; sourceTree = "<group>"; };
+		2C542E792BECB4A200B578AD /* CodePlaygroundManagerCountTabSizePerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePlaygroundManagerCountTabSizePerformanceTests.swift; sourceTree = "<group>"; };
 		2C54E4212A1F6672003406B9 /* TrackSelectionDetailsFeatureViewStateKsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSelectionDetailsFeatureViewStateKsExtensions.swift; sourceTree = "<group>"; };
 		2C54E4252A1F7086003406B9 /* TrackSelectionDetailsDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSelectionDetailsDescriptionView.swift; sourceTree = "<group>"; };
 		2C54E4272A1F717F003406B9 /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
@@ -3332,6 +3336,8 @@
 				2CB2BDB02BEB7F65009E2D83 /* CodePlaygroundGetChangesSubstringTests.swift */,
 				2C1CF25A2BEBD5260073C234 /* CodePlaygroundGetCurrentTokenPerformanceTests.swift */,
 				2CB2BDB22BEB8054009E2D83 /* CodePlaygroundGetCurrentTokenTests.swift */,
+				2C542E792BECB4A200B578AD /* CodePlaygroundManagerCountTabSizePerformanceTests.swift */,
+				2C542E772BECB3B900B578AD /* CodePlaygroundManagerCountTabSizeTests.swift */,
 				2CB2BDB82BEB934D009E2D83 /* CodePlaygroundShouldMakeTabLineAfterPerformanceTests.swift */,
 				2CB2BDB42BEB81A1009E2D83 /* CodePlaygroundShouldMakeTabLineAfterTests.swift */,
 			);
@@ -4652,6 +4658,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2C542E782BECB3B900B578AD /* CodePlaygroundManagerCountTabSizeTests.swift in Sources */,
 				2CF87DA729B71D150092FF83 /* IntrospectTestUtils.swift in Sources */,
 				2C919E3327EEF92F0022A2F2 /* LinkedListTests.swift in Sources */,
 				2CB2BDB12BEB7F65009E2D83 /* CodePlaygroundGetChangesSubstringTests.swift in Sources */,
@@ -4664,6 +4671,7 @@
 				2CB2BDB32BEB8054009E2D83 /* CodePlaygroundGetCurrentTokenTests.swift in Sources */,
 				2CA542272ACAE32A00EF24B5 /* IntrospectScrollViewTests.swift in Sources */,
 				2C1CF25B2BEBD5260073C234 /* CodePlaygroundGetCurrentTokenPerformanceTests.swift in Sources */,
+				2C542E7A2BECB4A200B578AD /* CodePlaygroundManagerCountTabSizePerformanceTests.swift in Sources */,
 				2CE7B48F2AB0A09100DCBE4D /* HTMLStringTests.swift in Sources */,
 				2C77E8B32BDBD80A0046E5D1 /* HTMLExtractorTests.swift in Sources */,
 			);

--- a/iosHyperskillApp/iosHyperskillApp.xcodeproj/xcshareddata/xcbaselines/2C919DEC27EEF5BC0022A2F2.xcbaseline/ADDDB70F-EE79-4C0E-9923-72C0A4A25AEF.plist
+++ b/iosHyperskillApp/iosHyperskillApp.xcodeproj/xcshareddata/xcbaselines/2C919DEC27EEF5BC0022A2F2.xcbaseline/ADDDB70F-EE79-4C0E-9923-72C0A4A25AEF.plist
@@ -280,6 +280,29 @@
 				</dict>
 			</dict>
 		</dict>
+		<key>CodePlaygroundManagerCountTabSizePerformanceTests</key>
+		<dict>
+			<key>testPerformanceOfOptimizedCountTabSize()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.001714</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testPerformanceOfOriginalCountTabSize()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.000934</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
 		<key>CodePlaygroundShouldMakeTabLineAfterPerformanceTests</key>
 		<dict>
 			<key>testShouldMakeTabLineAfterOptimizedWithColon()</key>

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/Model/Analyze/CodePlaygroundManager.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/Model/Analyze/CodePlaygroundManager.swift
@@ -318,29 +318,17 @@ final class CodePlaygroundManager {
     }
 
     func countTabSize(text: String) -> Int {
-        var minTabSize = 100
+        var minTabSize = Int.max
 
         text.enumerateLines { line, _ in
-            var spacesBeforeFirstCharacter = 0
-
-            for character in line {
-                if character == " " {
-                    spacesBeforeFirstCharacter += 1
-                } else {
-                    break
-                }
-            }
-
-            if spacesBeforeFirstCharacter > 0 && minTabSize > spacesBeforeFirstCharacter {
-                minTabSize = spacesBeforeFirstCharacter
+            let leadingSpaces = line.prefix(while: { $0 == " " }).count
+            // Update the minimum tab size if this line has leading spaces and it's fewer than any previous line
+            if leadingSpaces > 0 {
+                minTabSize = min(minTabSize, leadingSpaces)
             }
         }
 
-        if minTabSize == 100 {
-            minTabSize = 4
-        }
-
-        return minTabSize
+        return minTabSize == Int.max ? 4 : minTabSize
     }
 
     private func hideCodeCompletion() {

--- a/iosHyperskillApp/iosHyperskillAppTests/FrameworksTests/CodeEditor/CodePlaygroundManager/CodePlaygroundManagerCountTabSizePerformanceTests.swift
+++ b/iosHyperskillApp/iosHyperskillAppTests/FrameworksTests/CodeEditor/CodePlaygroundManager/CodePlaygroundManagerCountTabSizePerformanceTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+final class CodePlaygroundManagerCountTabSizePerformanceTests: XCTestCase {
+    func countTabSize(text: String) -> Int {
+        var minTabSize = 100
+
+        text.enumerateLines { line, _ in
+            var spacesBeforeFirstCharacter = 0
+
+            for character in line {
+                if character == " " {
+                    spacesBeforeFirstCharacter += 1
+                } else {
+                    break
+                }
+            }
+
+            if spacesBeforeFirstCharacter > 0 && minTabSize > spacesBeforeFirstCharacter {
+                minTabSize = spacesBeforeFirstCharacter
+            }
+        }
+
+        if minTabSize == 100 {
+            minTabSize = 4
+        }
+
+        return minTabSize
+    }
+
+    func countTabSizeOptimized(text: String) -> Int {
+        // Start with a very high default value, indicating no tabs found yet
+        var minTabSize = Int.max
+
+        // Enumerate through each line of the text
+        text.enumerateLines { line, _ in
+            // Count leading spaces using prefix(while:)
+            let leadingSpaces = line.prefix(while: { $0 == " " }).count
+
+            // Update the minimum tab size if this line has leading spaces and it's fewer than any previous line
+            if leadingSpaces > 0 {
+                minTabSize = min(minTabSize, leadingSpaces)
+            }
+        }
+
+        // If minTabSize is still the default value, then no tabs were found, default to 4
+        return minTabSize == Int.max ? 4 : minTabSize
+    }
+
+    func testPerformanceOfOriginalCountTabSize() {
+        let text = generateTestString(lines: 1000, spaces: 5, extraContent: "some content after spaces")
+        measure {
+            _ = countTabSize(text: text)
+        }
+    }
+
+    func testPerformanceOfOptimizedCountTabSize() {
+        let text = generateTestString(lines: 1000, spaces: 5, extraContent: "some content after spaces")
+        measure {
+            _ = countTabSizeOptimized(text: text)
+        }
+    }
+
+    // Helper function to generate test strings
+    private func generateTestString(lines: Int, spaces: Int, extraContent: String) -> String {
+        let line = String(repeating: " ", count: spaces) + extraContent + "\n"
+        return String(repeating: line, count: lines)
+    }
+}

--- a/iosHyperskillApp/iosHyperskillAppTests/FrameworksTests/CodeEditor/CodePlaygroundManager/CodePlaygroundManagerCountTabSizeTests.swift
+++ b/iosHyperskillApp/iosHyperskillAppTests/FrameworksTests/CodeEditor/CodePlaygroundManager/CodePlaygroundManagerCountTabSizeTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+@testable import iosHyperskillApp
+
+final class CodePlaygroundManagerCountTabSizeTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    var manager: CodePlaygroundManager!
+
+    override func setUp() {
+        super.setUp()
+        manager = CodePlaygroundManager()
+    }
+
+    override func tearDown() {
+        manager = nil
+        super.tearDown()
+    }
+
+    func testBasicFunctionality() {
+        let text = "    func testExample() {\n        var x = 10\n  return x\n}"
+        XCTAssertEqual(manager.countTabSize(text: text), 2)
+    }
+
+    func testNoLeadingSpaces() {
+        let text = "func testExample() {\nvar x = 10\nreturn x\n}"
+        XCTAssertEqual(manager.countTabSize(text: text), 4)  // Default to 4 since no spaces
+    }
+
+    func testMixedContent() {
+        let text = "func testExample() {\n     var x = 10\n    return x\n}"
+        XCTAssertEqual(manager.countTabSize(text: text), 4)
+    }
+
+    func testEmptyText() {
+        let text = ""
+        XCTAssertEqual(manager.countTabSize(text: text), 4)  // Default to 4 since empty
+    }
+
+    func testTextWithNoSpaces() {
+        let text = "func testExample(){\nvar x=10\nreturn x\n}"
+        XCTAssertEqual(manager.countTabSize(text: text), 4)  // Default to 4 since no spaces
+    }
+
+    func testLinesWithNoCharacters() {
+        let text = "\n\n\n   \n"
+        XCTAssertEqual(manager.countTabSize(text: text), 3)
+    }
+}


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-637](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-637)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

- Optimizes `countTabSize(text:)`
- Simplifying Logic: The use of `prefix(while:)` directly counts leading spaces without manually iterating over each character. This not only cleans up the code but should improve performance by utilizing Swift's optimized string handling.
- This approach should lead to faster performance, especially with large text inputs.