### PR TITLE
ALTAPPS-1258: iOS display matching problem as table remove default ordering when reply is missing

### DIFF
--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -28,7 +28,7 @@
     <ID>CyclomaticComplexMethod:StepQuizActionDispatcher.kt$StepQuizActionDispatcher$override suspend fun doSuspendableAction(action: Action)</ID>
     <ID>CyclomaticComplexMethod:StepQuizHintsReducer.kt$StepQuizHintsReducer$override fun reduce(state: State, message: Message): Pair&lt;State, Set&lt;Action&gt;&gt;</ID>
     <ID>CyclomaticComplexMethod:StepQuizReducer.kt$StepQuizReducer$override fun reduce(state: State, message: Message): StepQuizReducerResult</ID>
-    <ID>CyclomaticComplexMethod:StepQuizReplyValidator.kt$StepQuizReplyValidator$fun validate(reply: Reply, stepBlockName: String): ReplyValidationResult</ID>
+    <ID>CyclomaticComplexMethod:StepQuizReplyValidator.kt$StepQuizReplyValidator$fun validate(dataset: Dataset?, reply: Reply, stepBlockName: String): ReplyValidationResult</ID>
     <ID>CyclomaticComplexMethod:TopicsRepetitionsReducer.kt$TopicsRepetitionsReducer$override fun reduce(state: State, message: Message): Pair&lt;State, Set&lt;Action&gt;&gt;</ID>
     <ID>DefaultsVisibility:LeaderboardListDivider.kt$LeaderboardListDividerDefaults$LeaderboardListDividerDefaults</ID>
     <ID>EmptyCatchBlock:TimeIntervalPickerDialogFragment.kt$TimeIntervalPickerDialogFragment${ }</ID>
@@ -266,7 +266,7 @@
     <ID>ReturnCount:StepQuizHintsInteractor.kt$StepQuizHintsInteractor$suspend fun getLastSeenHint(stepId: Long): Comment?</ID>
     <ID>ReturnCount:StepQuizHintsInteractor.kt$StepQuizHintsInteractor$suspend fun getNotSeenHintsIds(stepId: Long): List&lt;Long&gt;</ID>
     <ID>ReturnCount:StepQuizReducer.kt$StepQuizReducer$private fun handleGenerateGptCodeWithErrorsResult( state: State, message: InternalMessage.GenerateGptCodeWithErrorsResult ): StepQuizReducerResult</ID>
-    <ID>ReturnCount:StepQuizReplyValidator.kt$StepQuizReplyValidator$fun validate(reply: Reply, stepBlockName: String): ReplyValidationResult</ID>
+    <ID>ReturnCount:StepQuizReplyValidator.kt$StepQuizReplyValidator$fun validate(dataset: Dataset?, reply: Reply, stepBlockName: String): ReplyValidationResult</ID>
     <ID>ReturnCount:StepQuizResolver.kt$StepQuizResolver$fun isQuizEnabled(state: StepQuizFeature.StepQuizState.AttemptLoaded): Boolean</ID>
     <ID>ReturnCount:StepQuizResolver.kt$StepQuizResolver$fun shouldSyncReply(state: StepQuizFeature.StepQuizState): Boolean</ID>
     <ID>ReturnCount:StepQuizResolver.kt$StepQuizResolver$internal fun isIdeRequired(step: Step, submissionState: StepQuizFeature.SubmissionState): Boolean</ID>

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizMatching/StepQuizMatchingView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizMatching/StepQuizMatchingView.swift
@@ -12,7 +12,7 @@ struct StepQuizMatchingView: View {
             ForEach(viewModel.viewData.items) { item in
                 StepQuizTableRowView(
                     title: item.title.text,
-                    subtitle: item.option.text,
+                    subtitle: item.option?.text,
                     onTap: { doSelectColumnsPresentation(for: item) }
                 )
             }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizMatching/StepQuizMatchingViewData.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizMatching/StepQuizMatchingViewData.swift
@@ -7,7 +7,7 @@ struct StepQuizMatchingViewData {
         var id: Int { title.id }
 
         let title: Title
-        var option: Option
+        var option: Option?
 
         struct Title: Hashable, Identifiable {
             let id: Int

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizSorting/StepQuizSortingViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizSorting/StepQuizSortingViewModel.swift
@@ -17,8 +17,8 @@ final class StepQuizSortingViewModel: ObservableObject, StepQuizChildQuizInputPr
         if let options = dataset.options {
             let items: [StepQuizSortingViewData.Option]
 
-            if let ordering = reply?.ordering {
-                items = ordering.map { .init(id: $0.intValue, text: options[$0.intValue]) }
+            if let ordering = reply?.ordering as? [Int] {
+                items = ordering.map { .init(id: $0, text: options[$0]) }
             } else {
                 items = options.enumerated().map { .init(id: $0, text: $1) }
             }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/domain/validation/StepQuizReplyValidator.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/domain/validation/StepQuizReplyValidator.kt
@@ -28,7 +28,7 @@ internal class StepQuizReplyValidator(private val resourceProvider: ResourceProv
                 }
             }
             BlockName.MATCHING -> {
-                val uniqueOrdering = reply.ordering?.toSet()
+                val uniqueOrdering = reply.ordering?.filterNotNull()?.toSet()
                 val optionsCount = dataset?.pairs?.map { it.second }?.size ?: 0
 
                 if (uniqueOrdering.isNullOrEmpty() || uniqueOrdering.size != optionsCount) {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizActionDispatcher.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizActionDispatcher.kt
@@ -120,7 +120,11 @@ internal class StepQuizActionDispatcher(
                 }
             }
             is Action.CreateSubmissionValidateReply -> {
-                val validationResult = stepQuizReplyValidator.validate(action.reply, action.step.block.name)
+                val validationResult = stepQuizReplyValidator.validate(
+                    dataset = action.dataset,
+                    reply = action.reply,
+                    stepBlockName = action.step.block.name
+                )
                 onNewMessage(Message.CreateSubmissionReplyValidationResult(action.step, action.reply, validationResult))
             }
             is Action.CreateSubmission -> {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizFeature.kt
@@ -8,6 +8,7 @@ import org.hyperskill.app.step.domain.model.Step
 import org.hyperskill.app.step.domain.model.StepContext
 import org.hyperskill.app.step.domain.model.StepRoute
 import org.hyperskill.app.step_quiz.domain.model.attempts.Attempt
+import org.hyperskill.app.step_quiz.domain.model.attempts.Dataset
 import org.hyperskill.app.step_quiz.domain.validation.ReplyValidationResult
 import org.hyperskill.app.step_quiz_hints.presentation.StepQuizHintsFeature
 import org.hyperskill.app.step_quiz_toolbar.presentation.StepQuizToolbarFeature
@@ -170,7 +171,11 @@ object StepQuizFeature {
             val shouldResetReply: Boolean
         ) : Action
 
-        data class CreateSubmissionValidateReply(val step: Step, val reply: Reply) : Action
+        data class CreateSubmissionValidateReply(
+            val step: Step,
+            val dataset: Dataset?,
+            val reply: Reply
+        ) : Action
         data class CreateSubmission(
             val step: Step,
             val stepContext: StepContext,

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizReducer.kt
@@ -114,7 +114,11 @@ internal class StepQuizReducer(
                             StepQuizClickedSendHyperskillAnalyticEvent(stepRoute.analyticRoute)
                         }
                     state to setOf(
-                        Action.CreateSubmissionValidateReply(message.step, message.reply),
+                        Action.CreateSubmissionValidateReply(
+                            step = message.step,
+                            dataset = state.stepQuizState.attempt.dataset,
+                            reply = message.reply
+                        ),
                         InternalAction.LogAnalyticEvent(analyticEvent)
                     )
                 } else {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/submissions/domain/model/Reply.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/submissions/domain/model/Reply.kt
@@ -20,7 +20,7 @@ data class Reply(
     @SerialName("number")
     val number: String? = null,
     @SerialName("ordering")
-    val ordering: List<Int>? = null,
+    val ordering: List<Int?>? = null,
     @SerialName("language")
     val language: String? = null,
     @SerialName("code")
@@ -45,6 +45,9 @@ data class Reply(
 
     companion object {
         internal const val PROMPT_MANUALLY_CONFIRMED_SCORE: Float = 1F
+
+        fun matching(ordering: List<Int?>): Reply =
+            Reply(ordering = ordering)
 
         fun code(code: String?, language: String?): Reply =
             Reply(code = code, language = language)

--- a/shared/src/commonTest/kotlin/org/hyperskill/step_quiz/domain/validation/StepQuizReplyValidatorTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/step_quiz/domain/validation/StepQuizReplyValidatorTest.kt
@@ -1,0 +1,50 @@
+package org.hyperskill.step_quiz.domain.validation
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import org.hyperskill.ResourceProviderStub
+import org.hyperskill.app.step.domain.model.BlockName
+import org.hyperskill.app.step_quiz.domain.model.attempts.Dataset
+import org.hyperskill.app.step_quiz.domain.validation.ReplyValidationResult
+import org.hyperskill.app.step_quiz.domain.validation.StepQuizReplyValidator
+import org.hyperskill.app.submissions.domain.model.Reply
+import org.hyperskill.app.step_quiz.domain.model.attempts.Pair as DatasetPair
+
+class StepQuizReplyValidatorTest {
+    private val validator = StepQuizReplyValidator(ResourceProviderStub())
+
+    @Test
+    fun `Matching reply validation should return error when ordering is null or empty`() {
+        val dataset = Dataset(pairs = listOf(DatasetPair("1", "2"), DatasetPair("3", "4")))
+        listOf(
+            Reply(ordering = null),
+            Reply(ordering = emptyList())
+        ).forEach { reply ->
+            val result = validator.validate(dataset, reply, BlockName.MATCHING)
+            assertTrue(result is ReplyValidationResult.Error)
+        }
+    }
+
+    @Test
+    fun `Matching reply validation should return error when ordering size does not match options count`() {
+        val dataset = Dataset(pairs = listOf(DatasetPair("1", "2"), DatasetPair("3", "4"), DatasetPair("5", "6")))
+        listOf(
+            Reply(ordering = listOf(1, 2)),
+            Reply(ordering = listOf(1, null, 2))
+        ).forEach { reply ->
+            val result = validator.validate(dataset, reply, BlockName.MATCHING)
+
+            assertTrue(result is ReplyValidationResult.Error)
+        }
+    }
+
+    @Test
+    fun `Matching reply validation should return success when ordering size matches options count`() {
+        val reply = Reply(ordering = listOf(1, 2, 3))
+        val dataset = Dataset(pairs = listOf(DatasetPair("1", "2"), DatasetPair("3", "4"), DatasetPair("5", "6")))
+
+        val result = validator.validate(dataset, reply, BlockName.MATCHING)
+
+        assertTrue(result is ReplyValidationResult.Success)
+    }
+}


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1258](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1258)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

- Don't assign a default option for a matched item if the reply doesn't specify an order for it