### PR TITLE
ALTAPPS-1301: Shared, Android root topics section pagination

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/delegate/StudyPlanWidgetDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/delegate/StudyPlanWidgetDelegate.kt
@@ -45,6 +45,7 @@ class StudyPlanWidgetDelegate(
             }
         )
         addDelegate(sectionsLoadingAdapterDelegate())
+        addDelegate(loadAllTopicsButtonDelegate {})
         addDelegate(paywallAdapterDelegate())
         addDelegate(ActivityLoadingAdapterDelegate())
         addDelegate(
@@ -132,10 +133,12 @@ class StudyPlanWidgetDelegate(
     private fun getTopMarginFor(item: StudyPlanRecyclerItem): Int =
         when (item) {
             is StudyPlanRecyclerItem.SectionLoading,
-            is StudyPlanRecyclerItem.Section -> sectionTopMargin
+            is StudyPlanRecyclerItem.Section,
+            is StudyPlanRecyclerItem.PaywallBanner -> sectionTopMargin
             is StudyPlanRecyclerItem.ActivityLoading,
             is StudyPlanRecyclerItem.Activity,
-            is StudyPlanRecyclerItem.ActivitiesError -> activityTopMargin
+            is StudyPlanRecyclerItem.ActivitiesError,
+            is StudyPlanRecyclerItem.LoadAllTopicsButton -> activityTopMargin
             else -> 0
         }
 
@@ -171,6 +174,17 @@ class StudyPlanWidgetDelegate(
             }
         }
 
+    private fun loadAllTopicsButtonDelegate(
+        onClick: () -> Unit
+    ) =
+        adapterDelegate<StudyPlanRecyclerItem, StudyPlanRecyclerItem.LoadAllTopicsButton>(
+            R.layout.item_study_plan_load_more_button
+        ) {
+            itemView.setOnClickListener {
+                onClick()
+            }
+        }
+
     private fun mapContentToRecyclerItems(
         studyPlanContent: StudyPlanWidgetViewState.Content
     ): List<StudyPlanRecyclerItem> =
@@ -192,7 +206,10 @@ class StudyPlanWidgetDelegate(
                         )
                     }
                     is StudyPlanWidgetViewState.SectionContent.Content -> {
-                        addAll(mapSectionContentToActivityItems(section.id, sectionContent))
+                        addAll(mapSectionItemsToActivityItems(section.id, sectionContent.sectionItems))
+                        if (sectionContent.isLoadAllTopicsButtonShown) {
+                            add(StudyPlanRecyclerItem.LoadAllTopicsButton(section.id))
+                        }
                     }
                     StudyPlanWidgetViewState.SectionContent.Error -> {
                         add(StudyPlanRecyclerItem.ActivitiesError(section.id))
@@ -220,11 +237,11 @@ class StudyPlanWidgetDelegate(
             isCurrentBadgeShown = section.isCurrentBadgeShown
         )
 
-    private fun mapSectionContentToActivityItems(
+    private fun mapSectionItemsToActivityItems(
         sectionId: Long,
-        content: StudyPlanWidgetViewState.SectionContent.Content
+        sectionItems: List<StudyPlanWidgetViewState.SectionItem>
     ): List<StudyPlanRecyclerItem.Activity> =
-        content.sectionItems.map { item ->
+        sectionItems.map { item ->
             StudyPlanRecyclerItem.Activity(
                 id = item.id,
                 sectionId = sectionId,

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/delegate/StudyPlanWidgetDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/delegate/StudyPlanWidgetDelegate.kt
@@ -45,7 +45,7 @@ class StudyPlanWidgetDelegate(
             }
         )
         addDelegate(sectionsLoadingAdapterDelegate())
-        addDelegate(loadAllTopicsButtonDelegate {})
+        addDelegate(loadAllTopicsButtonDelegate())
         addDelegate(paywallAdapterDelegate())
         addDelegate(ActivityLoadingAdapterDelegate())
         addDelegate(
@@ -174,14 +174,17 @@ class StudyPlanWidgetDelegate(
             }
         }
 
-    private fun loadAllTopicsButtonDelegate(
-        onClick: () -> Unit
-    ) =
+    private fun loadAllTopicsButtonDelegate() =
         adapterDelegate<StudyPlanRecyclerItem, StudyPlanRecyclerItem.LoadAllTopicsButton>(
             R.layout.item_study_plan_load_more_button
         ) {
             itemView.setOnClickListener {
-                onClick()
+                val sectionId = item?.sectionId
+                if (sectionId != null) {
+                    onNewMessage(
+                        StudyPlanWidgetFeature.Message.LoadMoreActivitiesClicked(sectionId)
+                    )
+                }
             }
         }
 
@@ -199,16 +202,15 @@ class StudyPlanWidgetDelegate(
                         // no op
                     }
                     StudyPlanWidgetViewState.SectionContent.Loading -> {
-                        addAll(
-                            List(ACTIVITIES_LOADING_ITEMS_COUNT) { index ->
-                                StudyPlanRecyclerItem.ActivityLoading(section.id, index)
-                            }
-                        )
+                        addAll(getActivitiesLoadingItems(section.id))
                     }
                     is StudyPlanWidgetViewState.SectionContent.Content -> {
                         addAll(mapSectionItemsToActivityItems(section.id, sectionContent.sectionItems))
                         if (sectionContent.isLoadAllTopicsButtonShown) {
                             add(StudyPlanRecyclerItem.LoadAllTopicsButton(section.id))
+                        }
+                        if (sectionContent.isNextPageLoadingShowed) {
+                            addAll(getActivitiesLoadingItems(section.id))
                         }
                     }
                     StudyPlanWidgetViewState.SectionContent.Error -> {
@@ -263,5 +265,10 @@ class StudyPlanWidgetDelegate(
                 },
                 isIdeRequired = item.isIdeRequired
             )
+        }
+
+    private fun getActivitiesLoadingItems(sectionId: Long) =
+        List(ACTIVITIES_LOADING_ITEMS_COUNT) { index ->
+            StudyPlanRecyclerItem.ActivityLoading(sectionId, index)
         }
 }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/model/StudyPlanRecyclerItem.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/model/StudyPlanRecyclerItem.kt
@@ -19,26 +19,28 @@ interface StudyPlanRecyclerItem {
     data class SectionLoading(
         val index: Int
     ) : StudyPlanRecyclerItem, Identifiable<String> {
-        override val id: String
-            get() = "sections-list-loading-item-$index"
+        override val id: String = "sections-list-loading-item-$index"
+    }
+
+    data class LoadAllTopicsButton(
+        val sectionId: Long
+    ) : StudyPlanRecyclerItem, Identifiable<String> {
+        override val id: String = "study-plan-$sectionId-load-all-topics"
     }
 
     object PaywallBanner : StudyPlanRecyclerItem, Identifiable<String> {
-        override val id: String
-            get() = "study-plan-paywall-banner"
+        override val id: String = "study-plan-paywall-banner"
     }
 
     data class ActivityLoading(
         val sectionId: Long,
         val index: Int
     ) : StudyPlanRecyclerItem, Identifiable<String> {
-        override val id: String
-            get() = "activity-loading-item-$sectionId-$index"
+        override val id: String = "activity-loading-item-$sectionId-$index"
     }
 
     data class ActivitiesError(val sectionId: Long) : StudyPlanRecyclerItem, Identifiable<String> {
-        override val id: String
-            get() = "section-content-error-$sectionId"
+        override val id: String = "section-content-error-$sectionId"
     }
 
     data class Activity(

--- a/androidHyperskillApp/src/main/res/layout/item_study_plan_load_more_button.xml
+++ b/androidHyperskillApp/src/main/res/layout/item_study_plan_load_more_button.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.button.MaterialButton
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    style="@style/Widget.AppTheme.Button.TextButton"
+    android:text="@string/study_plan_load_more_button_text" />

--- a/androidHyperskillApp/src/main/res/values/styles.xml
+++ b/androidHyperskillApp/src/main/res/values/styles.xml
@@ -35,6 +35,12 @@
         <item name="cornerRadius">8dp</item>
     </style>
 
+    <style name="Widget.AppTheme.Button.TextButton" parent="@style/Widget.MaterialComponents.Button.TextButton">
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+
+    </style>
+
     <style name="Widget.AppTheme.TextInputLayouts.InputText" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
         <item name="boxCornerRadiusBottomStart">@dimen/corner_radius</item>
         <item name="boxCornerRadiusBottomEnd">@dimen/corner_radius</item>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -283,6 +283,7 @@
     <ID>TooManyFunctions:ProfileFragment.kt$ProfileFragment : FragmentReduxViewCallbackCallback</ID>
     <ID>TooManyFunctions:SharedDateFormatter.kt$SharedDateFormatter</ID>
     <ID>TooManyFunctions:StepActionDispatcher.kt$StepActionDispatcher : CoroutineActionDispatcher</ID>
+    <ID>TooManyFunctions:StudyPlanWidgetDelegate.kt$StudyPlanWidgetDelegate</ID>
     <ID>TopLevelPropertyNaming:HyperskillNotificationChannel.kt$private const val dailyReminderId = "dailyReminderChannel"</ID>
     <ID>TopLevelPropertyNaming:HyperskillNotificationChannel.kt$private const val otherId = "otherChannel"</ID>
     <ID>TopLevelPropertyNaming:HyperskillNotificationChannel.kt$private const val regularLearningRemindersId = "regularLearningRemindersChannel"</ID>

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StudyPlan/Views/Section/StudyPlanSectionView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StudyPlan/Views/Section/StudyPlanSectionView.swift
@@ -74,7 +74,9 @@ extension StudyPlanWidgetViewStateSection {
                     .makePlaceholder(state: .skipped),
                     .makePlaceholder(state: .completed),
                     .makePlaceholder(state: .next)
-                ]
+                ],
+                isNextPageLoadingShowed: false,
+                isLoadAllTopicsButtonShown: false
             )
         )
     }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/analytic/domain/model/hyperskill/HyperskillAnalyticTarget.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/analytic/domain/model/hyperskill/HyperskillAnalyticTarget.kt
@@ -137,5 +137,6 @@ enum class HyperskillAnalyticTarget(val targetName: String) {
     SHOW_MORE("show_more"),
     SHOW_REPLIES("show_replies"),
     CODE_BLOCK("code_block"),
-    CODE_BLOCK_SUGGESTION("code_block_suggestion")
+    CODE_BLOCK_SUGGESTION("code_block_suggestion"),
+    LOAD_MORE("load_more")
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/model/Profile.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile/domain/model/Profile.kt
@@ -65,7 +65,7 @@ data class Profile(
     @SerialName("notification_hour")
     val notificationHour: Int? = null,
     @SerialName("feature_values")
-    val feautureValues: FeatureValues = FeatureValues(),
+    val featureValues: FeatureValues = FeatureValues(),
     @SerialName("features")
     private val featuresMap: Map<String, Boolean> = emptyMap(),
 ) {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_completion/presentation/MainStepCompletionActionDispatcher.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_completion/presentation/MainStepCompletionActionDispatcher.kt
@@ -169,7 +169,7 @@ internal class MainStepCompletionActionDispatcher(
                         val isTopicsLimitReached = isTopicsLimitReached(
                             trackId = trackId,
                             isMobileContentTrialEnabled = profile.features.isMobileContentTrialEnabled,
-                            mobileContentTrialFreeTopics = profile.feautureValues.mobileContentTrialFreeTopics
+                            mobileContentTrialFreeTopics = profile.featureValues.mobileContentTrialFreeTopics
                         )
 
                         val nextLearningActivity = if (!isTopicsLimitReached) {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/analytic/StudyPlanAnalyticKeys.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/analytic/StudyPlanAnalyticKeys.kt
@@ -1,0 +1,5 @@
+package org.hyperskill.app.study_plan.domain.analytic
+
+object StudyPlanAnalyticKeys {
+    const val SECTION_ID = "section_id"
+}

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/analytic/StudyPlanLoadMoreActivitiesClickedHSAnalyticEvent.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/analytic/StudyPlanLoadMoreActivitiesClickedHSAnalyticEvent.kt
@@ -7,15 +7,15 @@ import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticRou
 import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticTarget
 
 /**
- * Represents a click analytic event of the error state placeholder in the section activities.
+ * Represents a click analytic event of the load more button in the section.
  *
  * JSON payload:
  * ```
  * {
  *     "route": "/study-plan"",
  *     "action": "click",
- *     "part": "study_plan_section_activities",
- *     "target": "retry",
+ *     "part": "study_plan_section",
+ *     "target": "load_more",
  *     "context":
  *     {
  *         "section_id": 123
@@ -24,12 +24,12 @@ import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticTar
  * ```
  * @see HyperskillAnalyticEvent
  */
-class StudyPlanClickedRetryActivitiesLoadingHyperskillAnalyticEvent(
+class StudyPlanLoadMoreActivitiesClickedHSAnalyticEvent(
     val sectionId: Long
 ) : HyperskillAnalyticEvent(
     route = HyperskillAnalyticRoute.StudyPlan(),
     action = HyperskillAnalyticAction.CLICK,
-    part = HyperskillAnalyticPart.STUDY_PLAN_SECTION_ACTIVITIES,
-    target = HyperskillAnalyticTarget.RETRY,
+    part = HyperskillAnalyticPart.STUDY_PLAN_SECTION,
+    target = HyperskillAnalyticTarget.LOAD_MORE,
     context = mapOf(StudyPlanAnalyticKeys.SECTION_ID to sectionId)
 )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSection.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSection.kt
@@ -37,3 +37,8 @@ internal val StudyPlanSection.firstRootTopicsActivityIndexToBeLoaded: Int
     } else {
         0
     }
+
+internal val StudyPlanSection.activitiesToBeLoaded: List<Long>
+    get() = activities.slice(
+        firstRootTopicsActivityIndexToBeLoaded..activities.lastIndex
+    )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSection.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSection.kt
@@ -1,5 +1,6 @@
 package org.hyperskill.app.study_plan.domain.model
 
+import kotlin.math.max
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -29,3 +30,10 @@ data class StudyPlanSection(
     val type: StudyPlanSectionType?
         get() = StudyPlanSectionType.getByValue(typeValue)
 }
+
+internal val StudyPlanSection.firstRootTopicsActivityIndexToBeLoaded: Int
+    get() = if (nextActivityId != null) {
+        max(0, activities.indexOf(nextActivityId))
+    } else {
+        0
+    }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSection.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSection.kt
@@ -39,6 +39,4 @@ internal val StudyPlanSection.firstRootTopicsActivityIndexToBeLoaded: Int
     }
 
 internal val StudyPlanSection.activitiesToBeLoaded: List<Long>
-    get() = activities.slice(
-        firstRootTopicsActivityIndexToBeLoaded..activities.lastIndex
-    )
+    get() = activities.slice(firstRootTopicsActivityIndexToBeLoaded..activities.lastIndex)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSection.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/model/StudyPlanSection.kt
@@ -38,5 +38,5 @@ internal val StudyPlanSection.firstRootTopicsActivityIndexToBeLoaded: Int
         0
     }
 
-internal val StudyPlanSection.activitiesToBeLoaded: List<Long>
+internal val StudyPlanSection.rootTopicsActivitiesToBeLoaded: List<Long>
     get() = activities.slice(firstRootTopicsActivityIndexToBeLoaded..activities.lastIndex)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StateExtentions.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StateExtentions.kt
@@ -62,14 +62,13 @@ internal fun StudyPlanWidgetFeature.State.getActivitiesToBeLoaded(sectionId: Lon
     }
 }
 
-internal fun StudyPlanSection.getActivitiesToBeLoaded(allLoadedActivities: Collection<LearningActivity>): Set<Long> {
-    return if (type == StudyPlanSectionType.ROOT_TOPICS) {
+internal fun StudyPlanSection.getActivitiesToBeLoaded(allLoadedActivities: Collection<LearningActivity>): Set<Long> =
+    if (type == StudyPlanSectionType.ROOT_TOPICS) {
         val sectionActivities = activities.intersect(allLoadedActivities.map { it.id }.toSet())
         activitiesToBeLoaded.subtract(sectionActivities)
     } else {
         emptySet()
     }
-}
 
 /**
  * @param sectionId target section id.

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
@@ -92,15 +92,15 @@ object StudyPlanWidgetFeature {
         /**
          * Stage implementation unsupported modal
          */
-        object StageImplementUnsupportedModalGoToHomeClicked : Message
-        object StageImplementUnsupportedModalShownEventMessage : Message
-        object StageImplementUnsupportedModalHiddenEventMessage : Message
+        data object StageImplementUnsupportedModalGoToHomeClicked : Message
+        data object StageImplementUnsupportedModalShownEventMessage : Message
+        data object StageImplementUnsupportedModalHiddenEventMessage : Message
     }
 
     internal sealed interface InternalMessage : Message {
         data class Initialize(val forceUpdate: Boolean = false) : InternalMessage
 
-        object ReloadContentInBackground : InternalMessage
+        data object ReloadContentInBackground : InternalMessage
 
         data class ProfileChanged(val profile: Profile) : InternalMessage
 
@@ -116,7 +116,7 @@ object StudyPlanWidgetFeature {
             val canMakePayments: Boolean
         ) : LearningActivitiesWithSectionsFetchResult
 
-        object Failed : LearningActivitiesWithSectionsFetchResult
+        data object Failed : LearningActivitiesWithSectionsFetchResult
     }
 
     internal sealed interface LearningActivitiesFetchResult : Message {
@@ -131,13 +131,13 @@ object StudyPlanWidgetFeature {
     internal sealed interface ProfileFetchResult : Message {
         data class Success(val profile: Profile) : ProfileFetchResult
 
-        object Failed : ProfileFetchResult
+        data object Failed : ProfileFetchResult
     }
 
     sealed interface Action {
         sealed interface ViewAction : Action {
             sealed interface NavigateTo : ViewAction {
-                object Home : NavigateTo
+                data object Home : NavigateTo
                 data class LearningActivityTarget(val viewAction: LearningActivityTargetViewAction) : NavigateTo
                 data class Paywall(val paywallTransitionSource: PaywallTransitionSource) : NavigateTo
             }
@@ -159,14 +159,14 @@ object StudyPlanWidgetFeature {
             val sentryTransaction: HyperskillSentryTransaction
         ) : InternalAction
 
-        object FetchProfile : InternalAction
+        data object FetchProfile : InternalAction
 
         data class UpdateCurrentStudyPlanState(val forceUpdate: Boolean) : InternalAction
         data class UpdateNextLearningActivityState(val learningActivity: LearningActivity?) : InternalAction
 
         data class PutTopicsProgressesToCache(val topicsProgresses: List<TopicProgress>) : InternalAction
 
-        object FetchPaymentAbility : InternalAction
+        data object FetchPaymentAbility : InternalAction
 
         data class CaptureSentryException(val throwable: Throwable) : InternalAction
         data class LogAnalyticEvent(val analyticEvent: AnalyticEvent) : InternalAction

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
@@ -24,7 +24,7 @@ object StudyPlanWidgetFeature {
         /**
          * Describes status of sections loading
          */
-        val sectionsStatus: ContentStatus = ContentStatus.IDLE,
+        val sectionsStatus: SectionStatus = SectionStatus.IDLE,
 
         /**
          * Map of activity ids to activities
@@ -61,11 +61,21 @@ object StudyPlanWidgetFeature {
             get() = profile?.features?.isMobileContentTrialEnabled ?: false
     }
 
-    enum class ContentStatus {
+    enum class SectionStatus {
         IDLE,
         LOADING,
         ERROR,
         LOADED
+    }
+
+    enum class SectionContentStatus {
+        IDLE,
+        ERROR,
+
+        FIRST_PAGE_LOADING,
+        NEXT_PAGE_LOADING,
+        PAGE_LOADED,
+        ALL_PAGES_LOADED
     }
 
     data class StudyPlanSectionInfo(
@@ -75,13 +85,15 @@ object StudyPlanWidgetFeature {
         /**
          * Describes status of section's activities loading
          * */
-        val contentStatus: ContentStatus
+        val sectionContentStatus: SectionContentStatus
     )
 
     sealed interface Message {
         data class SectionClicked(val sectionId: Long) : Message
 
         data class ActivityClicked(val activityId: Long, val sectionId: Long) : Message
+
+        data class LoadMoreActivitiesClicked(val sectionId: Long) : Message
 
         data class RetryActivitiesLoading(val sectionId: Long) : Message
 

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -140,7 +140,11 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
     ): StudyPlanWidgetReducerResult {
         val learningActivitiesIds = message.learningActivities.map { it.id }.toSet()
         val visibleSections = getVisibleSections(message.studyPlanSections, learningActivitiesIds)
-        val currentSectionId = visibleSections.first().id
+        val currentSectionId = visibleSections.firstOrNull()?.id ?: return state.copy(
+            studyPlanSections = emptyMap(),
+            sectionsStatus = StudyPlanWidgetFeature.SectionStatus.LOADED,
+            isRefreshing = false
+        ) to emptySet()
 
         val supportedSections = visibleSections
             .filter { studyPlanSection ->

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -1,6 +1,5 @@
 package org.hyperskill.app.study_plan.widget.presentation
 
-import kotlin.math.max
 import kotlin.math.min
 import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticRoute
 import org.hyperskill.app.learning_activities.domain.model.LearningActivity
@@ -15,6 +14,7 @@ import org.hyperskill.app.study_plan.domain.analytic.StudyPlanStageImplementUnsu
 import org.hyperskill.app.study_plan.domain.analytic.StudyPlanStageImplementUnsupportedModalHiddenHyperskillAnalyticEvent
 import org.hyperskill.app.study_plan.domain.analytic.StudyPlanStageImplementUnsupportedModalShownHyperskillAnalyticEvent
 import org.hyperskill.app.study_plan.domain.model.StudyPlanSectionType
+import org.hyperskill.app.study_plan.domain.model.firstRootTopicsActivityIndexToBeLoaded
 import org.hyperskill.app.study_plan.widget.domain.mapper.LearningActivityToTopicProgressMapper
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.Action
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.InternalAction
@@ -356,10 +356,9 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
             section.studyPlanSection.nextActivityId != null &&
             !isLearningPathDividedTrackTopicsEnabled
         ) {
-            val startIndex =
-                max(0, section.studyPlanSection.activities.indexOf(section.studyPlanSection.nextActivityId))
+            val startIndex = section.studyPlanSection.firstRootTopicsActivityIndexToBeLoaded
             val endIndex =
-                min(startIndex + (SECTION_ROOT_TOPICS_PAGE_SIZE - 1), section.studyPlanSection.activities.size - 1)
+                min(startIndex + (SECTION_ROOT_TOPICS_PAGE_SIZE - 1), section.studyPlanSection.activities.lastIndex)
             section.studyPlanSection.activities.slice(startIndex..endIndex)
         } else {
             section.studyPlanSection.activities

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -12,6 +12,7 @@ import org.hyperskill.app.study_plan.domain.analytic.StudyPlanClickedActivityHyp
 import org.hyperskill.app.study_plan.domain.analytic.StudyPlanClickedRetryActivitiesLoadingHyperskillAnalyticEvent
 import org.hyperskill.app.study_plan.domain.analytic.StudyPlanClickedSectionHyperskillAnalyticEvent
 import org.hyperskill.app.study_plan.domain.analytic.StudyPlanClickedSubscribeHyperskillAnalyticEvent
+import org.hyperskill.app.study_plan.domain.analytic.StudyPlanLoadMoreActivitiesClickedHSAnalyticEvent
 import org.hyperskill.app.study_plan.domain.analytic.StudyPlanStageImplementUnsupportedModalClickedGoToHomeScreenHyperskillAnalyticEvent
 import org.hyperskill.app.study_plan.domain.analytic.StudyPlanStageImplementUnsupportedModalHiddenHyperskillAnalyticEvent
 import org.hyperskill.app.study_plan.domain.analytic.StudyPlanStageImplementUnsupportedModalShownHyperskillAnalyticEvent
@@ -348,6 +349,7 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
                 sectionInfo.copy(sectionContentStatus = SectionContentStatus.NEXT_PAGE_LOADING)
             }
         ) to setOf(
+            InternalAction.LogAnalyticEvent(StudyPlanLoadMoreActivitiesClickedHSAnalyticEvent(message.sectionId)),
             InternalAction.FetchLearningActivities(
                 sectionId = message.sectionId,
                 activitiesIds = state.getActivitiesToBeLoaded(message.sectionId).toList(),

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -208,8 +208,8 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
     private fun handleLearningActivitiesFetchSuccess(
         state: State,
         message: StudyPlanWidgetFeature.LearningActivitiesFetchResult.Success,
-    ): StudyPlanWidgetReducerResult {
-        return handleNewActivities(
+    ): StudyPlanWidgetReducerResult =
+        handleNewActivities(
             state = state.copy(
                 activities = state.activities.mutate {
                     putAll(message.activities.associateBy { it.id })
@@ -233,7 +233,6 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
             sectionId = message.sectionId,
             activities = message.activities
         )
-    }
 
     private fun handleNewActivities(
         state: State,

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetStateExtensions.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetStateExtensions.kt
@@ -4,7 +4,7 @@ import org.hyperskill.app.learning_activities.domain.model.LearningActivity
 import org.hyperskill.app.learning_activities.domain.model.LearningActivityState
 import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
 import org.hyperskill.app.study_plan.domain.model.StudyPlanSectionType
-import org.hyperskill.app.study_plan.domain.model.activitiesToBeLoaded
+import org.hyperskill.app.study_plan.domain.model.rootTopicsActivitiesToBeLoaded
 import org.hyperskill.app.subscriptions.domain.model.SubscriptionLimitType
 import org.hyperskill.app.subscriptions.domain.model.getSubscriptionLimitType
 
@@ -56,7 +56,7 @@ internal fun StudyPlanWidgetFeature.State.getActivitiesToBeLoaded(sectionId: Lon
     val studyPlanSection = sectionInfo.studyPlanSection
     return if (studyPlanSection.type == StudyPlanSectionType.ROOT_TOPICS) {
         val sectionLoadedActivity = getLoadedSectionActivities(sectionId).map { it.id }.toSet()
-        studyPlanSection.activitiesToBeLoaded.subtract(sectionLoadedActivity)
+        studyPlanSection.rootTopicsActivitiesToBeLoaded.subtract(sectionLoadedActivity)
     } else {
         emptySet()
     }
@@ -65,7 +65,7 @@ internal fun StudyPlanWidgetFeature.State.getActivitiesToBeLoaded(sectionId: Lon
 internal fun StudyPlanSection.getActivitiesToBeLoaded(allLoadedActivities: Collection<LearningActivity>): Set<Long> =
     if (type == StudyPlanSectionType.ROOT_TOPICS) {
         val sectionActivities = activities.intersect(allLoadedActivities.map { it.id }.toSet())
-        activitiesToBeLoaded.subtract(sectionActivities)
+        rootTopicsActivitiesToBeLoaded.subtract(sectionActivities)
     } else {
         emptySet()
     }
@@ -105,7 +105,7 @@ internal fun StudyPlanWidgetFeature.State.getUnlockedActivitiesCount(sectionId: 
             isMobileContentTrialEnabled = isMobileContentTrialEnabled,
             canMakePayments = canMakePayments
         ) == SubscriptionLimitType.TOPICS
-    val unlockedActivitiesCount = profile?.feautureValues?.mobileContentTrialFreeTopics?.minus(learnedTopicsCount)
+    val unlockedActivitiesCount = profile?.featureValues?.mobileContentTrialFreeTopics?.minus(learnedTopicsCount)
     return if (isRootTopicsSection && isTopicsLimitEnabled && unlockedActivitiesCount != null) {
         unlockedActivitiesCount
     } else {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/model/StudyPlanWidgetViewState.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/model/StudyPlanWidgetViewState.kt
@@ -1,11 +1,11 @@
 package org.hyperskill.app.study_plan.widget.view.model
 
 sealed interface StudyPlanWidgetViewState {
-    object Idle : StudyPlanWidgetViewState
+    data object Idle : StudyPlanWidgetViewState
 
-    object Loading : StudyPlanWidgetViewState
+    data object Loading : StudyPlanWidgetViewState
 
-    object Error : StudyPlanWidgetViewState
+    data object Error : StudyPlanWidgetViewState
 
     data class Content(
         val isPaywallBannerShown: Boolean,
@@ -26,14 +26,15 @@ sealed interface StudyPlanWidgetViewState {
     }
 
     sealed interface SectionContent {
-        object Collapsed : SectionContent
+        data object Collapsed : SectionContent
 
-        object Loading : SectionContent
+        data object Loading : SectionContent
 
-        object Error : SectionContent
+        data object Error : SectionContent
 
         data class Content(
-            val sectionItems: List<SectionItem>
+            val sectionItems: List<SectionItem>,
+            val isLoadAllTopicsButtonShown: Boolean
         ) : SectionContent
     }
 

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/model/StudyPlanWidgetViewState.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/model/StudyPlanWidgetViewState.kt
@@ -34,6 +34,7 @@ sealed interface StudyPlanWidgetViewState {
 
         data class Content(
             val sectionItems: List<SectionItem>,
+            val isNextPageLoadingShowed: Boolean,
             val isLoadAllTopicsButtonShown: Boolean
         ) : SectionContent
     }

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -528,6 +528,7 @@
     <string name="study_plan_activities_error_text">Oops! We were unable to load the content.</string>
     <string name="study_plan_paywall_title">Learn unlimited with\nMobile only plan</string>
     <string name="study_plan_paywall_subscribe_button">Subscribe now</string>
+    <string name="study_plan_load_more_button_text">Load more</string>
 
     <!--Project selection list -->
     <string name="projects_list_toolbar_title">Select project</string>

--- a/shared/src/commonTest/kotlin/org/hyperskill/learning_activities/domain/model/LearningActivityStub.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/learning_activities/domain/model/LearningActivityStub.kt
@@ -1,0 +1,31 @@
+package org.hyperskill.learning_activities.domain.model
+
+import org.hyperskill.app.core.domain.model.ContentType
+import org.hyperskill.app.learning_activities.domain.model.LearningActivity
+import org.hyperskill.app.learning_activities.domain.model.LearningActivityState
+import org.hyperskill.app.learning_activities.domain.model.LearningActivityType
+
+fun LearningActivity.Companion.stub(
+    id: Long = 0,
+    state: LearningActivityState = LearningActivityState.TODO,
+    targetId: Long = 0L,
+    type: LearningActivityType = LearningActivityType.LEARN_TOPIC,
+    targetType: ContentType = ContentType.STEP,
+    title: String = "",
+    description: String? = null,
+    isIdeRequired: Boolean = false,
+    progress: Float = 0f,
+    topicId: Long? = null
+): LearningActivity =
+    LearningActivity(
+        id = id,
+        stateValue = state.value,
+        targetId = targetId,
+        typeValue = type.value,
+        targetType = targetType,
+        title = title,
+        description = description,
+        isIdeRequired = isIdeRequired,
+        progress = progress,
+        topicId = topicId
+    )

--- a/shared/src/commonTest/kotlin/org/hyperskill/profile/ProfileStub.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/profile/ProfileStub.kt
@@ -1,5 +1,6 @@
 package org.hyperskill.profile
 
+import org.hyperskill.app.profile.domain.model.FeatureValues
 import org.hyperskill.app.profile.domain.model.Gamification
 import org.hyperskill.app.profile.domain.model.Profile
 
@@ -9,6 +10,7 @@ fun Profile.Companion.stub(
     isGuest: Boolean = false,
     trackId: Long? = null,
     projectId: Long? = null,
+    featureValues: FeatureValues = FeatureValues(),
     featuresMap: Map<String, Boolean> = emptyMap()
 ): Profile =
     Profile(
@@ -36,5 +38,6 @@ fun Profile.Companion.stub(
         trackTitle = null,
         projectId = projectId,
         isBeta = isBeta,
+        featureValues = featureValues,
         featuresMap = featuresMap
     )

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/domain/model/StudyPlanSectionStub.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/domain/model/StudyPlanSectionStub.kt
@@ -1,0 +1,29 @@
+package org.hyperskill.study_plan.domain.model
+
+import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
+import org.hyperskill.app.study_plan.domain.model.StudyPlanSectionType
+
+fun StudyPlanSection.Companion.stub(
+    id: Long = 0,
+    type: StudyPlanSectionType = StudyPlanSectionType.STAGE,
+    nextActivityId: Long? = null,
+    isVisible: Boolean = true,
+    title: String = "title",
+    subtitle: String = "subtitle",
+    topicsCount: Int = 0,
+    completedTopicsCount: Int = 0,
+    secondsToComplete: Float = 100f,
+    activities: List<Long> = emptyList()
+): StudyPlanSection =
+    StudyPlanSection(
+        id = id,
+        typeValue = type.value,
+        nextActivityId = nextActivityId,
+        isVisible = isVisible,
+        title = title,
+        subtitle = subtitle,
+        topicsCount = topicsCount,
+        completedTopicsCount = completedTopicsCount,
+        secondsToComplete = secondsToComplete,
+        activities = activities
+    )

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/domain/model/StudyPlanSectionTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/domain/model/StudyPlanSectionTest.kt
@@ -1,0 +1,54 @@
+package org.hyperskill.study_plan.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
+import org.hyperskill.app.study_plan.domain.model.firstRootTopicsActivityIndexToBeLoaded
+import org.hyperskill.app.study_plan.domain.model.rootTopicsActivitiesToBeLoaded
+
+class StudyPlanSectionTest {
+    @Test
+    fun `firstRootTopicsActivityIndexToBeLoaded returns zero when nextActivityId is null`() {
+        val section = StudyPlanSection.stub(
+            nextActivityId = null,
+            activities = listOf(1L, 2L, 3L)
+        )
+        assertEquals(0, section.firstRootTopicsActivityIndexToBeLoaded)
+    }
+
+    @Test
+    fun `firstRootTopicsActivityIndexToBeLoaded returns index when nextActivityId is in activities`() {
+        val section = StudyPlanSection.stub(
+            nextActivityId = 2L,
+            activities = listOf(1L, 2L, 3L)
+        )
+        assertEquals(1, section.firstRootTopicsActivityIndexToBeLoaded)
+    }
+
+    @Test
+    fun `firstRootTopicsActivityIndexToBeLoaded returns zero when nextActivityId is not in activities`() {
+        val section = StudyPlanSection.stub(
+            nextActivityId = 4L,
+            activities = listOf(1L, 2L, 3L)
+        )
+        assertEquals(0, section.firstRootTopicsActivityIndexToBeLoaded)
+    }
+
+    @Test
+    fun `rootTopicsActivitiesToBeLoaded returns all activities when firstRootTopicsActivityIndex is zero`() {
+        val section = StudyPlanSection.stub(
+            nextActivityId = null,
+            activities = listOf(1L, 2L, 3L)
+        )
+        assertEquals(listOf(1L, 2L, 3L), section.rootTopicsActivitiesToBeLoaded)
+    }
+
+    @Test
+    fun `rootTopicsActivitiesToBeLoaded returns sublist when firstRootTopicsActivityIndex is non zero`() {
+        val section = StudyPlanSection.stub(
+            nextActivityId = 2L,
+            activities = listOf(1L, 2L, 3L)
+        )
+        assertEquals(listOf(2L, 3L), section.rootTopicsActivitiesToBeLoaded)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/screen/StudyPlanScreenTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/screen/StudyPlanScreenTest.kt
@@ -14,6 +14,7 @@ import org.hyperskill.app.study_plan.domain.analytic.StudyPlanViewedHyperskillAn
 import org.hyperskill.app.study_plan.screen.presentation.StudyPlanScreenFeature
 import org.hyperskill.app.study_plan.screen.presentation.StudyPlanScreenReducer
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
+import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.SectionStatus
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetReducer
 import org.hyperskill.app.users_interview_widget.presentation.UsersInterviewWidgetFeature
 import org.hyperskill.app.users_interview_widget.presentation.UsersInterviewWidgetReducer
@@ -61,7 +62,7 @@ class StudyPlanScreenTest {
             toolbarState = GamificationToolbarFeature.State.Loading,
             questionnaireWidgetState = UsersInterviewWidgetFeature.State.Loading,
             studyPlanWidgetState = StudyPlanWidgetFeature.State(
-                sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADING
+                sectionsStatus = SectionStatus.LOADING
             )
         )
 

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetStateExtensionsTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetStateExtensionsTest.kt
@@ -1,0 +1,375 @@
+package org.hyperskill.study_plan.widget
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.hyperskill.app.learning_activities.domain.model.LearningActivity
+import org.hyperskill.app.learning_activities.domain.model.LearningActivityState
+import org.hyperskill.app.profile.domain.model.FeatureKeys
+import org.hyperskill.app.profile.domain.model.FeatureValues
+import org.hyperskill.app.profile.domain.model.Profile
+import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
+import org.hyperskill.app.study_plan.domain.model.StudyPlanSectionType
+import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
+import org.hyperskill.app.study_plan.widget.presentation.getActivitiesToBeLoaded
+import org.hyperskill.app.study_plan.widget.presentation.getCurrentActivity
+import org.hyperskill.app.study_plan.widget.presentation.getCurrentSection
+import org.hyperskill.app.study_plan.widget.presentation.getLoadedSectionActivities
+import org.hyperskill.app.study_plan.widget.presentation.getUnlockedActivitiesCount
+import org.hyperskill.app.study_plan.widget.presentation.isActivityLocked
+import org.hyperskill.app.study_plan.widget.presentation.isPaywallShown
+import org.hyperskill.app.subscriptions.domain.model.Subscription
+import org.hyperskill.app.subscriptions.domain.model.SubscriptionStatus
+import org.hyperskill.app.subscriptions.domain.model.SubscriptionType
+import org.hyperskill.learning_activities.domain.model.stub
+import org.hyperskill.profile.stub
+import org.hyperskill.study_plan.domain.model.stub
+
+class StudyPlanWidgetStateExtensionsTest {
+    @Test
+    fun `getCurrentSection should return the first section`() {
+        val section1 = StudyPlanSection.stub(id = 1)
+        val section2 = StudyPlanSection.stub(id = 2)
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section1.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section1,
+                    true,
+                    StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                ),
+                section2.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section2,
+                    true,
+                    StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            )
+        )
+
+        val currentSection = state.getCurrentSection()
+        assertEquals(section1, currentSection)
+    }
+
+    @Test
+    fun `getCurrentActivity should return the next activity for ROOT_TOPICS section`() {
+        val nextActivityId = 1L
+        val section = StudyPlanSection.stub(
+            id = 1,
+            type = StudyPlanSectionType.ROOT_TOPICS,
+            nextActivityId = nextActivityId,
+            activities = listOf(nextActivityId)
+        )
+        val activity = LearningActivity.stub(id = nextActivityId)
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section,
+                    true,
+                    StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            activities = mapOf(activity.id to activity)
+        )
+
+        val currentActivity = state.getCurrentActivity()
+        assertEquals(activity, currentActivity)
+    }
+
+    @Test
+    fun `getCurrentActivity should return first TODO activity`() {
+        val section = StudyPlanSection.stub(id = 1, activities = listOf(1L, 2L))
+        val activity1 = LearningActivity.stub(id = 1, state = LearningActivityState.COMPLETED)
+        val activity2 = LearningActivity.stub(id = 2)
+
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section,
+                    isExpanded = false,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            activities = mapOf(activity1.id to activity1, activity2.id to activity2)
+        )
+
+        val currentActivity = state.getCurrentActivity()
+        assertEquals(activity2, currentActivity)
+    }
+
+    @Test
+    fun `getLoadedSectionActivities should return activities for given section`() {
+        val sectionId = 1L
+        val activities = listOf(1L, 2L).map { LearningActivity.stub(id = it) }
+        val section = StudyPlanSection.stub(id = sectionId, activities = activities.map { it.id })
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section,
+                    true,
+                    StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            activities = activities.associateBy { it.id }
+        )
+
+        val loadedActivities = state.getLoadedSectionActivities(sectionId).toList()
+        assertEquals(activities, loadedActivities)
+    }
+
+    @Test
+    fun `getActivitiesToBeLoaded should return activities to be loaded for ROOT_TOPICS section`() {
+        val sectionId = 1L
+        val activities = listOf(1L, 2L).map { LearningActivity.stub(id = it) }
+        val section = StudyPlanSection.stub(
+            id = sectionId,
+            type = StudyPlanSectionType.ROOT_TOPICS,
+            activities = activities.map { it.id }
+        )
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section,
+                    true,
+                    StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            activities = emptyMap()
+        )
+
+        val activitiesToBeLoaded = state.getActivitiesToBeLoaded(sectionId)
+        assertEquals(section.activities.toSet(), activitiesToBeLoaded)
+    }
+
+    @Test
+    fun `StudyPlanSection getActivitiesToBeLoaded should return activities to be loaded for a given section`() {
+        val section = StudyPlanSection.stub(
+            id = 1,
+            type = StudyPlanSectionType.ROOT_TOPICS,
+            activities = listOf(1L, 2L, 3L)
+        )
+        val loadedActivities = listOf(LearningActivity.stub(id = 1))
+
+        val activitiesToBeLoaded = section.getActivitiesToBeLoaded(loadedActivities)
+        assertEquals(setOf(2L, 3L), activitiesToBeLoaded)
+    }
+
+    @Test
+    fun `isActivityLocked should return true if activity is locked`() {
+        val section = StudyPlanSection.stub(
+            id = 1,
+            type = StudyPlanSectionType.ROOT_TOPICS,
+            activities = listOf(1L, 2L, 3L)
+        )
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section,
+                    isExpanded = false,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            activities = mapOf(1L to LearningActivity.stub(id = 1)),
+            profile = Profile.stub(),
+            subscription = Subscription(
+                type = SubscriptionType.MOBILE_CONTENT_TRIAL,
+                status = SubscriptionStatus.ACTIVE
+            ),
+            learnedTopicsCount = 1
+        )
+
+        val isLocked = state.isActivityLocked(section.id, 3L)
+        assertTrue(isLocked)
+    }
+
+    @Test
+    fun `getUnlockedActivitiesCount should return unlocked activities count for root topics section`() {
+        val section = StudyPlanSection.stub(
+            id = 1,
+            type = StudyPlanSectionType.ROOT_TOPICS,
+            activities = listOf(1L, 2L, 3L)
+        )
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section,
+                    isExpanded = false,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            profile = Profile.stub(
+                featureValues = FeatureValues(mobileContentTrialFreeTopics = 2),
+                featuresMap = mapOf(FeatureKeys.MOBILE_CONTENT_TRIAL to true),
+            ),
+            subscription = Subscription(
+                type = SubscriptionType.MOBILE_CONTENT_TRIAL,
+                status = SubscriptionStatus.ACTIVE
+            ),
+            learnedTopicsCount = 1
+        )
+
+        val unlockedCount = state.getUnlockedActivitiesCount(section.id)
+        assertEquals(1, unlockedCount)
+    }
+
+    @Test
+    fun `getUnlockedActivitiesCount should return null if not root topics section`() {
+        val section = StudyPlanSection.stub(
+            id = 1,
+            type = StudyPlanSectionType.STAGE,
+            activities = listOf(1L, 2L, 3L)
+        )
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section,
+                    isExpanded = false,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            profile = Profile.stub(
+                featureValues = FeatureValues(mobileContentTrialFreeTopics = 2),
+                featuresMap = mapOf(FeatureKeys.MOBILE_CONTENT_TRIAL to true),
+            ),
+            subscription = Subscription(
+                type = SubscriptionType.MOBILE_CONTENT_TRIAL,
+                status = SubscriptionStatus.ACTIVE
+            ),
+            learnedTopicsCount = 1
+        )
+
+        val unlockedCount = state.getUnlockedActivitiesCount(section.id)
+        assertNull(unlockedCount)
+    }
+
+    @Test
+    fun `isPaywallShown should return true if all free topics are solved in root topics section`() {
+        val section = StudyPlanSection.stub(
+            id = 1,
+            type = StudyPlanSectionType.ROOT_TOPICS,
+            activities = listOf(1L, 2L, 3L)
+        )
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section,
+                    isExpanded = false,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            profile = Profile.stub(
+                featureValues = FeatureValues(mobileContentTrialFreeTopics = 10),
+                featuresMap = mapOf(FeatureKeys.MOBILE_CONTENT_TRIAL to true),
+            ),
+            subscription = Subscription(
+                type = SubscriptionType.MOBILE_CONTENT_TRIAL,
+                status = SubscriptionStatus.ACTIVE
+            ),
+            learnedTopicsCount = 10
+        )
+
+        val isPaywallShown = state.isPaywallShown()
+        assertTrue(isPaywallShown)
+    }
+
+    @Test
+    fun `isPaywallShown should return false if not root topics section`() {
+        val section = StudyPlanSection.stub(
+            id = 1,
+            type = StudyPlanSectionType.STAGE,
+            activities = listOf(1L, 2L, 3L)
+        )
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section,
+                    isExpanded = false,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            profile = Profile.stub(
+                featureValues = FeatureValues(mobileContentTrialFreeTopics = 10),
+                featuresMap = mapOf(FeatureKeys.MOBILE_CONTENT_TRIAL to true),
+            ),
+            subscription = Subscription(
+                type = SubscriptionType.MOBILE_CONTENT_TRIAL,
+                status = SubscriptionStatus.ACTIVE
+            ),
+            learnedTopicsCount = 10
+        )
+
+        val isPaywallShown = state.isPaywallShown()
+        assertFalse(isPaywallShown)
+    }
+
+    @Test
+    fun `isPaywallShown should return false if there are multiple root topics sections`() {
+        val section1 = StudyPlanSection.stub(
+            id = 1,
+            type = StudyPlanSectionType.ROOT_TOPICS,
+            activities = listOf(1L)
+        )
+        val section2 = StudyPlanSection.stub(
+            id = 2,
+            type = StudyPlanSectionType.ROOT_TOPICS,
+            activities = listOf(2L)
+        )
+
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section1.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section1,
+                    isExpanded = false,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                ),
+                section2.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section2,
+                    isExpanded = false,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            profile = Profile.stub(
+                featureValues = FeatureValues(mobileContentTrialFreeTopics = 10),
+                featuresMap = mapOf(FeatureKeys.MOBILE_CONTENT_TRIAL to true),
+            ),
+            subscription = Subscription(
+                type = SubscriptionType.MOBILE_CONTENT_TRIAL,
+                status = SubscriptionStatus.ACTIVE
+            ),
+            learnedTopicsCount = 10
+        )
+
+        val isPaywallShown = state.isPaywallShown()
+        assertFalse(isPaywallShown)
+    }
+
+    @Test
+    fun `isPaywallShown should return false if unlocked activities count is greater than zero`() {
+        val section = StudyPlanSection.stub(
+            id = 1,
+            type = StudyPlanSectionType.ROOT_TOPICS,
+            activities = listOf(1L, 2L, 3L)
+        )
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    section,
+                    isExpanded = false,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            profile = Profile.stub(
+                featureValues = FeatureValues(mobileContentTrialFreeTopics = 10),
+                featuresMap = mapOf(FeatureKeys.MOBILE_CONTENT_TRIAL to true),
+            ),
+            subscription = Subscription(
+                type = SubscriptionType.MOBILE_CONTENT_TRIAL,
+                status = SubscriptionStatus.ACTIVE
+            ),
+            learnedTopicsCount = 5
+        )
+
+        val isPaywallShown = state.isPaywallShown()
+        assertFalse(isPaywallShown)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetTest.kt
@@ -22,6 +22,7 @@ import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
 import org.hyperskill.app.study_plan.domain.model.StudyPlanSectionType
 import org.hyperskill.app.study_plan.widget.domain.mapper.LearningActivityToTopicProgressMapper
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
+import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.SectionStatus
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetReducer
 import org.hyperskill.app.study_plan.widget.view.mapper.StudyPlanWidgetViewStateMapper
 import org.hyperskill.app.study_plan.widget.view.model.StudyPlanWidgetViewState
@@ -46,7 +47,7 @@ class StudyPlanWidgetTest {
         val initialState = StudyPlanWidgetFeature.State()
         val (state, actions) = reducer.reduce(initialState, StudyPlanWidgetFeature.InternalMessage.Initialize())
         assertContains(actions, StudyPlanWidgetFeature.InternalAction.FetchLearningActivitiesWithSections())
-        assertEquals(state.sectionsStatus, StudyPlanWidgetFeature.ContentStatus.LOADING)
+        assertEquals(state.sectionsStatus, SectionStatus.LOADING)
     }
 
     @Test
@@ -61,7 +62,7 @@ class StudyPlanWidgetTest {
                 learnedTopicsCount = 0
             )
         )
-        assertEquals(StudyPlanWidgetFeature.ContentStatus.LOADED, state.sectionsStatus)
+        assertEquals(SectionStatus.LOADED, state.sectionsStatus)
     }
 
     @Test
@@ -168,7 +169,7 @@ class StudyPlanWidgetTest {
     fun `Study plan sections should be empty if loaded sections does not contains current section`() {
         val expectedState = StudyPlanWidgetFeature.State(
             studyPlanSections = emptyMap(),
-            sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED,
+            sectionsStatus = SectionStatus.LOADED,
             isRefreshing = false
         )
 
@@ -209,7 +210,9 @@ class StudyPlanWidgetTest {
                                     activityId = 1,
                                     state = StudyPlanWidgetViewState.SectionItemState.NEXT
                                 )
-                            )
+                            ),
+                            isLoadAllTopicsButtonShown = false,
+                            isNextPageLoadingShowed = false
                         )
                     },
                     isCurrent = sectionId == expectedSectionsIds[0]
@@ -267,7 +270,7 @@ class StudyPlanWidgetTest {
         }
 
         val actualFirstSection = state.studyPlanSections[firstSection.id]
-        assertEquals(StudyPlanWidgetFeature.ContentStatus.LOADED, actualFirstSection?.contentStatus)
+        assertEquals(StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED, actualFirstSection?.sectionContentStatus)
         assertEquals(true, actualFirstSection?.isExpanded)
     }
 
@@ -278,7 +281,7 @@ class StudyPlanWidgetTest {
             studyPlanSections = mapOf(
                 sectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(sectionId),
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADING,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.NEXT_PAGE_LOADING,
                     isExpanded = true
                 )
             )
@@ -291,7 +294,7 @@ class StudyPlanWidgetTest {
                     activities = listOf(stubLearningActivity(1L))
                 )
             )
-        assertEquals(StudyPlanWidgetFeature.ContentStatus.LOADED, state.studyPlanSections[sectionId]?.contentStatus)
+        assertEquals(StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED, state.studyPlanSections[sectionId]?.sectionContentStatus)
     }
 
     @Test
@@ -302,12 +305,12 @@ class StudyPlanWidgetTest {
             studyPlanSections = mapOf(
                 currentSectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(currentSectionId),
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADING,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.NEXT_PAGE_LOADING,
                     isExpanded = true
                 ),
                 nextSectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(nextSectionId),
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE,
                     isExpanded = false
                 )
             )
@@ -320,7 +323,7 @@ class StudyPlanWidgetTest {
         assertTrue(state.studyPlanSections.containsKey(currentSectionId).not())
         val nextSection = state.studyPlanSections[nextSectionId]
         assertTrue(nextSection?.isExpanded == true)
-        assertEquals(StudyPlanWidgetFeature.ContentStatus.LOADING, nextSection?.contentStatus)
+        assertEquals(StudyPlanWidgetFeature.SectionContentStatus.NEXT_PAGE_LOADING, nextSection?.sectionContentStatus)
     }
 
     @Test
@@ -331,12 +334,12 @@ class StudyPlanWidgetTest {
             studyPlanSections = mapOf(
                 currentSectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(currentSectionId),
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED,
                     isExpanded = true
                 ),
                 notCurrent to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(notCurrent),
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADING,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.NEXT_PAGE_LOADING,
                     isExpanded = false
                 )
             )
@@ -383,7 +386,7 @@ class StudyPlanWidgetTest {
                         sectionId,
                         activities = activities.map { it.id }
                     ),
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADING,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.NEXT_PAGE_LOADING,
                     isExpanded = true
                 )
             )
@@ -426,7 +429,7 @@ class StudyPlanWidgetTest {
                                 sectionId,
                                 activities = oldActivities.map { it.id }
                             ),
-                            contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED,
+                            sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED,
                             isExpanded = true
                         )
                     )
@@ -448,7 +451,7 @@ class StudyPlanWidgetTest {
                 0L to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     section,
                     isExpanded = true,
-                    StudyPlanWidgetFeature.ContentStatus.ERROR
+                    StudyPlanWidgetFeature.SectionContentStatus.ERROR
                 )
             )
         )
@@ -464,7 +467,7 @@ class StudyPlanWidgetTest {
                 sentryTransaction = HyperskillSentryTransactionBuilder.buildStudyPlanWidgetFetchLearningActivities(true)
             )
         )
-        assertEquals(StudyPlanWidgetFeature.ContentStatus.LOADING, state.studyPlanSections[section.id]?.contentStatus)
+        assertEquals(StudyPlanWidgetFeature.SectionContentStatus.NEXT_PAGE_LOADING, state.studyPlanSections[section.id]?.sectionContentStatus)
 
         val analyticAction = actions.last() as StudyPlanWidgetFeature.InternalAction.LogAnalyticEvent
         if (analyticAction.analyticEvent is StudyPlanClickedRetryActivitiesLoadingHyperskillAnalyticEvent) {
@@ -481,20 +484,20 @@ class StudyPlanWidgetTest {
 
         val collapsedSection = StudyPlanWidgetFeature.StudyPlanSectionInfo(
             studyPlanSection = section,
-            contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED,
+            sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED,
             isExpanded = false
         )
 
         val idleSection = StudyPlanWidgetFeature.StudyPlanSectionInfo(
             studyPlanSection = section,
-            contentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+            sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE,
             isExpanded = false
         )
 
         listOf(collapsedSection, idleSection).forEach { givenSection ->
             val state = StudyPlanWidgetFeature.State(
                 studyPlanSections = mapOf(sectionId to givenSection),
-                sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                sectionsStatus = SectionStatus.LOADED
             )
 
             val viewState = studyPlanWidgetViewStateMapper.map(state)
@@ -520,12 +523,12 @@ class StudyPlanWidgetTest {
         val activityId = 0L
         val section = StudyPlanWidgetFeature.StudyPlanSectionInfo(
             studyPlanSection = studyPlanSectionStub(sectionId, activities = listOf(activityId)),
-            contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADING,
+            sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.NEXT_PAGE_LOADING,
             isExpanded = true
         )
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(sectionId to section),
-            sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED,
+            sectionsStatus = SectionStatus.LOADED,
             activities = mapOf(activityId to stubLearningActivity(activityId))
         )
 
@@ -542,7 +545,9 @@ class StudyPlanWidgetTest {
                                 activityId,
                                 state = StudyPlanWidgetViewState.SectionItemState.NEXT
                             )
-                        )
+                        ),
+                        isLoadAllTopicsButtonShown = false,
+                        isNextPageLoadingShowed = false
                     ),
                     isCurrent = true
                 )
@@ -559,12 +564,12 @@ class StudyPlanWidgetTest {
 
         val section = StudyPlanWidgetFeature.StudyPlanSectionInfo(
             studyPlanSection = studyPlanSectionStub(sectionId, activities = listOf(activityId)),
-            contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED,
+            sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED,
             isExpanded = true
         )
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(sectionId to section),
-            sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED,
+            sectionsStatus = SectionStatus.LOADED,
             activities = mapOf(activityId to stubLearningActivity(activityId))
         )
 
@@ -581,7 +586,9 @@ class StudyPlanWidgetTest {
                                 activityId,
                                 state = StudyPlanWidgetViewState.SectionItemState.NEXT
                             )
-                        )
+                        ),
+                        isLoadAllTopicsButtonShown = false,
+                        isNextPageLoadingShowed = false
                     ),
                     isCurrent = true
                 )
@@ -603,20 +610,20 @@ class StudyPlanWidgetTest {
         val sectionId = 0L
         val section = StudyPlanWidgetFeature.StudyPlanSectionInfo(
             studyPlanSection = studyPlanSectionStub(sectionId),
-            contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED,
+            sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED,
             isExpanded = true
         )
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(sectionId to section),
-            sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+            sectionsStatus = SectionStatus.LOADED
         )
 
         val (newState, actions) =
             reducer.reduce(state, StudyPlanWidgetFeature.InternalMessage.ReloadContentInBackground)
 
         assertEquals(
-            state.studyPlanSections[sectionId]?.contentStatus,
-            newState.studyPlanSections[sectionId]?.contentStatus
+            state.studyPlanSections[sectionId]?.sectionContentStatus,
+            newState.studyPlanSections[sectionId]?.sectionContentStatus
         )
         assertContains(actions, StudyPlanWidgetFeature.InternalAction.FetchLearningActivitiesWithSections())
     }
@@ -635,7 +642,9 @@ class StudyPlanWidgetTest {
                                 title = "Activity 1",
                                 state = StudyPlanWidgetViewState.SectionItemState.NEXT
                             )
-                        )
+                        ),
+                        isLoadAllTopicsButtonShown = false,
+                        isNextPageLoadingShowed = false
                     ),
                     isCurrent = true
                 )
@@ -647,13 +656,13 @@ class StudyPlanWidgetTest {
                 0L to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(id = 0, activities = listOf(0)),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             ),
             activities = mapOf(
                 0L to stubLearningActivity(id = 0, title = "Activity 1")
             ),
-            sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+            sectionsStatus = SectionStatus.LOADED
         )
 
         val viewState = studyPlanWidgetViewStateMapper.map(state)
@@ -674,7 +683,9 @@ class StudyPlanWidgetTest {
                                 title = "0",
                                 state = StudyPlanWidgetViewState.SectionItemState.NEXT
                             )
-                        )
+                        ),
+                        isLoadAllTopicsButtonShown = false,
+                        isNextPageLoadingShowed = false
                     ),
                     isCurrent = true
                 )
@@ -686,11 +697,11 @@ class StudyPlanWidgetTest {
                 0L to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(id = 0, activities = listOf(0)),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             ),
             activities = mapOf(0L to stubLearningActivity(id = 0, title = "")),
-            sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+            sectionsStatus = SectionStatus.LOADED
         )
 
         val viewState = studyPlanWidgetViewStateMapper.map(state)
@@ -712,7 +723,9 @@ class StudyPlanWidgetTest {
                                 subtitle = "Hello, coffee!",
                                 state = StudyPlanWidgetViewState.SectionItemState.NEXT
                             )
-                        )
+                        ),
+                        isLoadAllTopicsButtonShown = false,
+                        isNextPageLoadingShowed = false
                     ),
                     isCurrent = true
                 )
@@ -724,7 +737,7 @@ class StudyPlanWidgetTest {
                 0L to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(id = 0, activities = listOf(0)),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             ),
             activities = mapOf(
@@ -734,7 +747,7 @@ class StudyPlanWidgetTest {
                     description = "Work on project. Stage: 1/6"
                 )
             ),
-            sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+            sectionsStatus = SectionStatus.LOADED
         )
 
         val viewState = studyPlanWidgetViewStateMapper.map(state)
@@ -753,10 +766,10 @@ class StudyPlanWidgetTest {
                             topicsCount = 10
                         ),
                         isExpanded = isExpanded,
-                        contentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE
+                        sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
                     )
                 ),
-                sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                sectionsStatus = SectionStatus.LOADED
             )
 
         val expectedViewState = StudyPlanWidgetViewState.Content(
@@ -789,19 +802,23 @@ class StudyPlanWidgetTest {
                                 activityId = 0,
                                 state = StudyPlanWidgetViewState.SectionItemState.NEXT
                             )
-                        )
+                        ),
+                        isLoadAllTopicsButtonShown = false,
+                        isNextPageLoadingShowed = false
                     ),
                     isCurrent = true
                 ),
                 sectionViewState(
                     section = studyPlanSectionStub(id = 1),
                     content = StudyPlanWidgetViewState.SectionContent.Content(
-                        listOf(
+                        sectionItems = listOf(
                             studyPlanSectionItemStub(
                                 activityId = 1,
                                 state = StudyPlanWidgetViewState.SectionItemState.IDLE
                             )
-                        )
+                        ),
+                        isLoadAllTopicsButtonShown = false,
+                        isNextPageLoadingShowed = false
                     ),
                     isCurrent = false,
                     formattedTopicsCount = "1 / 10",
@@ -815,7 +832,7 @@ class StudyPlanWidgetTest {
                 0L to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(id = 0, activities = listOf(0)),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 ),
                 1L to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(
@@ -825,14 +842,14 @@ class StudyPlanWidgetTest {
                         topicsCount = 10
                     ),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             ),
             activities = mapOf(
                 0L to stubLearningActivity(id = 0),
                 1L to stubLearningActivity(id = 1)
             ),
-            sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+            sectionsStatus = SectionStatus.LOADED
         )
 
         val viewState = studyPlanWidgetViewStateMapper.map(state)
@@ -852,7 +869,7 @@ class StudyPlanWidgetTest {
                 sectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(id = sectionId, activities = listOf(activityId)),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             ),
             activities = mapOf(
@@ -890,7 +907,7 @@ class StudyPlanWidgetTest {
                 sectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(id = 0, activities = listOf(activityId)),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             ),
             activities = mapOf(
@@ -924,7 +941,7 @@ class StudyPlanWidgetTest {
                 sectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(id = sectionId, activities = listOf(activityId)),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             ),
             activities = mapOf(
@@ -972,7 +989,7 @@ class StudyPlanWidgetTest {
                 0L to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(id = 0, activities = listOf(activityId)),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             ),
             activities = mapOf(
@@ -1006,7 +1023,7 @@ class StudyPlanWidgetTest {
                 sectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(id = sectionId, activities = listOf(activityId)),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             ),
             activities = mapOf(
@@ -1047,7 +1064,7 @@ class StudyPlanWidgetTest {
                 sectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(id = sectionId, activities = listOf(activityId)),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             ),
             activities = mapOf(
@@ -1079,7 +1096,7 @@ class StudyPlanWidgetTest {
                 sectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(id = sectionId, activities = listOf(activityId)),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             ),
             activities = mapOf(
@@ -1110,7 +1127,7 @@ class StudyPlanWidgetTest {
                 sectionId to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = studyPlanSectionStub(id = sectionId),
                     isExpanded = false,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             )
         )
@@ -1137,7 +1154,7 @@ class StudyPlanWidgetTest {
                 activities = expectedActivitiesIds
             ),
             isExpanded = false,
-            contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+            sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
         )
 
         assertEquals(
@@ -1156,7 +1173,7 @@ class StudyPlanWidgetTest {
                 activities = expectedActivitiesIds
             ),
             isExpanded = false,
-            contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+            sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
         )
 
         assertEquals(
@@ -1176,7 +1193,7 @@ class StudyPlanWidgetTest {
                 nextActivityId = 3L
             ),
             isExpanded = false,
-            contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+            sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
         )
 
         assertEquals(
@@ -1196,7 +1213,7 @@ class StudyPlanWidgetTest {
                 nextActivityId = 5L
             ),
             isExpanded = false,
-            contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+            sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
         )
 
         assertEquals(
@@ -1216,7 +1233,7 @@ class StudyPlanWidgetTest {
                 nextActivityId = 10L
             ),
             isExpanded = false,
-            contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+            sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
         )
 
         assertEquals(
@@ -1236,7 +1253,7 @@ class StudyPlanWidgetTest {
                 nextActivityId = 5L
             ),
             isExpanded = false,
-            contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+            sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
         )
 
         assertEquals(
@@ -1259,14 +1276,14 @@ class StudyPlanWidgetTest {
                         nextActivityId = nextActivityId
                     ),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             ),
             activities = mapOf(
                 notNextActivityId to stubLearningActivity(notNextActivityId),
                 nextActivityId to stubLearningActivity(nextActivityId)
             ),
-            sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+            sectionsStatus = SectionStatus.LOADED
         )
 
         val viewState = studyPlanWidgetViewStateMapper.map(state)
@@ -1302,14 +1319,14 @@ class StudyPlanWidgetTest {
                         nextActivityId = null
                     ),
                     isExpanded = true,
-                    contentStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
                 )
             ),
             activities = mapOf(
                 firstActivityId to stubLearningActivity(firstActivityId),
                 secondActivityId to stubLearningActivity(secondActivityId)
             ),
-            sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED
+            sectionsStatus = SectionStatus.LOADED
         )
 
         val viewState = studyPlanWidgetViewStateMapper.map(state)


### PR DESCRIPTION
**YouTrack Issues**:
[ALTAPPS-1301](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1301)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] New analytics events are documented;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Add `StudyPlanWidgetFeature.State.getActivitiesToBeLoaded` & `StudyPlanSection.getActivitiesToBeLoaded` to determine which activities are still not loaded;
- Add `StudyPlanWidgetFeature.Message.LoadMoreActivitiesClicked`;
- Add `isNextPageLoadingShowed` & `isLoadAllTopicsButtonShown` to the `StudyPlanWidgetViewState.SectionContent.Content`;
- Split `StudyPlanWidgetFeature.ContentStatus` to `StudyPlanWidgetFeature.SectionStatus` & `StudyPlanWidgetViewState.SectionContentStatus`; add `FIRST_PAGE_LOADING` `NEXT_PAGE_LOADING`, `PAGE_LOADED`, `ALL_PAGES_LOADED` to describe pages loading;
- Remove replacing old section activities with new loaded activities for RootTopics section.