### PR TITLE
ALTAPPS-1328: Shared Aug 2024 ads campaigns onboarding improvements

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/notification/local/cache/NotificationCacheKeyValues.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/notification/local/cache/NotificationCacheKeyValues.kt
@@ -6,5 +6,4 @@ internal object NotificationCacheKeyValues {
     const val DAILY_STUDY_REMINDERS_ENABLED = "notifications_daily_reminder_enabled"
     const val DAILY_STUDY_REMINDERS_START_HOUR = "notifications_daily_reminder_start_hour"
     const val DAILY_STUDY_REMINDERS_START_HOUR_DEFAULT = 20
-    const val DAILY_STUDY_REMINDERS_START_HOUR_ONBOARDING = 12
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/notifications_onboarding/presentation/NotificationsOnboardingFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/notifications_onboarding/presentation/NotificationsOnboardingFeature.kt
@@ -1,7 +1,9 @@
 package org.hyperskill.app.notifications_onboarding.presentation
 
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import org.hyperskill.app.analytic.domain.model.AnalyticEvent
-import org.hyperskill.app.notification.local.cache.NotificationCacheKeyValues
 
 object NotificationsOnboardingFeature {
     internal data class State(val dailyStudyRemindersStartHour: Int)
@@ -9,29 +11,33 @@ object NotificationsOnboardingFeature {
     data class ViewState(val formattedDailyStudyRemindersInterval: String)
 
     internal fun initialState() =
-        State(dailyStudyRemindersStartHour = NotificationCacheKeyValues.DAILY_STUDY_REMINDERS_START_HOUR_ONBOARDING)
+        State(
+            dailyStudyRemindersStartHour = Clock.System.now()
+                .toLocalDateTime(TimeZone.currentSystemDefault())
+                .hour
+        )
 
     sealed interface Message {
-        object AllowNotificationsClicked : Message
-        object NotNowClicked : Message
+        data object AllowNotificationsClicked : Message
+        data object NotNowClicked : Message
         data class NotificationPermissionRequestResult(val isPermissionGranted: Boolean) : Message
 
-        object DailyStudyRemindsIntervalHourClicked : Message
+        data object DailyStudyRemindsIntervalHourClicked : Message
         data class DailyStudyRemindsIntervalStartHourSelected(val startHour: Int) : Message
 
         /**
          * Analytic
          */
-        object ViewedEventMessage : Message
+        data object ViewedEventMessage : Message
 
-        object DailyStudyRemindersIntervalStartHourPickerModalShownEventMessage : Message
-        object DailyStudyRemindersIntervalStartHourPickerModalHiddenEventMessage : Message
+        data object DailyStudyRemindersIntervalStartHourPickerModalShownEventMessage : Message
+        data object DailyStudyRemindersIntervalStartHourPickerModalHiddenEventMessage : Message
     }
 
     sealed interface Action {
         sealed interface ViewAction : Action {
-            object RequestNotificationPermission : ViewAction
-            object CompleteNotificationOnboarding : ViewAction
+            data object RequestNotificationPermission : ViewAction
+            data object CompleteNotificationOnboarding : ViewAction
 
             data class ShowDailyStudyRemindersIntervalStartHourPickerModal(
                 val intervals: List<String>,

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/welcome_onboarding/root/presentation/WelcomeOnboardingFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/welcome_onboarding/root/presentation/WelcomeOnboardingFeature.kt
@@ -53,13 +53,11 @@ object WelcomeOnboardingFeature {
             val questionnaireType: WelcomeQuestionnaireType,
             val itemType: WelcomeQuestionnaireItemType
         ) : Message
-
         data class ProgrammingLanguageSelected(val language: WelcomeOnboardingProgrammingLanguage) : Message
         data class TrackSelected(
             val selectedTrack: WelcomeOnboardingTrack,
             val isNotificationPermissionGranted: Boolean
         ) : Message
-
         data object NotificationPermissionOnboardingCompleted : Message
         data object FinishClicked : Message
 

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/welcome_onboarding/root/presentation/WelcomeOnboardingFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/welcome_onboarding/root/presentation/WelcomeOnboardingFeature.kt
@@ -22,9 +22,9 @@ object WelcomeOnboardingFeature {
     )
 
     sealed interface NextLearningActivityState {
-        object Idle : NextLearningActivityState
-        object Loading : NextLearningActivityState
-        object Error : NextLearningActivityState
+        data object Idle : NextLearningActivityState
+        data object Loading : NextLearningActivityState
+        data object Error : NextLearningActivityState
         data class Success(val nextLearningActivity: LearningActivity?) : NextLearningActivityState
     }
 
@@ -47,47 +47,50 @@ object WelcomeOnboardingFeature {
         )
 
     sealed interface Message {
-        object Initialize : Message
-        object StartJourneyClicked : Message
+        data object Initialize : Message
+        data object StartJourneyClicked : Message
         data class QuestionnaireItemClicked(
             val questionnaireType: WelcomeQuestionnaireType,
             val itemType: WelcomeQuestionnaireItemType
         ) : Message
+
         data class ProgrammingLanguageSelected(val language: WelcomeOnboardingProgrammingLanguage) : Message
         data class TrackSelected(
             val selectedTrack: WelcomeOnboardingTrack,
             val isNotificationPermissionGranted: Boolean
         ) : Message
-        object NotificationPermissionOnboardingCompleted : Message
-        object FinishClicked : Message
 
-        object StartOnboardingViewed : Message
+        data object NotificationPermissionOnboardingCompleted : Message
+        data object FinishClicked : Message
+
+        data object StartOnboardingViewed : Message
         class UserQuestionnaireViewed(val questionnaireType: WelcomeQuestionnaireType) : Message
-        object SelectProgrammingLanguageViewed : Message
-        object FinishOnboardingViewed : Message
+        data object SelectProgrammingLanguageViewed : Message
+        data object FinishOnboardingViewed : Message
     }
 
     internal sealed interface InternalMessage : Message {
         data class FetchNextLearningActivitySuccess(val nextLearningActivity: LearningActivity?) : InternalMessage
-        object FetchNextLearningActivityError : InternalMessage
+        data object FetchNextLearningActivityError : InternalMessage
     }
 
     sealed interface Action {
         sealed interface ViewAction : Action {
             sealed interface NavigateTo : ViewAction {
-                object StartScreen : NavigateTo
+                data object StartScreen : NavigateTo
                 data class WelcomeOnboardingQuestionnaire(val type: WelcomeQuestionnaireType) : NavigateTo
-                object ChooseProgrammingLanguage : NavigateTo
+                data object ChooseProgrammingLanguage : NavigateTo
                 data class TrackDetails(val track: WelcomeOnboardingTrack) : NavigateTo
-                object NotificationOnboarding : NavigateTo
+                data object NotificationOnboarding : NavigateTo
                 data class OnboardingFinish(val selectedTrack: WelcomeOnboardingTrack) : NavigateTo
             }
+
             data class CompleteWelcomeOnboarding(val stepRoute: StepRoute?) : ViewAction
         }
     }
 
     internal sealed interface InternalAction : Action {
         data class LogAnalyticEvent(val event: AnalyticEvent) : InternalAction
-        object FetchNextLearningActivity : InternalAction
+        data object FetchNextLearningActivity : InternalAction
     }
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/welcome_onboarding/root/presentation/WelcomeOnboardingReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/welcome_onboarding/root/presentation/WelcomeOnboardingReducer.kt
@@ -83,7 +83,9 @@ internal class WelcomeOnboardingReducer : StateReducer<State, Message, Action> {
                 WelcomeQuestionnaireType.LEARNING_REASON ->
                     NavigateTo.WelcomeOnboardingQuestionnaire(WelcomeQuestionnaireType.CODING_EXPERIENCE)
                 WelcomeQuestionnaireType.CODING_EXPERIENCE ->
-                    NavigateTo.ChooseProgrammingLanguage
+                    // NavigateTo.ChooseProgrammingLanguage
+                    // ALTAPPS-1328: Redirect to Python track directly
+                    NavigateTo.TrackDetails(WelcomeOnboardingTrack.PYTHON)
             }
         )
 

--- a/shared/src/commonTest/kotlin/org/hyperskill/notifications_onboarding/NotificationsOnboardingFeatureTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/notifications_onboarding/NotificationsOnboardingFeatureTest.kt
@@ -1,0 +1,17 @@
+package org.hyperskill.notifications_onboarding
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.hyperskill.app.notifications_onboarding.presentation.NotificationsOnboardingFeature
+
+class NotificationsOnboardingFeatureTest {
+    @Test
+    fun `initialState should set dailyStudyRemindersStartHour to current hour`() {
+        val currentHour = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).hour
+        val state = NotificationsOnboardingFeature.initialState()
+        assertEquals(currentHour, state.dailyStudyRemindersStartHour)
+    }
+}


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1328](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1328)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

1. Skip programming language selection, redirect to Python track directly after questionnaire
2. Set default notifications onboarding hour to current hour