### PR TITLE
ALTAPPS-1339: Android fix double resume coroutine when calling AndroidPurchaseManager.canMakePayments

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ coil = '2.2.0'
 lottie = '6.1.0'
 kermit = '2.0.4'
 androidxBrowser = "1.5.0"
-revenueCat = "7.4.0"
+revenueCat = "8.6.0"
 googlePlayReview = "2.0.1"
 googlePlayInstallReferrer = "2.2"
 


### PR DESCRIPTION
**YouTrack Issues**:
[ALTAPPS-1339](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1339)

**Checklist**

_Before Code Review:_

- [ ] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [ ] All checks have been passed;
- [ ] Changes have been checked locally

**Description**
- Update revenuecat lib on Android platform. New lib version contains fix, to call `canMakePayments` callback only once. This should prevent resuming coroutines more than once.
