### PR TITLE
ALTAPPS-1308: Shared speed up code submissions evaluation for beginners by removing linters

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Extensions/Shared/Model/ReplyExtensions.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Extensions/Shared/Model/ReplyExtensions.swift
@@ -44,7 +44,8 @@ extension Reply {
             solution: solution,
             checkProfile: checkProfile,
             lines: lines,
-            prompt: nil
+            prompt: nil, 
+            lintProfile: nil
         )
     }
 }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCode/StepQuizCodeViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCode/StepQuizCodeViewModel.swift
@@ -82,7 +82,11 @@ class StepQuizCodeViewModel: ObservableObject {
 extension StepQuizCodeViewModel: StepQuizChildQuizInputProtocol {
     @objc
     func createReply() -> Reply {
-        Reply(language: viewData.languageStringValue, code: viewData.code)
+        Reply.Companion.shared.code(
+            code: viewData.code,
+            language: viewData.languageStringValue,
+            lintProfile: nil
+        )
     }
 
     func update(step: Step, dataset: Dataset, reply: Reply?) {
@@ -148,7 +152,11 @@ extension StepQuizCodeViewModel: StepQuizCodeFullScreenOutputProtocol {
 
     @objc
     func syncReply(code: String?) {
-        let reply = Reply.Companion.shared.code(code: code, language: viewData.languageStringValue)
+        let reply = Reply.Companion.shared.code(
+            code: code,
+            language: viewData.languageStringValue,
+            lintProfile: nil
+        )
         moduleOutput?.handleChildQuizSync(reply: reply)
     }
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/submissions/domain/model/Reply.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/submissions/domain/model/Reply.kt
@@ -40,14 +40,16 @@ data class Reply(
     @SerialName("lines")
     val lines: List<ParsonsLine>? = null,
     @SerialName("prompt")
-    val prompt: String? = null
+    val prompt: String? = null,
+    @SerialName("lint_profile")
+    val lintProfile: String? = ""
 ) {
 
     companion object {
         internal const val PROMPT_MANUALLY_CONFIRMED_SCORE: Float = 1F
 
-        fun code(code: String?, language: String?): Reply =
-            Reply(code = code, language = language)
+        fun code(code: String?, language: String?, lintProfile: String? = null): Reply =
+            Reply(code = code, language = language, lintProfile = lintProfile)
 
         fun sql(sqlCode: String?): Reply =
             Reply(solveSql = sqlCode)

--- a/shared/src/commonTest/kotlin/org/hyperskill/ReplySerializationTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/ReplySerializationTest.kt
@@ -3,6 +3,7 @@ package org.hyperskill
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -297,5 +298,57 @@ class ReplySerializationTest {
             "{ \"prompt\": \"prompt\" }"
         )
         assertEquals(expectedReply, decodedReply)
+    }
+
+    @Test
+    fun `Code Reply serialization with nullable lint_profile`() {
+        val json = NetworkModule.provideJson()
+        val encodedValue = json.encodeToJsonElement(
+            Reply.code(
+                code = "code",
+                language = "language"
+            )
+        )
+        val expected = buildJsonObject {
+            put("code", JsonPrimitive("code"))
+            put("language", JsonPrimitive("language"))
+            put("lint_profile", JsonNull)
+        }
+        assertEquals(expected, encodedValue)
+    }
+
+    @Test
+    fun `Code Reply serialization with provided lint_profile`() {
+        val json = NetworkModule.provideJson()
+        val encodedValue = json.encodeToJsonElement(
+            Reply.code(
+                code = "code",
+                language = "language",
+                lintProfile = "lint_profile"
+            )
+        )
+        val expected = buildJsonObject {
+            put("code", JsonPrimitive("code"))
+            put("language", JsonPrimitive("language"))
+            put("lint_profile", JsonPrimitive("lint_profile"))
+        }
+        assertEquals(expected, encodedValue)
+    }
+
+    @Test
+    fun `Code Reply serialization with default lint_profile`() {
+        val json = NetworkModule.provideJson()
+        val encodedValue = json.encodeToJsonElement(
+            Reply.code(
+                code = "code",
+                language = "language",
+                lintProfile = ""
+            )
+        )
+        val expected = buildJsonObject {
+            put("code", JsonPrimitive("code"))
+            put("language", JsonPrimitive("language"))
+        }
+        assertEquals(expected, encodedValue)
     }
 }


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1308](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1308)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

1. Adds `"lint_profile": null` in the reply for code problems.
2. Our JSON configuration does not encode defaults ([code](https://github.com/hyperskill/mobile-app/blob/1b9e0c497e33cc06fff6ec3d77e8c9389ea9d098/shared/src/commonMain/kotlin/org/hyperskill/app/network/injection/NetworkModule.kt#L17), [docs](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json-configuration/encode-defaults.html)), so I made `Reply.lintProfile` with a `String?` type and a default value of an empty string to be able to serialize `null`.