### PR TITLE
ALTAPPS-1257: Android fix fill blanks options spacing

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz_fill_blanks/delegate/FillBlanksStepQuizFormDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz_fill_blanks/delegate/FillBlanksStepQuizFormDelegate.kt
@@ -331,28 +331,6 @@ class FillBlanksStepQuizFormDelegate(
             isNestedScrollingEnabled = false
             layoutManager = FlexboxLayoutManager(context)
                 .apply { justifyContent = JustifyContent.FLEX_START }
-            addItemDecoration(
-                FlexboxItemDecoration(context).apply {
-                    setOrientation(FlexboxItemDecoration.HORIZONTAL)
-                    setDrawable(
-                        ContextCompat.getDrawable(
-                            context,
-                            R.drawable.bg_step_quiz_fill_blanks_options_horizontal_divider
-                        )
-                    )
-                }
-            )
-            addItemDecoration(
-                FlexboxItemDecoration(context).apply {
-                    setOrientation(FlexboxItemDecoration.VERTICAL)
-                    setDrawable(
-                        ContextCompat.getDrawable(
-                            context,
-                            R.drawable.bg_step_quiz_fill_blanks_options_vertical_divider
-                        )
-                    )
-                }
-            )
             isVisible = true
         }
     }

--- a/androidHyperskillApp/src/main/res/layout/item_step_quiz_fill_blanks_select_option.xml
+++ b/androidHyperskillApp/src/main/res/layout/item_step_quiz_fill_blanks_select_option.xml
@@ -9,7 +9,9 @@
     android:focusable="true"
     android:background="@drawable/bg_step_quiz_fill_blanks_select_item"
     android:paddingVertical="12dp"
-    android:paddingHorizontal="13dp">
+    android:paddingHorizontal="13dp"
+    android:layout_marginEnd="12dp"
+    android:layout_marginBottom="12dp">
 
     <TextView
         android:id="@+id/stepQuizFillBlanksSelectOptionText"


### PR DESCRIPTION
**YouTrack Issues**:
[ALTAPPS-1257](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1257)


**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Replace `FlexboxItemDecoration` with a plain margin on each fill blanks item to avoid spacing issues.
