### PR TITLE
ALTAPPS-1341: iOS fix incorrect code blanks step 47913 rendering

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCodeBlanks/Views/StepQuizCodeBlanksSuggestionsView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizCodeBlanks/Views/StepQuizCodeBlanksSuggestionsView.swift
@@ -39,20 +39,34 @@ struct StepQuizCodeBlanksSuggestionsView: View {
                 )
                 .buttonStyle(BounceButtonStyle())
             }
+
+            // Preserve height to avoid layout jumps
+            if suggestions.isEmpty {
+                StepQuizCodeBlanksOptionView(text: "", isActive: false)
+                    .hidden()
+            }
         }
         .padding(LayoutInsets.defaultInset)
-        .frame(minHeight: 72)
     }
 }
 
 #if DEBUG
 #Preview {
-    StepQuizCodeBlanksSuggestionsView(
-        suggestions: [
-            Suggestion.ConstantString(text: "Hello world")
-        ],
-        isAnimationEffectActive: true,
-        onSuggestionTap: { _ in }
-    )
+    VStack {
+        StepQuizCodeBlanksSuggestionsView(
+            suggestions: [
+                Suggestion.ConstantString(text: "128"),
+                Suggestion.ConstantString(text: "5")
+            ],
+            isAnimationEffectActive: true,
+            onSuggestionTap: { _ in }
+        )
+
+        StepQuizCodeBlanksSuggestionsView(
+            suggestions: [],
+            isAnimationEffectActive: true,
+            onSuggestionTap: { _ in }
+        )
+    }
 }
 #endif


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1341](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1341)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

- Fixes incorrect code blanks step 47913 rendering by preserving height to avoid layout jumps when no suggestions.