### PR TITLE
ALTAPPS-1318: Shared code blanks variable block type improvements

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz_matching/view/delegate/MatchingStepQuizFormDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz_matching/view/delegate/MatchingStepQuizFormDelegate.kt
@@ -9,6 +9,7 @@ import org.hyperskill.app.android.step_quiz_table.view.adapter.TableSelectionIte
 import org.hyperskill.app.android.step_quiz_table.view.fragment.TableColumnSelectionBottomSheetDialogFragment
 import org.hyperskill.app.android.step_quiz_table.view.model.TableChoiceItem
 import org.hyperskill.app.android.step_quiz_table.view.model.TableSelectionItem
+import org.hyperskill.app.core.utils.indexOfFirstOrNull
 import org.hyperskill.app.step_quiz.presentation.StepQuizFeature
 import org.hyperskill.app.step_quiz.presentation.StepQuizResolver
 import org.hyperskill.app.step_quiz.presentation.submission
@@ -79,13 +80,10 @@ class MatchingStepQuizFormDelegate(
     ): List<TableSelectionItem> {
         val selectedAnswerIndex =
             answers
-                .indexOfFirst { it.answer }
-                .takeIf { it != -1 }
+                .indexOfFirstOrNull { it.answer }
                 ?: return rows
         val rowIndexToSwap =
-            rows
-                .indexOfFirst { it.tableChoices[selectedAnswerIndex].answer }
-                .takeIf { it != -1 }
+            rows.indexOfFirstOrNull { it.tableChoices[selectedAnswerIndex].answer }
         return rows.mutate {
             val currentRow = get(currentRowIndex)
             if (rowIndexToSwap != null) {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/comments/screen/presentation/CommentsScreenReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/comments/screen/presentation/CommentsScreenReducer.kt
@@ -11,6 +11,7 @@ import org.hyperskill.app.comments.screen.presentation.CommentsScreenFeature.Int
 import org.hyperskill.app.comments.screen.presentation.CommentsScreenFeature.InternalMessage
 import org.hyperskill.app.comments.screen.presentation.CommentsScreenFeature.Message
 import org.hyperskill.app.comments.screen.presentation.CommentsScreenFeature.State
+import org.hyperskill.app.core.utils.indexOfFirstOrNull
 import org.hyperskill.app.core.utils.mutate
 import org.hyperskill.app.discussions.domain.model.getRepliesIds
 import org.hyperskill.app.discussions.remote.model.toPagedList
@@ -186,8 +187,7 @@ internal class CommentsScreenReducer : StateReducer<State, Message, Action> {
 
         val comment = discussionsState.commentsMap[message.commentId] ?: return null
         val reactionIndex = comment.reactions
-            .indexOfFirst { it.reactionType == message.reactionType }
-            .takeIf { it != -1 }
+            .indexOfFirstOrNull { it.reactionType == message.reactionType }
             ?: return null
         val reaction = comment.reactions[reactionIndex]
         val isSettingReaction = !reaction.isSet

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/core/utils/CollectionExtensions.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/core/utils/CollectionExtensions.kt
@@ -2,3 +2,6 @@ package org.hyperskill.app.core.utils
 
 fun <K, V> Map<K, V>.mutate(block: MutableMap<K, V>.() -> Unit): Map<K, V> =
     this.toMutableMap().apply(block)
+
+inline fun <T> List<T>.indexOfFirstOrNull(predicate: (T) -> Boolean): Int? =
+    indexOfFirst(predicate).takeIf { it >= 0 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/domain/model/CodeBlock.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/domain/model/CodeBlock.kt
@@ -1,5 +1,7 @@
 package org.hyperskill.app.step_quiz_code_blanks.domain.model
 
+import org.hyperskill.app.core.utils.indexOfFirstOrNull
+
 sealed class CodeBlock {
     internal abstract val isActive: Boolean
 
@@ -15,7 +17,7 @@ sealed class CodeBlock {
         children.firstOrNull { it.isActive }
 
     internal fun activeChildIndex(): Int? =
-        children.indexOfFirst { it.isActive }.takeIf { it != -1 }
+        children.indexOfFirstOrNull { it.isActive }
 
     internal data class Blank(
         override val isActive: Boolean,

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/presentation/StepQuizCodeBlanksReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/presentation/StepQuizCodeBlanksReducer.kt
@@ -1,5 +1,6 @@
 package org.hyperskill.app.step_quiz_code_blanks.presentation
 
+import org.hyperskill.app.core.utils.indexOfFirstOrNull
 import org.hyperskill.app.step.domain.model.StepRoute
 import org.hyperskill.app.step_quiz_code_blanks.domain.analytic.StepQuizCodeBlanksClickedCodeBlockChildHyperskillAnalyticEvent
 import org.hyperskill.app.step_quiz_code_blanks.domain.analytic.StepQuizCodeBlanksClickedCodeBlockHyperskillAnalyticEvent
@@ -121,6 +122,18 @@ class StepQuizCodeBlanksReducer(
                                         selectedSuggestion = message.suggestion as? Suggestion.ConstantString
                                     )
                                 )
+
+                                val nextUnselectedChildIndex = this.indexOfFirstOrNull { it.selectedSuggestion == null }
+                                if (nextUnselectedChildIndex != null) {
+                                    set(
+                                        nextUnselectedChildIndex,
+                                        this[nextUnselectedChildIndex].copy(isActive = true)
+                                    )
+                                    set(
+                                        activeChildIndex,
+                                        this[activeChildIndex].copy(isActive = false)
+                                    )
+                                }
                             }
                         )
                     } ?: activeCodeBlock

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/presentation/StepQuizCodeBlanksStateExtensions.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/presentation/StepQuizCodeBlanksStateExtensions.kt
@@ -15,6 +15,9 @@ internal val StepQuizCodeBlanksFeature.State.isVariableSuggestionsAvailable: Boo
 
 fun StepQuizCodeBlanksFeature.State.Content.createReply(): Reply =
     Reply.code(
-        code = codeBlocks.joinToString(separator = "\n") { it.toReplyString() },
+        code = buildString {
+            append("# solved with code blanks\n")
+            append(codeBlocks.joinToString(separator = "\n") { it.toReplyString() })
+        },
         language = step.block.options.codeTemplates?.keys?.firstOrNull()
     )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/presentation/StepQuizCodeBlanksStateExtensions.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/presentation/StepQuizCodeBlanksStateExtensions.kt
@@ -1,13 +1,12 @@
 package org.hyperskill.app.step_quiz_code_blanks.presentation
 
+import org.hyperskill.app.core.utils.indexOfFirstOrNull
 import org.hyperskill.app.submissions.domain.model.Reply
 
 internal fun StepQuizCodeBlanksFeature.State.Content.activeCodeBlockIndex(): Int? =
-    codeBlocks
-        .indexOfFirst { codeBlock ->
-            codeBlock.isActive || codeBlock.children.any { it.isActive }
-        }
-        .takeIf { it != -1 }
+    codeBlocks.indexOfFirstOrNull { codeBlock ->
+        codeBlock.isActive || codeBlock.children.any { it.isActive }
+    }
 
 internal val StepQuizCodeBlanksFeature.State.isVariableSuggestionsAvailable: Boolean
     get() = (this as? StepQuizCodeBlanksFeature.State.Content)?.step?.let {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_fill_blanks/presentation/FillBlanksItemMapper.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_fill_blanks/presentation/FillBlanksItemMapper.kt
@@ -1,6 +1,7 @@
 package org.hyperskill.app.step_quiz_fill_blanks.presentation
 
 import org.hyperskill.app.core.utils.DotMatchesAllRegexOption
+import org.hyperskill.app.core.utils.indexOfFirstOrNull
 import org.hyperskill.app.step_quiz.domain.model.attempts.Attempt
 import org.hyperskill.app.step_quiz.domain.model.attempts.Component
 import org.hyperskill.app.step_quiz.domain.model.attempts.Dataset
@@ -191,9 +192,7 @@ class FillBlanksItemMapper(private val mode: FillBlanksMode) {
         optionIndex: Int
     ): Int? {
         val replyOption = replyBlanks?.getOrNull(optionIndex) ?: return null
-        return blankOptions
-            .indexOfFirst { it.originalText == replyOption }
-            .takeIf { it != -1 }
+        return blankOptions.indexOfFirstOrNull { it.originalText == replyOption }
     }
 
     private fun parseLanguage(langClass: String): String? =

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -2,6 +2,7 @@ package org.hyperskill.app.study_plan.widget.presentation
 
 import kotlin.math.min
 import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticRoute
+import org.hyperskill.app.core.utils.indexOfFirstOrNull
 import org.hyperskill.app.core.utils.mutate
 import org.hyperskill.app.learning_activities.domain.model.LearningActivity
 import org.hyperskill.app.learning_activities.presentation.mapper.LearningActivityTargetViewActionMapper
@@ -203,10 +204,9 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
          */
         val visibleSections = sections.filter { it.isVisible }
         val currentSectionIndex = visibleSections
-            .indexOfFirst { studyPlanSection ->
+            .indexOfFirstOrNull { studyPlanSection ->
                 studyPlanSection.activities.intersect(learningActivitiesIds).isNotEmpty()
             }
-            .takeIf { it != -1 }
             ?: return emptyList()
         return visibleSections.slice(from = currentSectionIndex)
     }

--- a/shared/src/commonTest/kotlin/org/hyperskill/step_quiz_code_blanks/StepQuizCodeBlanksReducerTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/step_quiz_code_blanks/StepQuizCodeBlanksReducerTest.kt
@@ -193,7 +193,7 @@ class StepQuizCodeBlanksReducerTest {
     }
 
     @Test
-    fun `SuggestionClicked should update Variable code block with selected suggestion`() {
+    fun `SuggestionClicked should update Variable code block with selected suggestion for name`() {
         val suggestion = Suggestion.ConstantString("suggestion")
         val initialState = stubContentState(
             codeBlocks = listOf(
@@ -222,14 +222,63 @@ class StepQuizCodeBlanksReducerTest {
                 CodeBlock.Variable(
                     children = listOf(
                         CodeBlockChild.SelectSuggestion(
-                            isActive = true,
+                            isActive = false,
                             suggestions = listOf(suggestion),
                             selectedSuggestion = suggestion
                         ),
                         CodeBlockChild.SelectSuggestion(
+                            isActive = true,
+                            suggestions = listOf(suggestion),
+                            selectedSuggestion = null
+                        )
+                    )
+                )
+            )
+        )
+
+        assertTrue(state is StepQuizCodeBlanksFeature.State.Content)
+        assertEquals(expectedState.codeBlocks, state.codeBlocks)
+        assertContainsSuggestionClickedAnalyticEvent(actions)
+    }
+
+    @Test
+    fun `SuggestionClicked should update Variable code block with selected suggestion for value`() {
+        val suggestion = Suggestion.ConstantString("suggestion")
+        val initialState = stubContentState(
+            codeBlocks = listOf(
+                CodeBlock.Variable(
+                    children = listOf(
+                        CodeBlockChild.SelectSuggestion(
                             isActive = false,
                             suggestions = listOf(suggestion),
                             selectedSuggestion = null
+                        ),
+                        CodeBlockChild.SelectSuggestion(
+                            isActive = true,
+                            suggestions = listOf(suggestion),
+                            selectedSuggestion = null
+                        )
+                    )
+                )
+            )
+        )
+
+        val message = StepQuizCodeBlanksFeature.Message.SuggestionClicked(suggestion)
+        val (state, actions) = reducer.reduce(initialState, message)
+
+        val expectedState = initialState.copy(
+            codeBlocks = listOf(
+                CodeBlock.Variable(
+                    children = listOf(
+                        CodeBlockChild.SelectSuggestion(
+                            isActive = true,
+                            suggestions = listOf(suggestion),
+                            selectedSuggestion = null
+                        ),
+                        CodeBlockChild.SelectSuggestion(
+                            isActive = false,
+                            suggestions = listOf(suggestion),
+                            selectedSuggestion = suggestion
                         )
                     )
                 )

--- a/shared/src/commonTest/kotlin/org/hyperskill/step_quiz_code_blanks/StepQuizCodeBlanksStateExtensionsTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/step_quiz_code_blanks/StepQuizCodeBlanksStateExtensionsTest.kt
@@ -82,7 +82,13 @@ class StepQuizCodeBlanksStateExtensionsTest {
             codeBlocks = codeBlocks
         )
 
-        val expectedReply = Reply.code(code = "print(\"test\")\n", language = "python3")
+        val expectedReply = Reply.code(
+            code = buildString {
+                append("# solved with code blanks\n")
+                append("print(\"test\")\n")
+            },
+            language = "python3"
+        )
 
         assertEquals(expectedReply, state.createReply())
     }
@@ -126,7 +132,13 @@ class StepQuizCodeBlanksStateExtensionsTest {
             codeBlocks = codeBlocks
         )
 
-        val expectedReply = Reply.code(code = "a = 1\nprint(a)", language = "python3")
+        val expectedReply = Reply.code(
+            code = buildString {
+                append("# solved with code blanks\n")
+                append("a = 1\nprint(a)")
+            },
+            language = "python3"
+        )
 
         assertEquals(expectedReply, state.createReply())
     }


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1318](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1318)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

1. Updates `SuggestionClicked` logic for the `Variable` code block to automatically select the next unselected child.
2. Adds a `# solved with code blanks` comment to the reply.