### PR TITLE
ALTAPPS-1317: Shared fix subscription management is not available for MobileContentTrial subscription

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile_settings/presentation/ProfileSettingsReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile_settings/presentation/ProfileSettingsReducer.kt
@@ -189,8 +189,8 @@ internal class ProfileSettingsReducer : StateReducer<State, Message, Action> {
         state: State
     ): ReducerResult =
         if (state is State.Content) {
-            state to when (state.subscription?.type) {
-                SubscriptionType.MOBILE_ONLY ->
+            state to when {
+                state.subscription?.type == SubscriptionType.MOBILE_ONLY ->
                     setOf(
                         Action.LogAnalyticEvent(
                             ProfileSettingsClickedHyperskillAnalyticEvent(
@@ -199,7 +199,7 @@ internal class ProfileSettingsReducer : StateReducer<State, Message, Action> {
                         ),
                         Action.ViewAction.NavigateTo.SubscriptionManagement
                     )
-                SubscriptionType.FREEMIUM ->
+                state.subscription?.type?.canUpgradeToMobileOnly == true ->
                     setOf(
                         Action.LogAnalyticEvent(
                             ProfileSettingsClickedHyperskillAnalyticEvent(

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/profile_settings/view/ProfileSettingsViewStateMapper.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/profile_settings/view/ProfileSettingsViewStateMapper.kt
@@ -20,21 +20,20 @@ internal class ProfileSettingsViewStateMapper(
         ViewState.Content(
             profileSettings = state.profileSettings,
             isLoadingMagicLink = state.isLoadingMagicLink,
-            subscriptionState = if (isSubscriptionVisible(state)) {
-                when (state.subscription?.type) {
-                    SubscriptionType.MOBILE_ONLY ->
+            subscriptionState = if (state.subscription != null && state.mobileOnlyFormattedPrice != null) {
+                when {
+                    state.subscription.type == SubscriptionType.MOBILE_ONLY -> {
                         ViewState.Content.SubscriptionState(
                             resourceProvider.getString(SharedResources.strings.settings_subscription_mobile_only)
                         )
-                    SubscriptionType.FREEMIUM -> {
-                        state.mobileOnlyFormattedPrice?.let {
-                            ViewState.Content.SubscriptionState(
-                                resourceProvider.getString(
-                                    SharedResources.strings.settings_subscription_mobile_only_suggestion,
-                                    state.mobileOnlyFormattedPrice
-                                )
+                    }
+                    state.subscription.type.canUpgradeToMobileOnly -> {
+                        ViewState.Content.SubscriptionState(
+                            resourceProvider.getString(
+                                SharedResources.strings.settings_subscription_mobile_only_suggestion,
+                                state.mobileOnlyFormattedPrice
                             )
-                        }
+                        )
                     }
                     else -> null
                 }
@@ -42,13 +41,4 @@ internal class ProfileSettingsViewStateMapper(
                 null
             }
         )
-
-    private fun isSubscriptionVisible(state: ProfileSettingsFeature.State.Content): Boolean =
-        state.subscription != null &&
-            state.mobileOnlyFormattedPrice != null &&
-            when (state.subscription.type) {
-                SubscriptionType.FREEMIUM,
-                SubscriptionType.MOBILE_ONLY -> true
-                else -> false
-            }
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/subscriptions/domain/model/SubscriptionType.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/subscriptions/domain/model/SubscriptionType.kt
@@ -9,6 +9,8 @@ enum class SubscriptionType(
     val isProjectInfoAvailable: Boolean = true,
     val isCertificateAvailable: Boolean = true,
     val areHintsLimited: Boolean = false,
+    val isSubscriptionSettingsVisible: Boolean = false,
+    val canUpgradeToMobileOnly: Boolean = false,
     val subscriptionLimitType: SubscriptionLimitType = SubscriptionLimitType.NONE
 ) {
     @SerialName("personal")
@@ -39,12 +41,16 @@ enum class SubscriptionType(
         isCertificateAvailable = false,
         isProjectInfoAvailable = false,
         areHintsLimited = true,
+        isSubscriptionSettingsVisible = true,
+        canUpgradeToMobileOnly = true,
         subscriptionLimitType = SubscriptionLimitType.PROBLEMS
     ),
     MOBILE_CONTENT_TRIAL(
         isCertificateAvailable = false,
         isProjectInfoAvailable = false,
         areHintsLimited = true,
+        isSubscriptionSettingsVisible = true,
+        canUpgradeToMobileOnly = true,
         subscriptionLimitType = SubscriptionLimitType.TOPICS
     ),
 
@@ -52,7 +58,8 @@ enum class SubscriptionType(
     MOBILE_ONLY(
         isCertificateAvailable = false,
         isProjectInfoAvailable = false,
-        areHintsLimited = true
+        areHintsLimited = true,
+        isSubscriptionSettingsVisible = true,
     ),
 
     @SerialName("premium")

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/subscriptions/domain/model/SubscriptionType.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/subscriptions/domain/model/SubscriptionType.kt
@@ -9,7 +9,6 @@ enum class SubscriptionType(
     val isProjectInfoAvailable: Boolean = true,
     val isCertificateAvailable: Boolean = true,
     val areHintsLimited: Boolean = false,
-    val isSubscriptionSettingsVisible: Boolean = false,
     val canUpgradeToMobileOnly: Boolean = false,
     val subscriptionLimitType: SubscriptionLimitType = SubscriptionLimitType.NONE
 ) {
@@ -41,7 +40,6 @@ enum class SubscriptionType(
         isCertificateAvailable = false,
         isProjectInfoAvailable = false,
         areHintsLimited = true,
-        isSubscriptionSettingsVisible = true,
         canUpgradeToMobileOnly = true,
         subscriptionLimitType = SubscriptionLimitType.PROBLEMS
     ),
@@ -49,7 +47,6 @@ enum class SubscriptionType(
         isCertificateAvailable = false,
         isProjectInfoAvailable = false,
         areHintsLimited = true,
-        isSubscriptionSettingsVisible = true,
         canUpgradeToMobileOnly = true,
         subscriptionLimitType = SubscriptionLimitType.TOPICS
     ),
@@ -58,8 +55,7 @@ enum class SubscriptionType(
     MOBILE_ONLY(
         isCertificateAvailable = false,
         isProjectInfoAvailable = false,
-        areHintsLimited = true,
-        isSubscriptionSettingsVisible = true,
+        areHintsLimited = true
     ),
 
     @SerialName("premium")


### PR DESCRIPTION
**YouTrack Issues**:
[ALTAPPS-1317](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1317)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Add `SubscriptionType.canUpgradeToMobileOnly` flag;
- Update subscription management conditions in `ProfileSettingsViewStateMapper` & `ProfileSettingsReducer.handleSubscriptionDetailsClicked`.