### PR TITLE
ALTAPPS-1335: Shared, Android support skipped and completed studyplan activities

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/delegate/StudyPlanWidgetDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/delegate/StudyPlanWidgetDelegate.kt
@@ -205,12 +205,28 @@ class StudyPlanWidgetDelegate(
                         addAll(getActivitiesLoadingItems(section.id))
                     }
                     is StudyPlanWidgetViewState.SectionContent.Content -> {
-                        addAll(mapSectionItemsToActivityItems(section.id, sectionContent.sectionItems))
-                        if (sectionContent.isLoadAllTopicsButtonShown) {
-                            add(StudyPlanRecyclerItem.LoadAllTopicsButton(section.id))
+                        when (sectionContent.completedPageLoadingState) {
+                            SectionContentPageLoadingState.HIDDEN -> {
+                                // no op
+                            }
+                            SectionContentPageLoadingState.LOAD_MORE -> {
+                                add(StudyPlanRecyclerItem.ExpandCompletedActivitiesButton(section.id))
+                            }
+                            SectionContentPageLoadingState.LOADING -> {
+                                addAll(getActivitiesLoadingItems(section.id))
+                            }
                         }
-                        if (sectionContent.isNextPageLoadingShowed) {
-                            addAll(getActivitiesLoadingItems(section.id))
+                        addAll(mapSectionItemsToActivityItems(section.id, sectionContent.sectionItems))
+                        when (sectionContent.nextPageLoadingState) {
+                            SectionContentPageLoadingState.HIDDEN -> {
+                                // no op
+                            }
+                            SectionContentPageLoadingState.LOAD_MORE -> {
+                                add(StudyPlanRecyclerItem.LoadAllTopicsButton(section.id))
+                            }
+                            SectionContentPageLoadingState.LOADING -> {
+                                addAll(getActivitiesLoadingItems(section.id))
+                            }
                         }
                     }
                     StudyPlanWidgetViewState.SectionContent.Error -> {

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/delegate/StudyPlanWidgetDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/delegate/StudyPlanWidgetDelegate.kt
@@ -1,8 +1,6 @@
 package org.hyperskill.app.android.study_plan.delegate
 
 import android.content.Context
-import androidx.annotation.ColorInt
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import org.hyperskill.app.android.R
@@ -14,10 +12,10 @@ import org.hyperskill.app.android.study_plan.adapter.ActivityLoadingAdapterDeleg
 import org.hyperskill.app.android.study_plan.adapter.StudyPlanActivityAdapterDelegate
 import org.hyperskill.app.android.study_plan.adapter.StudyPlanItemAnimator
 import org.hyperskill.app.android.study_plan.adapter.StudyPlanSectionAdapterDelegate
+import org.hyperskill.app.android.study_plan.mapper.StudyPlanWidgetUIStateMapper
 import org.hyperskill.app.android.study_plan.model.StudyPlanRecyclerItem
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
 import org.hyperskill.app.study_plan.widget.view.model.StudyPlanWidgetViewState
-import org.hyperskill.app.study_plan.widget.view.model.StudyPlanWidgetViewState.SectionContentPageLoadingState
 import ru.nobird.android.ui.adapterdelegates.dsl.adapterDelegate
 import ru.nobird.android.ui.adapters.DefaultDelegateAdapter
 import ru.nobird.android.view.base.ui.delegate.ViewStateDelegate
@@ -27,11 +25,6 @@ class StudyPlanWidgetDelegate(
     private val onRetryContentLoadingClicked: () -> Unit,
     private val onNewMessage: (StudyPlanWidgetFeature.Message) -> Unit
 ) {
-
-    companion object {
-        private const val SECTIONS_LOADING_ITEMS_COUNT = 4
-        private const val ACTIVITIES_LOADING_ITEMS_COUNT = 3
-    }
 
     private val studyPlanAdapter = DefaultDelegateAdapter<StudyPlanRecyclerItem>().apply {
         addDelegate(StudyPlanSectionAdapterDelegate(onNewMessage))
@@ -57,38 +50,14 @@ class StudyPlanWidgetDelegate(
         )
     }
 
-    @ColorInt private val inactiveSectionTextColor: Int =
-        ContextCompat.getColor(context, org.hyperskill.app.R.color.color_on_surface_alpha_60)
-
-    @ColorInt private val activeSectionTextColor: Int =
-        ContextCompat.getColor(context, org.hyperskill.app.R.color.color_on_surface)
-
-    @ColorInt private val activeActivityTextColor: Int =
-        ContextCompat.getColor(context, org.hyperskill.app.R.color.color_on_surface_alpha_87)
-
-    @ColorInt private val inactiveActivityTextColor: Int =
-        ContextCompat.getColor(context, org.hyperskill.app.R.color.color_on_surface_alpha_60)
+    private val uiStateMapper: StudyPlanWidgetUIStateMapper = StudyPlanWidgetUIStateMapper(context)
 
     private val sectionTopMargin =
         context.resources.getDimensionPixelOffset(R.dimen.study_plan_section_top_margin)
     private val activityTopMargin =
         context.resources.getDimensionPixelOffset(R.dimen.study_plan_activity_top_margin)
 
-    private val activeIcon =
-        ContextCompat.getDrawable(context, R.drawable.ic_home_screen_arrow_button)
-    private val skippedIcon =
-        ContextCompat.getDrawable(context, R.drawable.ic_topic_skipped)
-    private val completedIcon =
-        ContextCompat.getDrawable(context, R.drawable.ic_topic_completed)
-    private val lockedIcon =
-        ContextCompat.getDrawable(context, R.drawable.ic_activity_locked)
-
     private var studyPlanViewStateDelegate: ViewStateDelegate<StudyPlanWidgetViewState>? = null
-
-    private val sectionsLoadingItems: List<StudyPlanRecyclerItem.SectionLoading> =
-        List(SECTIONS_LOADING_ITEMS_COUNT) { index ->
-            StudyPlanRecyclerItem.SectionLoading(index)
-        }
 
     fun setup(recyclerView: RecyclerView, errorViewBinding: ErrorNoConnectionWithButtonBinding) {
         studyPlanViewStateDelegate = ViewStateDelegate<StudyPlanWidgetViewState>().apply {
@@ -151,17 +120,7 @@ class StudyPlanWidgetDelegate(
 
     fun render(state: StudyPlanWidgetViewState) {
         studyPlanViewStateDelegate?.switchState(state)
-        when (state) {
-            StudyPlanWidgetViewState.Loading -> {
-                studyPlanAdapter.items = sectionsLoadingItems
-            }
-            is StudyPlanWidgetViewState.Content -> {
-                studyPlanAdapter.items = mapContentToRecyclerItems(state)
-            }
-            else -> {
-                // no op
-            }
-        }
+        studyPlanAdapter.items = uiStateMapper.map(state)
     }
 
     private fun sectionsLoadingAdapterDelegate() =
@@ -203,105 +162,5 @@ class StudyPlanWidgetDelegate(
                     )
                 }
             }
-        }
-
-    private fun mapContentToRecyclerItems(
-        studyPlanContent: StudyPlanWidgetViewState.Content
-    ): List<StudyPlanRecyclerItem> =
-        buildList {
-            if (studyPlanContent.isPaywallBannerShown) {
-                add(StudyPlanRecyclerItem.PaywallBanner)
-            }
-            studyPlanContent.sections.forEachIndexed { sectionIndex, section ->
-                add(mapSectionToRecyclerItem(sectionIndex, section))
-                when (val sectionContent = section.content) {
-                    StudyPlanWidgetViewState.SectionContent.Collapsed -> {
-                        // no op
-                    }
-                    StudyPlanWidgetViewState.SectionContent.Loading -> {
-                        addAll(getActivitiesLoadingItems(section.id))
-                    }
-                    is StudyPlanWidgetViewState.SectionContent.Content -> {
-                        when (sectionContent.completedPageLoadingState) {
-                            SectionContentPageLoadingState.HIDDEN -> {
-                                // no op
-                            }
-                            SectionContentPageLoadingState.LOAD_MORE -> {
-                                add(StudyPlanRecyclerItem.ExpandCompletedActivitiesButton(section.id))
-                            }
-                            SectionContentPageLoadingState.LOADING -> {
-                                addAll(getActivitiesLoadingItems(section.id))
-                            }
-                        }
-                        addAll(mapSectionItemsToActivityItems(section.id, sectionContent.sectionItems))
-                        when (sectionContent.nextPageLoadingState) {
-                            SectionContentPageLoadingState.HIDDEN -> {
-                                // no op
-                            }
-                            SectionContentPageLoadingState.LOAD_MORE -> {
-                                add(StudyPlanRecyclerItem.LoadAllTopicsButton(section.id))
-                            }
-                            SectionContentPageLoadingState.LOADING -> {
-                                addAll(getActivitiesLoadingItems(section.id))
-                            }
-                        }
-                    }
-                    StudyPlanWidgetViewState.SectionContent.Error -> {
-                        add(StudyPlanRecyclerItem.ActivitiesError(section.id))
-                    }
-                }
-            }
-        }
-
-    private fun mapSectionToRecyclerItem(
-        index: Int,
-        section: StudyPlanWidgetViewState.Section
-    ): StudyPlanRecyclerItem.Section =
-        StudyPlanRecyclerItem.Section(
-            id = section.id,
-            title = section.title,
-            titleTextColor = if (index == 0) {
-                activeSectionTextColor
-            } else {
-                inactiveSectionTextColor
-            },
-            subtitle = section.subtitle,
-            formattedTopicsCount = section.formattedTopicsCount,
-            formattedTimeToComplete = section.formattedTimeToComplete,
-            isExpanded = section.content !is StudyPlanWidgetViewState.SectionContent.Collapsed,
-            isCurrentBadgeShown = section.isCurrentBadgeShown
-        )
-
-    private fun mapSectionItemsToActivityItems(
-        sectionId: Long,
-        sectionItems: List<StudyPlanWidgetViewState.SectionItem>
-    ): List<StudyPlanRecyclerItem.Activity> =
-        sectionItems.map { item ->
-            StudyPlanRecyclerItem.Activity(
-                id = item.id,
-                sectionId = sectionId,
-                title = item.title,
-                subtitle = item.subtitle,
-                titleTextColor = if (item.state == StudyPlanWidgetViewState.SectionItemState.NEXT) {
-                    activeActivityTextColor
-                } else {
-                    inactiveActivityTextColor
-                },
-                progress = item.progress,
-                formattedProgress = item.formattedProgress,
-                endIcon = when (item.state) {
-                    StudyPlanWidgetViewState.SectionItemState.IDLE -> null
-                    StudyPlanWidgetViewState.SectionItemState.NEXT -> activeIcon
-                    StudyPlanWidgetViewState.SectionItemState.SKIPPED -> skippedIcon
-                    StudyPlanWidgetViewState.SectionItemState.COMPLETED -> completedIcon
-                    StudyPlanWidgetViewState.SectionItemState.LOCKED -> lockedIcon
-                },
-                isIdeRequired = item.isIdeRequired
-            )
-        }
-
-    private fun getActivitiesLoadingItems(sectionId: Long) =
-        List(ACTIVITIES_LOADING_ITEMS_COUNT) { index ->
-            StudyPlanRecyclerItem.ActivityLoading(sectionId, index)
         }
 }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/delegate/StudyPlanWidgetDelegate.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/delegate/StudyPlanWidgetDelegate.kt
@@ -17,6 +17,7 @@ import org.hyperskill.app.android.study_plan.adapter.StudyPlanSectionAdapterDele
 import org.hyperskill.app.android.study_plan.model.StudyPlanRecyclerItem
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
 import org.hyperskill.app.study_plan.widget.view.model.StudyPlanWidgetViewState
+import org.hyperskill.app.study_plan.widget.view.model.StudyPlanWidgetViewState.SectionContentPageLoadingState
 import ru.nobird.android.ui.adapterdelegates.dsl.adapterDelegate
 import ru.nobird.android.ui.adapters.DefaultDelegateAdapter
 import ru.nobird.android.view.base.ui.delegate.ViewStateDelegate
@@ -46,6 +47,7 @@ class StudyPlanWidgetDelegate(
         )
         addDelegate(sectionsLoadingAdapterDelegate())
         addDelegate(loadAllTopicsButtonDelegate())
+        addDelegate(expandCompletedActivitiesButtonDelegate())
         addDelegate(paywallAdapterDelegate())
         addDelegate(ActivityLoadingAdapterDelegate())
         addDelegate(
@@ -138,7 +140,8 @@ class StudyPlanWidgetDelegate(
             is StudyPlanRecyclerItem.ActivityLoading,
             is StudyPlanRecyclerItem.Activity,
             is StudyPlanRecyclerItem.ActivitiesError,
-            is StudyPlanRecyclerItem.LoadAllTopicsButton -> activityTopMargin
+            is StudyPlanRecyclerItem.LoadAllTopicsButton,
+            is StudyPlanRecyclerItem.ExpandCompletedActivitiesButton -> activityTopMargin
             else -> 0
         }
 
@@ -183,6 +186,20 @@ class StudyPlanWidgetDelegate(
                 if (sectionId != null) {
                     onNewMessage(
                         StudyPlanWidgetFeature.Message.LoadMoreActivitiesClicked(sectionId)
+                    )
+                }
+            }
+        }
+
+    private fun expandCompletedActivitiesButtonDelegate() =
+        adapterDelegate<StudyPlanRecyclerItem, StudyPlanRecyclerItem.ExpandCompletedActivitiesButton>(
+            R.layout.item_study_plan_expand_completed_button
+        ) {
+            itemView.setOnClickListener {
+                val sectionId = item?.sectionId
+                if (sectionId != null) {
+                    onNewMessage(
+                        StudyPlanWidgetFeature.Message.ExpandCompletedActivitiesClicked(sectionId)
                     )
                 }
             }

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/mapper/StudyPlanWidgetUIStateMapper.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/mapper/StudyPlanWidgetUIStateMapper.kt
@@ -1,0 +1,154 @@
+package org.hyperskill.app.android.study_plan.mapper
+
+import android.content.Context
+import androidx.annotation.ColorInt
+import androidx.core.content.ContextCompat
+import org.hyperskill.app.android.R
+import org.hyperskill.app.android.study_plan.model.StudyPlanRecyclerItem
+import org.hyperskill.app.study_plan.widget.view.model.StudyPlanWidgetViewState
+import org.hyperskill.app.study_plan.widget.view.model.StudyPlanWidgetViewState.SectionContentPageLoadingState
+
+class StudyPlanWidgetUIStateMapper(context: Context) {
+
+    companion object {
+        private const val SECTIONS_LOADING_ITEMS_COUNT = 4
+        private const val ACTIVITIES_LOADING_ITEMS_COUNT = 3
+    }
+
+    private val sectionsLoadingItems: List<StudyPlanRecyclerItem.SectionLoading> =
+        List(SECTIONS_LOADING_ITEMS_COUNT) { index ->
+            StudyPlanRecyclerItem.SectionLoading(index)
+        }
+
+    @ColorInt
+    private val inactiveSectionTextColor: Int =
+        ContextCompat.getColor(context, org.hyperskill.app.R.color.color_on_surface_alpha_60)
+
+    @ColorInt
+    private val activeSectionTextColor: Int =
+        ContextCompat.getColor(context, org.hyperskill.app.R.color.color_on_surface)
+
+    @ColorInt
+    private val activeActivityTextColor: Int =
+        ContextCompat.getColor(context, org.hyperskill.app.R.color.color_on_surface_alpha_87)
+
+    @ColorInt
+    private val inactiveActivityTextColor: Int =
+        ContextCompat.getColor(context, org.hyperskill.app.R.color.color_on_surface_alpha_60)
+
+    private val activeIcon =
+        ContextCompat.getDrawable(context, R.drawable.ic_home_screen_arrow_button)
+    private val skippedIcon =
+        ContextCompat.getDrawable(context, R.drawable.ic_topic_skipped)
+    private val completedIcon =
+        ContextCompat.getDrawable(context, R.drawable.ic_topic_completed)
+    private val lockedIcon =
+        ContextCompat.getDrawable(context, R.drawable.ic_activity_locked)
+
+    fun map(state: StudyPlanWidgetViewState): List<StudyPlanRecyclerItem> =
+        when (state) {
+            StudyPlanWidgetViewState.Loading -> sectionsLoadingItems
+            is StudyPlanWidgetViewState.Content -> mapContentToRecyclerItems(state)
+            else -> emptyList()
+        }
+
+    private fun mapContentToRecyclerItems(
+        studyPlanContent: StudyPlanWidgetViewState.Content
+    ): List<StudyPlanRecyclerItem> =
+        buildList {
+            if (studyPlanContent.isPaywallBannerShown) {
+                add(StudyPlanRecyclerItem.PaywallBanner)
+            }
+            studyPlanContent.sections.forEachIndexed { sectionIndex, section ->
+                add(mapSectionToRecyclerItem(sectionIndex, section))
+                when (val sectionContent = section.content) {
+                    StudyPlanWidgetViewState.SectionContent.Collapsed -> {
+                        // no op
+                    }
+                    StudyPlanWidgetViewState.SectionContent.Loading -> {
+                        addAll(getActivitiesLoadingItems(section.id))
+                    }
+                    is StudyPlanWidgetViewState.SectionContent.Content -> {
+                        when (sectionContent.completedPageLoadingState) {
+                            SectionContentPageLoadingState.HIDDEN -> {
+                                // no op
+                            }
+                            SectionContentPageLoadingState.LOAD_MORE -> {
+                                add(StudyPlanRecyclerItem.ExpandCompletedActivitiesButton(section.id))
+                            }
+                            SectionContentPageLoadingState.LOADING -> {
+                                addAll(getActivitiesLoadingItems(section.id))
+                            }
+                        }
+                        addAll(mapSectionItemsToActivityItems(section.id, sectionContent.sectionItems))
+                        when (sectionContent.nextPageLoadingState) {
+                            SectionContentPageLoadingState.HIDDEN -> {
+                                // no op
+                            }
+                            SectionContentPageLoadingState.LOAD_MORE -> {
+                                add(StudyPlanRecyclerItem.LoadAllTopicsButton(section.id))
+                            }
+                            SectionContentPageLoadingState.LOADING -> {
+                                addAll(getActivitiesLoadingItems(section.id))
+                            }
+                        }
+                    }
+                    StudyPlanWidgetViewState.SectionContent.Error -> {
+                        add(StudyPlanRecyclerItem.ActivitiesError(section.id))
+                    }
+                }
+            }
+        }
+
+    private fun mapSectionToRecyclerItem(
+        index: Int,
+        section: StudyPlanWidgetViewState.Section
+    ): StudyPlanRecyclerItem.Section =
+        StudyPlanRecyclerItem.Section(
+            id = section.id,
+            title = section.title,
+            titleTextColor = if (index == 0) {
+                activeSectionTextColor
+            } else {
+                inactiveSectionTextColor
+            },
+            subtitle = section.subtitle,
+            formattedTopicsCount = section.formattedTopicsCount,
+            formattedTimeToComplete = section.formattedTimeToComplete,
+            isExpanded = section.content !is StudyPlanWidgetViewState.SectionContent.Collapsed,
+            isCurrentBadgeShown = section.isCurrentBadgeShown
+        )
+
+    private fun mapSectionItemsToActivityItems(
+        sectionId: Long,
+        sectionItems: List<StudyPlanWidgetViewState.SectionItem>
+    ): List<StudyPlanRecyclerItem.Activity> =
+        sectionItems.map { item ->
+            StudyPlanRecyclerItem.Activity(
+                id = item.id,
+                sectionId = sectionId,
+                title = item.title,
+                subtitle = item.subtitle,
+                titleTextColor = if (item.state == StudyPlanWidgetViewState.SectionItemState.NEXT) {
+                    activeActivityTextColor
+                } else {
+                    inactiveActivityTextColor
+                },
+                progress = item.progress,
+                formattedProgress = item.formattedProgress,
+                endIcon = when (item.state) {
+                    StudyPlanWidgetViewState.SectionItemState.IDLE -> null
+                    StudyPlanWidgetViewState.SectionItemState.NEXT -> activeIcon
+                    StudyPlanWidgetViewState.SectionItemState.SKIPPED -> skippedIcon
+                    StudyPlanWidgetViewState.SectionItemState.COMPLETED -> completedIcon
+                    StudyPlanWidgetViewState.SectionItemState.LOCKED -> lockedIcon
+                },
+                isIdeRequired = item.isIdeRequired
+            )
+        }
+
+    private fun getActivitiesLoadingItems(sectionId: Long) =
+        List(ACTIVITIES_LOADING_ITEMS_COUNT) { index ->
+            StudyPlanRecyclerItem.ActivityLoading(sectionId, index)
+        }
+}

--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/model/StudyPlanRecyclerItem.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/study_plan/model/StudyPlanRecyclerItem.kt
@@ -28,6 +28,12 @@ interface StudyPlanRecyclerItem {
         override val id: String = "study-plan-$sectionId-load-all-topics"
     }
 
+    data class ExpandCompletedActivitiesButton(
+        val sectionId: Long
+    ) : StudyPlanRecyclerItem, Identifiable<String> {
+        override val id: String = "study-plan-$sectionId-expand-completed-activities"
+    }
+
     object PaywallBanner : StudyPlanRecyclerItem, Identifiable<String> {
         override val id: String = "study-plan-paywall-banner"
     }

--- a/androidHyperskillApp/src/main/res/drawable/ic_study_plan_expand_all.xml
+++ b/androidHyperskillApp/src/main/res/drawable/ic_study_plan_expand_all.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M17.965,6.705L16.555,5.295L10.215,11.635L11.625,13.045L17.965,6.705ZM22.205,5.295L11.625,15.875L7.445,11.705L6.035,13.115L11.625,18.705L23.625,6.705L22.205,5.295ZM0.375,13.115L5.965,18.705L7.375,17.295L1.795,11.705L0.375,13.115Z"
+      android:fillColor="#5D72E9"/>
+</vector>

--- a/androidHyperskillApp/src/main/res/layout/item_study_plan_activity.xml
+++ b/androidHyperskillApp/src/main/res/layout/item_study_plan_activity.xml
@@ -15,28 +15,28 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            app:layout_constraintGuide_begin="16dp"/>
+            app:layout_constraintGuide_begin="@dimen/study_plan_activity_padding"/>
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/endGuideline"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            app:layout_constraintGuide_end="16dp"/>
+            app:layout_constraintGuide_end="@dimen/study_plan_activity_padding"/>
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/topGuideline"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            app:layout_constraintGuide_begin="16dp"/>
+            app:layout_constraintGuide_begin="@dimen/study_plan_activity_padding"/>
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/bottomGuideline"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            app:layout_constraintGuide_end="16dp"/>
+            app:layout_constraintGuide_end="@dimen/study_plan_activity_padding"/>
 
         <LinearLayout
             android:id="@+id/activityTextGroup"

--- a/androidHyperskillApp/src/main/res/layout/item_study_plan_expand_completed_button.xml
+++ b/androidHyperskillApp/src/main/res/layout/item_study_plan_expand_completed_button.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    style="@style/TrackCardViewStyle">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        style="@style/TextAppearance.AppCompat.Body1"
+        android:textSize="17sp"
+        android:textColor="@color/button_ghost"
+        android:drawableStart="@drawable/ic_study_plan_expand_all"
+        android:drawablePadding="12dp"
+        android:text="@string/study_plan_expand_completed_button_text"
+        android:padding="@dimen/study_plan_activity_padding"/>
+
+</com.google.android.material.card.MaterialCardView>

--- a/androidHyperskillApp/src/main/res/values/dimens.xml
+++ b/androidHyperskillApp/src/main/res/values/dimens.xml
@@ -121,6 +121,7 @@
     <dimen name="study_plan_bottom_margin">20dp</dimen>
     <dimen name="study_plan_section_top_margin">16dp</dimen>
     <dimen name="study_plan_activity_top_margin">8dp</dimen>
+    <dimen name="study_plan_activity_padding">16dp</dimen>
 
     <!--Gamification toolbar-->
     <dimen name="gamification_toolbar_default_height">80dp</dimen>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -287,7 +287,6 @@
     <ID>TooManyFunctions:Reply.kt$Reply$Companion</ID>
     <ID>TooManyFunctions:SharedDateFormatter.kt$SharedDateFormatter</ID>
     <ID>TooManyFunctions:StepActionDispatcher.kt$StepActionDispatcher : CoroutineActionDispatcher</ID>
-    <ID>TooManyFunctions:StudyPlanWidgetDelegate.kt$StudyPlanWidgetDelegate</ID>
     <ID>TooManyFunctions:SubscriptionsInteractor.kt$SubscriptionsInteractor</ID>
     <ID>TopLevelPropertyNaming:HyperskillNotificationChannel.kt$private const val dailyReminderId = "dailyReminderChannel"</ID>
     <ID>TopLevelPropertyNaming:HyperskillNotificationChannel.kt$private const val otherId = "otherChannel"</ID>

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StudyPlan/Views/Section/StudyPlanSectionView.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StudyPlan/Views/Section/StudyPlanSectionView.swift
@@ -75,7 +75,7 @@ struct StudyPlanSectionView: View {
 #Preview {
     StudyPlanSectionView(
         section: StudyPlanWidgetViewStateSection.makePlaceholder(
-            isNextPageLoadingShowed: true
+            nextPageLoadingState: StudyPlanWidgetViewStateSectionContentPageLoadingState.loading
         ),
         onSectionTap: { _ in },
         onActivityTap: { _, _  in },
@@ -89,7 +89,7 @@ struct StudyPlanSectionView: View {
 #Preview {
     StudyPlanSectionView(
         section: StudyPlanWidgetViewStateSection.makePlaceholder(
-            isLoadAllTopicsButtonShown: true
+            nextPageLoadingState: StudyPlanWidgetViewStateSectionContentPageLoadingState.loadMore
         ),
         onSectionTap: { _ in },
         onActivityTap: { _, _  in },
@@ -102,8 +102,9 @@ struct StudyPlanSectionView: View {
 
 extension StudyPlanWidgetViewStateSection {
     static func makePlaceholder(
-        isNextPageLoadingShowed: Bool = false,
-        isLoadAllTopicsButtonShown: Bool = false
+        nextPageLoadingState: StudyPlanWidgetViewStateSectionContentPageLoadingState = StudyPlanWidgetViewStateSectionContentPageLoadingState.hidden,
+        completedPageLoadingState: StudyPlanWidgetViewStateSectionContentPageLoadingState =
+            StudyPlanWidgetViewStateSectionContentPageLoadingState.hidden
     ) -> StudyPlanWidgetViewStateSection {
         StudyPlanWidgetViewStateSection(
             id: 1,
@@ -119,8 +120,8 @@ extension StudyPlanWidgetViewStateSection {
                     .makePlaceholder(state: .completed),
                     .makePlaceholder(state: .next)
                 ],
-                isNextPageLoadingShowed: isNextPageLoadingShowed,
-                isLoadAllTopicsButtonShown: isLoadAllTopicsButtonShown
+                nextPageLoadingState: nextPageLoadingState,
+                completedPageLoadingState: completedPageLoadingState
             )
         )
     }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/analytic/domain/model/hyperskill/HyperskillAnalyticTarget.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/analytic/domain/model/hyperskill/HyperskillAnalyticTarget.kt
@@ -138,5 +138,6 @@ enum class HyperskillAnalyticTarget(val targetName: String) {
     CODE_BLOCK("code_block"),
     CODE_BLOCK_SUGGESTION("code_block_suggestion"),
     CODE_BLOCK_CHILD("code_block_child"),
-    LOAD_MORE("load_more")
+    LOAD_MORE("load_more"),
+    EXPAND_COMPLETED("expand_completed")
 }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/analytic/StudyPlanExpandCompletedActivitiesClickedHSAnalyticEvent.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/domain/analytic/StudyPlanExpandCompletedActivitiesClickedHSAnalyticEvent.kt
@@ -1,0 +1,35 @@
+package org.hyperskill.app.study_plan.domain.analytic
+
+import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticAction
+import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticEvent
+import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticPart
+import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticRoute
+import org.hyperskill.app.analytic.domain.model.hyperskill.HyperskillAnalyticTarget
+
+/**
+ * Represents a click analytic event of the ExpandCompleted button in the section.
+ *
+ * JSON payload:
+ * ```
+ * {
+ *     "route": "/study-plan"",
+ *     "action": "click",
+ *     "part": "study_plan_section",
+ *     "target": "expand_completed",
+ *     "context":
+ *     {
+ *         "section_id": 123
+ *     }
+ * }
+ * ```
+ * @see HyperskillAnalyticEvent
+ */
+class StudyPlanExpandCompletedActivitiesClickedHSAnalyticEvent(
+    val sectionId: Long
+) : HyperskillAnalyticEvent(
+    route = HyperskillAnalyticRoute.StudyPlan(),
+    action = HyperskillAnalyticAction.CLICK,
+    part = HyperskillAnalyticPart.STUDY_PLAN_SECTION,
+    target = HyperskillAnalyticTarget.EXPAND_COMPLETED,
+    context = mapOf(StudyPlanAnalyticParams.PARAM_SECTION_ID to sectionId)
+)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/MainStudyPlanWidgetActionDispatcher.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/MainStudyPlanWidgetActionDispatcher.kt
@@ -143,7 +143,12 @@ internal class MainStudyPlanWidgetActionDispatcher(
     ) {
         sentryInteractor.withTransaction(
             action.sentryTransaction,
-            onError = { StudyPlanWidgetFeature.LearningActivitiesFetchResult.Failed(action.sectionId) }
+            onError = {
+                StudyPlanWidgetFeature.LearningActivitiesFetchResult.Failed(
+                    sectionId = action.sectionId,
+                    targetPage = action.targetPage
+                )
+            }
         ) {
             learningActivitiesRepository
                 .getLearningActivities(
@@ -155,7 +160,8 @@ internal class MainStudyPlanWidgetActionDispatcher(
                 .let { learningActivities ->
                     StudyPlanWidgetFeature.LearningActivitiesFetchResult.Success(
                         sectionId = action.sectionId,
-                        activities = learningActivities
+                        activities = learningActivities,
+                        targetPage = action.targetPage
                     )
                 }
         }.let(onNewMessage)

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
@@ -60,16 +60,6 @@ object StudyPlanWidgetFeature {
         LOADED
     }
 
-    enum class SectionContentStatus {
-        IDLE,
-        ERROR,
-
-        FIRST_PAGE_LOADING,
-        FIRST_PAGE_LOADED,
-        NEXT_PAGE_LOADING,
-        ALL_PAGES_LOADED
-    }
-
     enum class PageContentStatus {
         IDLE,
         AWAIT_LOADING,
@@ -87,7 +77,6 @@ object StudyPlanWidgetFeature {
     data class StudyPlanSectionInfo(
         val studyPlanSection: StudyPlanSection,
         val isExpanded: Boolean,
-
 
         val mainPageContentStatus: ContentStatus,
         val nextPageContentStatus: PageContentStatus,

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
@@ -24,7 +24,7 @@ object StudyPlanWidgetFeature {
         /**
          * Describes status of sections loading
          */
-        val sectionsStatus: SectionStatus = SectionStatus.IDLE,
+        val sectionsStatus: ContentStatus = ContentStatus.IDLE,
 
         /**
          * Map of activity ids to activities
@@ -53,7 +53,7 @@ object StudyPlanWidgetFeature {
             get() = profile?.features?.isLearningPathDividedTrackTopicsEnabled ?: false
     }
 
-    enum class SectionStatus {
+    enum class ContentStatus {
         IDLE,
         LOADING,
         ERROR,

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
@@ -70,14 +70,28 @@ object StudyPlanWidgetFeature {
         ALL_PAGES_LOADED
     }
 
+    enum class PageContentStatus {
+        IDLE,
+        AWAIT_LOADING,
+        LOADING,
+        ERROR,
+        LOADED
+    }
+
+    enum class SectionPage {
+        MAIN,
+        NEXT,
+        COMPLETED
+    }
+
     data class StudyPlanSectionInfo(
         val studyPlanSection: StudyPlanSection,
         val isExpanded: Boolean,
 
-        /**
-         * Describes status of section's activities loading
-         * */
-        val sectionContentStatus: SectionContentStatus
+
+        val mainPageContentStatus: ContentStatus,
+        val nextPageContentStatus: PageContentStatus,
+        val completedPageContentStatus: PageContentStatus
     )
 
     sealed interface Message {
@@ -134,10 +148,14 @@ object StudyPlanWidgetFeature {
     internal sealed interface LearningActivitiesFetchResult : Message {
         data class Success(
             val sectionId: Long,
-            val activities: List<LearningActivity>
+            val activities: List<LearningActivity>,
+            val targetPage: SectionPage
         ) : LearningActivitiesFetchResult
 
-        data class Failed(val sectionId: Long) : LearningActivitiesFetchResult
+        data class Failed(
+            val sectionId: Long,
+            val targetPage: SectionPage
+        ) : LearningActivitiesFetchResult
     }
 
     internal sealed interface ProfileFetchResult : Message {
@@ -172,7 +190,8 @@ object StudyPlanWidgetFeature {
                 LearningActivityState.COMPLETED,
                 LearningActivityState.SKIPPED
             ),
-            val sentryTransaction: HyperskillSentryTransaction
+            val sentryTransaction: HyperskillSentryTransaction,
+            val targetPage: SectionPage
         ) : InternalAction
 
         data object FetchProfile : InternalAction

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
@@ -165,7 +165,11 @@ object StudyPlanWidgetFeature {
             val sectionId: Long,
             val activitiesIds: List<Long>,
             val types: Set<LearningActivityType> = LearningActivityType.supportedTypes(),
-            val states: Set<LearningActivityState> = setOf(LearningActivityState.TODO),
+            val states: Set<LearningActivityState> = setOf(
+                LearningActivityState.TODO,
+                LearningActivityState.COMPLETED,
+                LearningActivityState.SKIPPED
+            ),
             val sentryTransaction: HyperskillSentryTransaction
         ) : InternalAction
 

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetFeature.kt
@@ -89,6 +89,8 @@ object StudyPlanWidgetFeature {
 
         data class RetryActivitiesLoading(val sectionId: Long) : Message
 
+        data class ExpandCompletedActivitiesClicked(val sectionId: Long) : Message
+
         data object PullToRefresh : Message
 
         data object SubscribeClicked : Message

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -45,7 +45,7 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
             is StudyPlanWidgetFeature.LearningActivitiesWithSectionsFetchResult.Success ->
                 handleLearningActivitiesWithSectionsFetchSuccess(state, message)
             StudyPlanWidgetFeature.LearningActivitiesWithSectionsFetchResult.Failed -> {
-                state.copy(sectionsStatus = StudyPlanWidgetFeature.SectionStatus.ERROR) to emptySet()
+                state.copy(sectionsStatus = StudyPlanWidgetFeature.ContentStatus.ERROR) to emptySet()
             }
             is Message.RetryActivitiesLoading ->
                 handleRetryActivitiesLoading(state, message)
@@ -123,10 +123,10 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
         } ?: (state to emptySet())
 
     private fun coldContentFetch(state: State, message: InternalMessage.Initialize): StudyPlanWidgetReducerResult =
-        if (state.sectionsStatus == StudyPlanWidgetFeature.SectionStatus.IDLE ||
-            state.sectionsStatus == StudyPlanWidgetFeature.SectionStatus.ERROR && message.forceUpdate
+        if (state.sectionsStatus == StudyPlanWidgetFeature.ContentStatus.IDLE ||
+            state.sectionsStatus == StudyPlanWidgetFeature.ContentStatus.ERROR && message.forceUpdate
         ) {
-            State(sectionsStatus = StudyPlanWidgetFeature.SectionStatus.LOADING) to
+            State(sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADING) to
                 getContentFetchActions(forceUpdate = message.forceUpdate)
         } else {
             state to emptySet()
@@ -147,7 +147,7 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
         val visibleSections = getVisibleSections(message.studyPlanSections, learningActivitiesIds)
         val currentSectionId = visibleSections.firstOrNull()?.id ?: return state.copy(
             studyPlanSections = emptyMap(),
-            sectionsStatus = StudyPlanWidgetFeature.SectionStatus.LOADED,
+            sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED,
             isRefreshing = false,
             subscriptionLimitType = message.subscriptionLimitType
         ) to emptySet()
@@ -176,7 +176,7 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
 
         val loadedSectionsState = state.copy(
             studyPlanSections = studyPlanSections,
-            sectionsStatus = StudyPlanWidgetFeature.SectionStatus.LOADED,
+            sectionsStatus = StudyPlanWidgetFeature.ContentStatus.LOADED,
             isRefreshing = false,
             learnedTopicsCount = message.learnedTopicsCount,
             activities = message.learningActivities.associateBy { it.id },

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -418,7 +418,7 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
         state: State,
         message: Message.ExpandCompletedActivitiesClicked
     ): StudyPlanWidgetReducerResult {
-        val activitiesToBeLoaded =  state.getActivitiesBeforeCurrentActivityToBeLoaded(message.sectionId)
+        val activitiesToBeLoaded = state.getActivitiesBeforeCurrentActivityToBeLoaded(message.sectionId)
         return if (activitiesToBeLoaded.isNotEmpty()) {
             state.copy(
                 studyPlanSections = state.studyPlanSections.update(message.sectionId) { sectionInfo ->

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -263,9 +263,8 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
                                 sectionContentStatus = when (sectionContentStatus) {
                                     SectionContentStatus.FIRST_PAGE_LOADED -> {
                                         val canLoadMoreActivities =
-                                            sectionInfo
-                                                .studyPlanSection
-                                                .getActivitiesToBeLoaded(state.activities.values)
+                                            state
+                                                .getRootTopicsActivitiesToBeLoaded(sectionId)
                                                 .isNotEmpty()
                                         if (canLoadMoreActivities) {
                                             SectionContentStatus.FIRST_PAGE_LOADED
@@ -369,7 +368,7 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
             InternalAction.LogAnalyticEvent(StudyPlanLoadMoreActivitiesClickedHSAnalyticEvent(message.sectionId)),
             InternalAction.FetchLearningActivities(
                 sectionId = message.sectionId,
-                activitiesIds = state.getActivitiesToBeLoaded(message.sectionId).toList(),
+                activitiesIds = state.getRootTopicsActivitiesToBeLoaded(message.sectionId),
                 sentryTransaction = getFetchLearningActivitiesSentryTransaction(state, message.sectionId)
             )
         )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetReducer.kt
@@ -317,7 +317,7 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
                                 PageContentStatus.LOADED
                             }
                         }
-                        SectionPage.NEXT -> PageContentStatus.IDLE
+                        SectionPage.NEXT -> PageContentStatus.LOADED
                         SectionPage.COMPLETED -> sectionInfo.nextPageContentStatus
                     },
                     completedPageContentStatus = when (targetPage) {
@@ -332,7 +332,7 @@ class StudyPlanWidgetReducer : StateReducer<State, Message, Action> {
                                 PageContentStatus.LOADED
                             }
                         }
-                        SectionPage.COMPLETED -> PageContentStatus.IDLE
+                        SectionPage.COMPLETED -> PageContentStatus.LOADED
                         SectionPage.NEXT -> section.completedPageContentStatus
                     }
                 )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetStateExtensions.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetStateExtensions.kt
@@ -58,7 +58,7 @@ internal fun StudyPlanWidgetFeature.State.getLoadedSectionActivities(sectionId: 
  * starting from next to the last loaded activity for ROOT_TOPICS section
  * and ending with the last ROOT_TOPICS section activity.
  */
-internal fun StudyPlanWidgetFeature.State.getRootTopicsActivitiesToBeLoaded(sectionId: Long): List<Long> {
+internal fun StudyPlanWidgetFeature.State.getNextRootTopicsActivitiesToBeLoaded(sectionId: Long): List<Long> {
     val sectionInfo = studyPlanSections[sectionId] ?: return emptyList()
     val studyPlanSection = sectionInfo.studyPlanSection
     return if (studyPlanSection.type == StudyPlanSectionType.ROOT_TOPICS) {
@@ -69,6 +69,28 @@ internal fun StudyPlanWidgetFeature.State.getRootTopicsActivitiesToBeLoaded(sect
             0
         }
         studyPlanSection.activities.slice(from = lastLoadedActivityIndex)
+    } else {
+        emptyList()
+    }
+}
+
+/**
+ * @param sectionId target section id
+ * @return A list of activities to be loaded before first loaded activity for current section.
+ * If section with [sectionId] is not current, then returns empty list.
+ */
+internal fun StudyPlanWidgetFeature.State.getActivitiesBeforeCurrentActivityToBeLoaded(sectionId: Long): List<Long> {
+    val currentSection = getCurrentSection()
+    return if (currentSection?.id == sectionId) {
+        val sectionInfo = studyPlanSections[sectionId] ?: return emptyList()
+        val studyPlanSection = sectionInfo.studyPlanSection
+        val firstLoadedActivityId = getLoadedSectionActivities(sectionId).firstOrNull()?.id
+        val firstLoadedActivityIndex = if (firstLoadedActivityId != null) {
+            max(0, studyPlanSection.activities.indexOf(firstLoadedActivityId))
+        } else {
+            0
+        }
+        studyPlanSection.activities.slice(from = 0, to = firstLoadedActivityIndex)
     } else {
         emptyList()
     }

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetStateExtensions.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/presentation/StudyPlanWidgetStateExtensions.kt
@@ -1,6 +1,7 @@
 package org.hyperskill.app.study_plan.widget.presentation
 
 import kotlin.math.max
+import org.hyperskill.app.core.utils.mutate
 import org.hyperskill.app.learning_activities.domain.model.LearningActivity
 import org.hyperskill.app.learning_activities.domain.model.LearningActivityState
 import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
@@ -157,3 +158,10 @@ internal fun StudyPlanWidgetFeature.State.isPaywallShown(): Boolean {
         false
     }
 }
+
+internal fun StudyPlanWidgetFeature.State.hideSection(sectionId: Long): StudyPlanWidgetFeature.State =
+    copy(
+        studyPlanSections = studyPlanSections.mutate {
+            remove(sectionId)
+        }
+    )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/mapper/StudyPlanWidgetViewStateMapper.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/mapper/StudyPlanWidgetViewStateMapper.kt
@@ -6,13 +6,13 @@ import org.hyperskill.app.learning_activities.domain.model.LearningActivity
 import org.hyperskill.app.learning_activities.domain.model.LearningActivityState
 import org.hyperskill.app.learning_activities.view.mapper.LearningActivityTextsMapper
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
+import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.ContentStatus
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.SectionContentStatus.ERROR
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.SectionContentStatus.FIRST_PAGE_LOADED
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.SectionContentStatus.FIRST_PAGE_LOADING
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.SectionContentStatus.IDLE
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.SectionContentStatus.NEXT_PAGE_LOADING
-import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.SectionStatus
 import org.hyperskill.app.study_plan.widget.presentation.getCurrentActivity
 import org.hyperskill.app.study_plan.widget.presentation.getCurrentSection
 import org.hyperskill.app.study_plan.widget.presentation.getLoadedSectionActivities
@@ -24,10 +24,10 @@ import org.hyperskill.app.study_plan.widget.view.model.StudyPlanWidgetViewState.
 class StudyPlanWidgetViewStateMapper(private val dateFormatter: SharedDateFormatter) {
     fun map(state: StudyPlanWidgetFeature.State): StudyPlanWidgetViewState =
         when (state.sectionsStatus) {
-            SectionStatus.IDLE -> StudyPlanWidgetViewState.Idle
-            SectionStatus.LOADING -> StudyPlanWidgetViewState.Loading
-            SectionStatus.ERROR -> StudyPlanWidgetViewState.Error
-            SectionStatus.LOADED -> getLoadedWidgetContent(state)
+            ContentStatus.IDLE -> StudyPlanWidgetViewState.Idle
+            ContentStatus.LOADING -> StudyPlanWidgetViewState.Loading
+            ContentStatus.ERROR -> StudyPlanWidgetViewState.Error
+            ContentStatus.LOADED -> getLoadedWidgetContent(state)
         }
 
     private fun getLoadedWidgetContent(state: StudyPlanWidgetFeature.State): StudyPlanWidgetViewState.Content {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/model/StudyPlanWidgetViewState.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/model/StudyPlanWidgetViewState.kt
@@ -34,9 +34,15 @@ sealed interface StudyPlanWidgetViewState {
 
         data class Content(
             val sectionItems: List<SectionItem>,
-            val isNextPageLoadingShowed: Boolean,
-            val isLoadAllTopicsButtonShown: Boolean
+            val nextPageLoadingState: SectionContentPageLoadingState,
+            val completedPageLoadingState: SectionContentPageLoadingState
         ) : SectionContent
+    }
+
+    enum class SectionContentPageLoadingState {
+        IDLE,
+        LOAD_MORE,
+        LOADING
     }
 
     data class SectionItem(

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/model/StudyPlanWidgetViewState.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/model/StudyPlanWidgetViewState.kt
@@ -36,7 +36,17 @@ sealed interface StudyPlanWidgetViewState {
             val sectionItems: List<SectionItem>,
             val nextPageLoadingState: SectionContentPageLoadingState,
             val completedPageLoadingState: SectionContentPageLoadingState
-        ) : SectionContent
+        ) : SectionContent {
+            // TODO: ALTAPPS-1334 remove this property and use nextPageLoadingState directly
+            @Deprecated("Is used only for iOS compatibility")
+            val isLoadAllTopicsButtonShown: Boolean
+                get() = nextPageLoadingState == SectionContentPageLoadingState.LOAD_MORE
+
+            // TODO: ALTAPPS-1334 remove this property and use completedPageLoadingState directly
+            @Deprecated("Is used only for iOS compatibility")
+            val isNextPageLoadingShowed: Boolean
+                get() = nextPageLoadingState == SectionContentPageLoadingState.LOADING
+        }
     }
 
     enum class SectionContentPageLoadingState {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/model/StudyPlanWidgetViewState.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/study_plan/widget/view/model/StudyPlanWidgetViewState.kt
@@ -40,7 +40,7 @@ sealed interface StudyPlanWidgetViewState {
     }
 
     enum class SectionContentPageLoadingState {
-        IDLE,
+        HIDDEN,
         LOAD_MORE,
         LOADING
     }

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -530,6 +530,7 @@
     <string name="study_plan_paywall_title">Learn unlimited with\nMobile only plan</string>
     <string name="study_plan_paywall_subscribe_button">Subscribe now</string>
     <string name="study_plan_load_more_button_text">Load more</string>
+    <string name="study_plan_expand_completed_button_text">Expand completed</string>
 
     <!--Project selection list -->
     <string name="projects_list_toolbar_title">Select project</string>

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/screen/StudyPlanScreenTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/screen/StudyPlanScreenTest.kt
@@ -14,7 +14,7 @@ import org.hyperskill.app.study_plan.domain.analytic.StudyPlanViewedHyperskillAn
 import org.hyperskill.app.study_plan.screen.presentation.StudyPlanScreenFeature
 import org.hyperskill.app.study_plan.screen.presentation.StudyPlanScreenReducer
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
-import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.SectionStatus
+import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.ContentStatus
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetReducer
 import org.hyperskill.app.users_interview_widget.presentation.UsersInterviewWidgetFeature
 import org.hyperskill.app.users_interview_widget.presentation.UsersInterviewWidgetReducer
@@ -62,7 +62,7 @@ class StudyPlanScreenTest {
             toolbarState = GamificationToolbarFeature.State.Loading,
             questionnaireWidgetState = UsersInterviewWidgetFeature.State.Loading,
             studyPlanWidgetState = StudyPlanWidgetFeature.State(
-                sectionsStatus = SectionStatus.LOADING
+                sectionsStatus = ContentStatus.LOADING
             )
         )
 

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanExpandCompletedActivitiesTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanExpandCompletedActivitiesTest.kt
@@ -1,0 +1,84 @@
+package org.hyperskill.study_plan.widget
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.hyperskill.app.learning_activities.domain.model.LearningActivity
+import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
+import org.hyperskill.app.study_plan.domain.model.StudyPlanSectionType
+import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
+import org.hyperskill.app.study_plan.widget.presentation.getActivitiesBeforeCurrentActivityToBeLoaded
+import org.hyperskill.learning_activities.domain.model.stub
+import org.hyperskill.study_plan.domain.model.stub
+
+class StudyPlanExpandCompletedActivitiesTest {
+    @Test
+    fun `getActivitiesBeforeCurrentActivityToBeLoaded should return all the activities before last loaded activity`() {
+        val sectionId = 1L
+        val sectionActivitiesIds = List(10) { it.toLong() }
+        val section = StudyPlanSection.stub(
+            id = sectionId,
+            type = StudyPlanSectionType.ROOT_TOPICS,
+            activities = sectionActivitiesIds
+        )
+        val loadedActivitiesIds = listOf(4L, /*5L,*/ 6L, /*7L,*/ 8L)
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    studyPlanSection = section,
+                    isExpanded = true,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            activities = loadedActivitiesIds.associateWith { id -> LearningActivity.stub(id = id) }
+        )
+
+        val expectedActivitiesToBeLoaded = listOf(0L, 1L, 2L, 3L)
+        val actualActivitiesToBeLoaded = state.getActivitiesBeforeCurrentActivityToBeLoaded(sectionId)
+        assertEquals(
+            expected = expectedActivitiesToBeLoaded.toList(),
+            actual = actualActivitiesToBeLoaded
+        )
+    }
+
+    @Test
+    fun `getActivitiesBeforeCurrentActivityToBeLoaded should return empty list for non current sections`() {
+        val allActivities = List(10) { it.toLong() }
+
+        val currentSectionId = 0L
+        val currentSectionActivities = listOf(/*0L, 1L, 2L,*/ 3L, 4L)
+        val currentSection = StudyPlanSection.stub(
+            id = currentSectionId,
+            type = StudyPlanSectionType.EXTRA_TOPICS,
+            activities = currentSectionActivities
+        )
+
+        val nextSectionId = 1L
+        val nextSectionActivities = listOf(/*5L, 6L, 7L,*/ 8L, 9L)
+        val nextSection = StudyPlanSection.stub(
+            id = nextSectionId,
+            type = StudyPlanSectionType.EXTRA_TOPICS,
+            activities = nextSectionActivities
+        )
+
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                currentSection.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    studyPlanSection = currentSection,
+                    isExpanded = true,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
+                ),
+                nextSection.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    studyPlanSection = nextSection,
+                    isExpanded = true,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
+                )
+            ),
+            activities = allActivities.associateWith { id -> LearningActivity.stub(id = id) }
+        )
+
+        assertEquals(
+            expected = emptyList(),
+            actual = state.getActivitiesBeforeCurrentActivityToBeLoaded(nextSectionId)
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanExpandCompletedActivitiesTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanExpandCompletedActivitiesTest.kt
@@ -26,7 +26,9 @@ class StudyPlanExpandCompletedActivitiesTest {
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = section,
                     isExpanded = true,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             activities = loadedActivitiesIds.associateWith { id -> LearningActivity.stub(id = id) }
@@ -65,12 +67,16 @@ class StudyPlanExpandCompletedActivitiesTest {
                 currentSection.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = currentSection,
                     isExpanded = true,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 ),
                 nextSection.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = nextSection,
                     isExpanded = true,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.ALL_PAGES_LOADED
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             activities = allActivities.associateWith { id -> LearningActivity.stub(id = id) }

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanExpandCompletedActivitiesTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanExpandCompletedActivitiesTest.kt
@@ -94,7 +94,7 @@ class StudyPlanExpandCompletedActivitiesTest {
         )
     }
 
-    // ktlint-disable
+    /* ktlint-disable*/
     @Test
     fun `Azfter successfully fetch completed activities page status should become LOADED even if not all activities are loaded`() {
         val allActivities = List(10) { it.toLong() }

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
@@ -6,13 +6,13 @@ import org.hyperskill.app.learning_activities.domain.model.LearningActivity
 import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
 import org.hyperskill.app.study_plan.domain.model.StudyPlanSectionType
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
-import org.hyperskill.app.study_plan.widget.presentation.getRootTopicsActivitiesToBeLoaded
+import org.hyperskill.app.study_plan.widget.presentation.getNextRootTopicsActivitiesToBeLoaded
 import org.hyperskill.learning_activities.domain.model.stub
 import org.hyperskill.study_plan.domain.model.stub
 
 class StudyPlanLoadMoreActivitiesTest {
     @Test
-    fun `getActivitiesToBeLoaded should return all the section activities for ROOT_TOPICS section`() {
+    fun `getNextRootTopicsActivitiesToBeLoaded should return all the section activities for ROOT_TOPICS section`() {
         val sectionId = 1L
         val sectionActivitiesIds = List(2) { it.toLong() }
         val section = StudyPlanSection.stub(
@@ -31,12 +31,13 @@ class StudyPlanLoadMoreActivitiesTest {
             activities = emptyMap()
         )
 
-        val activitiesToBeLoaded = state.getRootTopicsActivitiesToBeLoaded(sectionId)
+        val activitiesToBeLoaded = state.getNextRootTopicsActivitiesToBeLoaded(sectionId)
         assertEquals(section.activities, activitiesToBeLoaded)
     }
 
+    // ktlint-disable
     @Test
-    fun `getActivitiesToBeLoaded should return all activities after last loaded activity for ROOT_TOPICS section`() {
+    fun `getNextRootTopicsActivitiesToBeLoaded should return all activities after last loaded activity for ROOT_TOPICS section`() {
         val sectionId = 1L
         val sectionActivitiesIds = List(10) { it.toLong() }
         val section = StudyPlanSection.stub(
@@ -44,7 +45,7 @@ class StudyPlanLoadMoreActivitiesTest {
             type = StudyPlanSectionType.ROOT_TOPICS,
             activities = sectionActivitiesIds
         )
-        val loadedActivitiesIds = sectionActivitiesIds.take(5)
+        val loadedActivitiesIds = listOf(/*0L,*/ 1L, /*2L,*/ 3L, 4L)
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
@@ -56,13 +57,14 @@ class StudyPlanLoadMoreActivitiesTest {
             activities = loadedActivitiesIds.associateWith { id -> LearningActivity.stub(id = id) }
         )
 
-        val expectedActivitiesToBeLoaded = sectionActivitiesIds.subtract(loadedActivitiesIds.toSet())
-        val actualActivitiesToBeLoaded = state.getRootTopicsActivitiesToBeLoaded(sectionId)
+        val expectedActivitiesToBeLoaded = listOf(5L, 6L, 7L, 8L, 9L)
+        val actualActivitiesToBeLoaded = state.getNextRootTopicsActivitiesToBeLoaded(sectionId)
         assertEquals(expectedActivitiesToBeLoaded.toList(), actualActivitiesToBeLoaded)
     }
 
+    // ktlint-disable
     @Test
-    fun `getActivitiesToBeLoaded should return empty list if all ROOT_TOPICS section activities are loaded`() {
+    fun `getNextRootTopicsActivitiesToBeLoaded should return empty list if all ROOT_TOPICS section activities are loaded`() {
         val sectionId = 1L
         val sectionActivitiesIds = List(10) { it.toLong() }
         val section = StudyPlanSection.stub(
@@ -81,7 +83,7 @@ class StudyPlanLoadMoreActivitiesTest {
             activities = sectionActivitiesIds.associateWith { id -> LearningActivity.stub(id = id) }
         )
 
-        val actualActivitiesToBeLoaded = state.getRootTopicsActivitiesToBeLoaded(sectionId)
+        val actualActivitiesToBeLoaded = state.getNextRootTopicsActivitiesToBeLoaded(sectionId)
         assertEquals(
             expected = emptyList(),
             actual = actualActivitiesToBeLoaded
@@ -89,7 +91,7 @@ class StudyPlanLoadMoreActivitiesTest {
     }
 
     @Test
-    fun `getActivitiesToBeLoaded should return empty list for ROOT_TOPICS sections`() {
+    fun `getNextRootTopicsActivitiesToBeLoaded should return empty list for ROOT_TOPICS sections`() {
         val nonRootSectionTypes =
             StudyPlanSectionType.entries - StudyPlanSectionType.ROOT_TOPICS
         nonRootSectionTypes.forEach { sectionType ->
@@ -111,7 +113,7 @@ class StudyPlanLoadMoreActivitiesTest {
                 activities = emptyMap()
             )
 
-            val activitiesToBeLoaded = state.getRootTopicsActivitiesToBeLoaded(sectionId)
+            val activitiesToBeLoaded = state.getNextRootTopicsActivitiesToBeLoaded(sectionId)
             assertEquals(
                 expected = emptyList(),
                 actual = activitiesToBeLoaded

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
@@ -6,11 +6,17 @@ import org.hyperskill.app.learning_activities.domain.model.LearningActivity
 import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
 import org.hyperskill.app.study_plan.domain.model.StudyPlanSectionType
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
+import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.ContentStatus
+import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.PageContentStatus
+import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetReducer
 import org.hyperskill.app.study_plan.widget.presentation.getNextRootTopicsActivitiesToBeLoaded
 import org.hyperskill.learning_activities.domain.model.stub
 import org.hyperskill.study_plan.domain.model.stub
 
 class StudyPlanLoadMoreActivitiesTest {
+
+    private val reducer = StudyPlanWidgetReducer()
+
     @Test
     fun `getNextRootTopicsActivitiesToBeLoaded should return all the section activities for ROOT_TOPICS section`() {
         val sectionId = 1L
@@ -25,9 +31,9 @@ class StudyPlanLoadMoreActivitiesTest {
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = section,
                     isExpanded = true,
-                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
-                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
-                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
+                    mainPageContentStatus = ContentStatus.IDLE,
+                    nextPageContentStatus = PageContentStatus.IDLE,
+                    completedPageContentStatus = PageContentStatus.IDLE
                 )
             ),
             activities = emptyMap()
@@ -53,9 +59,9 @@ class StudyPlanLoadMoreActivitiesTest {
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = section,
                     isExpanded = true,
-                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
-                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
-                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
+                    mainPageContentStatus = ContentStatus.IDLE,
+                    nextPageContentStatus = PageContentStatus.IDLE,
+                    completedPageContentStatus = PageContentStatus.IDLE
                 )
             ),
             activities = loadedActivitiesIds.associateWith { id -> LearningActivity.stub(id = id) }
@@ -81,9 +87,9 @@ class StudyPlanLoadMoreActivitiesTest {
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = section,
                     isExpanded = true,
-                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
-                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
-                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
+                    mainPageContentStatus = ContentStatus.IDLE,
+                    nextPageContentStatus = PageContentStatus.IDLE,
+                    completedPageContentStatus = PageContentStatus.IDLE
                 )
             ),
             activities = sectionActivitiesIds.associateWith { id -> LearningActivity.stub(id = id) }
@@ -113,9 +119,9 @@ class StudyPlanLoadMoreActivitiesTest {
                     section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                         studyPlanSection = section,
                         isExpanded = true,
-                        mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
-                        nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
-                        completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
+                        mainPageContentStatus = ContentStatus.IDLE,
+                        nextPageContentStatus = PageContentStatus.IDLE,
+                        completedPageContentStatus = PageContentStatus.IDLE
                     )
                 ),
                 activities = emptyMap()
@@ -127,5 +133,48 @@ class StudyPlanLoadMoreActivitiesTest {
                 actual = activitiesToBeLoaded
             )
         }
+    }
+
+    // ktlint-disable
+    @Test
+    fun `Azfter successfully fetch completed activities page status should become LOADED even if not all activities are loaded`() {
+        val allActivities = List(10) { it.toLong() }
+        val mainPageActivities = listOf(5L, 6L, 7L, 8L, 9L)
+        val loadedCompletedPageActivities = listOf(/*0L,*/ 1L, /*2L, 3L,*/ 4L)
+
+        val sectionId = 0L
+        val section = StudyPlanSection.stub(
+            id = sectionId,
+            type = StudyPlanSectionType.EXTRA_TOPICS,
+            activities = allActivities
+        )
+
+        val initialState = StudyPlanWidgetFeature.State(
+            sectionsStatus = ContentStatus.LOADED,
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    studyPlanSection = section,
+                    isExpanded = true,
+                    mainPageContentStatus = ContentStatus.LOADED,
+                    nextPageContentStatus = PageContentStatus.IDLE,
+                    completedPageContentStatus = PageContentStatus.LOADING
+                )
+            ),
+            activities = mainPageActivities.associateWith { id -> LearningActivity.stub(id = id) }
+        )
+
+        val (state, _) = reducer.reduce(
+            initialState,
+            StudyPlanWidgetFeature.LearningActivitiesFetchResult.Success(
+                sectionId = sectionId,
+                activities = loadedCompletedPageActivities.map { id -> LearningActivity.stub(id = id) },
+                targetPage = StudyPlanWidgetFeature.SectionPage.NEXT
+            )
+        )
+
+        assertEquals(
+            expected = PageContentStatus.LOADED,
+            actual = state.studyPlanSections[sectionId]?.nextPageContentStatus
+        )
     }
 }

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
@@ -1,0 +1,121 @@
+package org.hyperskill.study_plan.widget
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.hyperskill.app.learning_activities.domain.model.LearningActivity
+import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
+import org.hyperskill.app.study_plan.domain.model.StudyPlanSectionType
+import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
+import org.hyperskill.app.study_plan.widget.presentation.getRootTopicsActivitiesToBeLoaded
+import org.hyperskill.learning_activities.domain.model.stub
+import org.hyperskill.study_plan.domain.model.stub
+
+class StudyPlanLoadMoreActivitiesTest {
+    @Test
+    fun `getActivitiesToBeLoaded should return all the section activities for ROOT_TOPICS section`() {
+        val sectionId = 1L
+        val sectionActivitiesIds = List(2) { it.toLong() }
+        val section = StudyPlanSection.stub(
+            id = sectionId,
+            type = StudyPlanSectionType.ROOT_TOPICS,
+            activities = sectionActivitiesIds
+        )
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    studyPlanSection = section,
+                    isExpanded = true,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            activities = emptyMap()
+        )
+
+        val activitiesToBeLoaded = state.getRootTopicsActivitiesToBeLoaded(sectionId)
+        assertEquals(section.activities, activitiesToBeLoaded)
+    }
+
+    @Test
+    fun `getActivitiesToBeLoaded should return all activities after last loaded activity for ROOT_TOPICS section`() {
+        val sectionId = 1L
+        val sectionActivitiesIds = List(10) { it.toLong() }
+        val section = StudyPlanSection.stub(
+            id = sectionId,
+            type = StudyPlanSectionType.ROOT_TOPICS,
+            activities = sectionActivitiesIds
+        )
+        val loadedActivitiesIds = sectionActivitiesIds.take(5)
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    studyPlanSection = section,
+                    isExpanded = true,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            activities = loadedActivitiesIds.associateWith { id -> LearningActivity.stub(id = id) }
+        )
+
+        val expectedActivitiesToBeLoaded = sectionActivitiesIds.subtract(loadedActivitiesIds.toSet())
+        val actualActivitiesToBeLoaded = state.getRootTopicsActivitiesToBeLoaded(sectionId)
+        assertEquals(expectedActivitiesToBeLoaded.toList(), actualActivitiesToBeLoaded)
+    }
+
+    @Test
+    fun `getActivitiesToBeLoaded should return empty list if all ROOT_TOPICS section activities are loaded`() {
+        val sectionId = 1L
+        val sectionActivitiesIds = List(10) { it.toLong() }
+        val section = StudyPlanSection.stub(
+            id = sectionId,
+            type = StudyPlanSectionType.ROOT_TOPICS,
+            activities = sectionActivitiesIds
+        )
+        val state = StudyPlanWidgetFeature.State(
+            studyPlanSections = mapOf(
+                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                    studyPlanSection = section,
+                    isExpanded = true,
+                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                )
+            ),
+            activities = sectionActivitiesIds.associateWith { id -> LearningActivity.stub(id = id) }
+        )
+
+        val actualActivitiesToBeLoaded = state.getRootTopicsActivitiesToBeLoaded(sectionId)
+        assertEquals(
+            expected = emptyList(),
+            actual = actualActivitiesToBeLoaded
+        )
+    }
+
+    @Test
+    fun `getActivitiesToBeLoaded should return empty list for ROOT_TOPICS sections`() {
+        val nonRootSectionTypes =
+            StudyPlanSectionType.entries - StudyPlanSectionType.ROOT_TOPICS
+        nonRootSectionTypes.forEach { sectionType ->
+            val sectionId = 1L
+            val sectionActivitiesIds = List(2) { it.toLong() }
+            val section = StudyPlanSection.stub(
+                id = sectionId,
+                type = sectionType,
+                activities = sectionActivitiesIds
+            )
+            val state = StudyPlanWidgetFeature.State(
+                studyPlanSections = mapOf(
+                    section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
+                        studyPlanSection = section,
+                        isExpanded = true,
+                        sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    )
+                ),
+                activities = emptyMap()
+            )
+
+            val activitiesToBeLoaded = state.getRootTopicsActivitiesToBeLoaded(sectionId)
+            assertEquals(
+                expected = emptyList(),
+                actual = activitiesToBeLoaded
+            )
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
@@ -72,7 +72,7 @@ class StudyPlanLoadMoreActivitiesTest {
         assertEquals(expectedActivitiesToBeLoaded.toList(), actualActivitiesToBeLoaded)
     }
 
-    // ktlint-disable
+    /*ktlint-disable*/
     @Test
     fun `getNextRootTopicsActivitiesToBeLoaded should return empty list if all ROOT_TOPICS section activities are loaded`() {
         val sectionId = 1L
@@ -135,7 +135,7 @@ class StudyPlanLoadMoreActivitiesTest {
         }
     }
 
-    // ktlint-disable
+    /*ktlint-disable*/
     @Test
     fun `Azfter successfully fetch completed activities page status should become LOADED even if not all activities are loaded`() {
         val allActivities = List(10) { it.toLong() }

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
@@ -137,7 +137,7 @@ class StudyPlanLoadMoreActivitiesTest {
 
     /*ktlint-disable*/
     @Test
-    fun `Azfter successfully fetch completed activities page status should become LOADED even if not all activities are loaded`() {
+    fun `After successfully fetch completed activities page status should become LOADED even if not all activities are loaded`() {
         val allActivities = List(10) { it.toLong() }
         val mainPageActivities = listOf(5L, 6L, 7L, 8L, 9L)
         val loadedCompletedPageActivities = listOf(/*0L,*/ 1L, /*2L, 3L,*/ 4L)

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
@@ -25,7 +25,9 @@ class StudyPlanLoadMoreActivitiesTest {
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = section,
                     isExpanded = true,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             activities = emptyMap()
@@ -51,7 +53,9 @@ class StudyPlanLoadMoreActivitiesTest {
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = section,
                     isExpanded = true,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             activities = loadedActivitiesIds.associateWith { id -> LearningActivity.stub(id = id) }
@@ -77,7 +81,9 @@ class StudyPlanLoadMoreActivitiesTest {
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                     studyPlanSection = section,
                     isExpanded = true,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             activities = sectionActivitiesIds.associateWith { id -> LearningActivity.stub(id = id) }
@@ -107,7 +113,9 @@ class StudyPlanLoadMoreActivitiesTest {
                     section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
                         studyPlanSection = section,
                         isExpanded = true,
-                        sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                        mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                        nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                        completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                     )
                 ),
                 activities = emptyMap()

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanLoadMoreActivitiesTest.kt
@@ -43,7 +43,7 @@ class StudyPlanLoadMoreActivitiesTest {
         assertEquals(section.activities, activitiesToBeLoaded)
     }
 
-    // ktlint-disable
+    /*ktlint-disable*/
     @Test
     fun `getNextRootTopicsActivitiesToBeLoaded should return all activities after last loaded activity for ROOT_TOPICS section`() {
         val sectionId = 1L

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetStateExtensionsTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetStateExtensionsTest.kt
@@ -32,14 +32,18 @@ class StudyPlanWidgetStateExtensionsTest {
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(
                 section1.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    section1,
-                    true,
-                    StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    studyPlanSection = section1,
+                    isExpanded = true,
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 ),
                 section2.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    section2,
-                    true,
-                    StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    studyPlanSection = section2,
+                    isExpanded = true,
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             )
         )
@@ -61,9 +65,11 @@ class StudyPlanWidgetStateExtensionsTest {
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    section,
-                    true,
-                    StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    studyPlanSection = section,
+                    isExpanded = true,
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             activities = mapOf(activity.id to activity)
@@ -82,9 +88,11 @@ class StudyPlanWidgetStateExtensionsTest {
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    section,
+                    studyPlanSection = section,
                     isExpanded = false,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             activities = mapOf(activity1.id to activity1, activity2.id to activity2)
@@ -102,9 +110,11 @@ class StudyPlanWidgetStateExtensionsTest {
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    section,
-                    true,
-                    StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    studyPlanSection = section,
+                    isExpanded = true,
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             activities = activities.associateBy { it.id }
@@ -124,9 +134,11 @@ class StudyPlanWidgetStateExtensionsTest {
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    section,
+                    studyPlanSection = section,
                     isExpanded = false,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             activities = mapOf(1L to LearningActivity.stub(id = 1)),
@@ -149,9 +161,11 @@ class StudyPlanWidgetStateExtensionsTest {
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    section,
+                    studyPlanSection = section,
                     isExpanded = false,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             profile = Profile.stub(
@@ -176,9 +190,11 @@ class StudyPlanWidgetStateExtensionsTest {
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    section,
+                    studyPlanSection = section,
                     isExpanded = false,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             profile = Profile.stub(
@@ -203,9 +219,11 @@ class StudyPlanWidgetStateExtensionsTest {
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    section,
+                    studyPlanSection = section,
                     isExpanded = false,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             profile = Profile.stub(
@@ -230,9 +248,11 @@ class StudyPlanWidgetStateExtensionsTest {
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    section,
+                    studyPlanSection = section,
                     isExpanded = false,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             profile = Profile.stub(
@@ -263,14 +283,18 @@ class StudyPlanWidgetStateExtensionsTest {
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(
                 section1.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    section1,
+                    studyPlanSection = section1,
                     isExpanded = false,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 ),
                 section2.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    section2,
+                    studyPlanSection = section2,
                     isExpanded = false,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             profile = Profile.stub(
@@ -295,9 +319,11 @@ class StudyPlanWidgetStateExtensionsTest {
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(
                 section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    section,
+                    studyPlanSection = section,
                     isExpanded = false,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
+                    mainPageContentStatus = StudyPlanWidgetFeature.ContentStatus.IDLE,
+                    nextPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE,
+                    completedPageContentStatus = StudyPlanWidgetFeature.PageContentStatus.IDLE
                 )
             ),
             profile = Profile.stub(

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetStateExtensionsTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetStateExtensionsTest.kt
@@ -16,7 +16,6 @@ import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
 import org.hyperskill.app.study_plan.widget.presentation.getCurrentActivity
 import org.hyperskill.app.study_plan.widget.presentation.getCurrentSection
 import org.hyperskill.app.study_plan.widget.presentation.getLoadedSectionActivities
-import org.hyperskill.app.study_plan.widget.presentation.getRootTopicsActivitiesToBeLoaded
 import org.hyperskill.app.study_plan.widget.presentation.getUnlockedActivitiesCount
 import org.hyperskill.app.study_plan.widget.presentation.isActivityLocked
 import org.hyperskill.app.study_plan.widget.presentation.isPaywallShown
@@ -113,114 +112,6 @@ class StudyPlanWidgetStateExtensionsTest {
 
         val loadedActivities = state.getLoadedSectionActivities(sectionId).toList()
         assertEquals(activities, loadedActivities)
-    }
-
-    @Test
-    fun `getActivitiesToBeLoaded should return all the section activities for ROOT_TOPICS section`() {
-        val sectionId = 1L
-        val sectionActivitiesIds = List(2) { it.toLong() }
-        val section = StudyPlanSection.stub(
-            id = sectionId,
-            type = StudyPlanSectionType.ROOT_TOPICS,
-            activities = sectionActivitiesIds
-        )
-        val state = StudyPlanWidgetFeature.State(
-            studyPlanSections = mapOf(
-                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    studyPlanSection = section,
-                    isExpanded = true,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
-                )
-            ),
-            activities = emptyMap()
-        )
-
-        val activitiesToBeLoaded = state.getRootTopicsActivitiesToBeLoaded(sectionId)
-        assertEquals(section.activities, activitiesToBeLoaded)
-    }
-
-    @Test
-    fun `getActivitiesToBeLoaded should return all activities after last loaded activity for ROOT_TOPICS section`() {
-        val sectionId = 1L
-        val sectionActivitiesIds = List(10) { it.toLong() }
-        val section = StudyPlanSection.stub(
-            id = sectionId,
-            type = StudyPlanSectionType.ROOT_TOPICS,
-            activities = sectionActivitiesIds
-        )
-        val loadedActivitiesIds = sectionActivitiesIds.take(5)
-        val state = StudyPlanWidgetFeature.State(
-            studyPlanSections = mapOf(
-                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    studyPlanSection = section,
-                    isExpanded = true,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
-                )
-            ),
-            activities = loadedActivitiesIds.associateWith { id -> LearningActivity.stub(id = id) }
-        )
-
-        val expectedActivitiesToBeLoaded = sectionActivitiesIds.subtract(loadedActivitiesIds.toSet())
-        val actualActivitiesToBeLoaded = state.getRootTopicsActivitiesToBeLoaded(sectionId)
-        assertEquals(expectedActivitiesToBeLoaded.toList(), actualActivitiesToBeLoaded)
-    }
-
-    @Test
-    fun `getActivitiesToBeLoaded should return empty list if all ROOT_TOPICS section activities are loaded`() {
-        val sectionId = 1L
-        val sectionActivitiesIds = List(10) { it.toLong() }
-        val section = StudyPlanSection.stub(
-            id = sectionId,
-            type = StudyPlanSectionType.ROOT_TOPICS,
-            activities = sectionActivitiesIds
-        )
-        val state = StudyPlanWidgetFeature.State(
-            studyPlanSections = mapOf(
-                section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                    studyPlanSection = section,
-                    isExpanded = true,
-                    sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
-                )
-            ),
-            activities = sectionActivitiesIds.associateWith { id -> LearningActivity.stub(id = id) }
-        )
-
-        val actualActivitiesToBeLoaded = state.getRootTopicsActivitiesToBeLoaded(sectionId)
-        assertEquals(
-            expected = emptyList(),
-            actual = actualActivitiesToBeLoaded
-        )
-    }
-
-    @Test
-    fun `getActivitiesToBeLoaded should return empty list for ROOT_TOPICS sections`() {
-        val nonRootSectionTypes =
-            StudyPlanSectionType.entries - StudyPlanSectionType.ROOT_TOPICS
-        nonRootSectionTypes.forEach { sectionType ->
-            val sectionId = 1L
-            val sectionActivitiesIds = List(2) { it.toLong() }
-            val section = StudyPlanSection.stub(
-                id = sectionId,
-                type = sectionType,
-                activities = sectionActivitiesIds
-            )
-            val state = StudyPlanWidgetFeature.State(
-                studyPlanSections = mapOf(
-                    section.id to StudyPlanWidgetFeature.StudyPlanSectionInfo(
-                        studyPlanSection = section,
-                        isExpanded = true,
-                        sectionContentStatus = StudyPlanWidgetFeature.SectionContentStatus.IDLE
-                    )
-                ),
-                activities = emptyMap()
-            )
-
-            val activitiesToBeLoaded = state.getRootTopicsActivitiesToBeLoaded(sectionId)
-            assertEquals(
-                expected = emptyList(),
-                actual = activitiesToBeLoaded
-            )
-        }
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetTest.kt
@@ -558,7 +558,8 @@ class StudyPlanWidgetTest {
             StudyPlanWidgetFeature.InternalAction.FetchLearningActivities(
                 sectionId = section.id,
                 activitiesIds = activities,
-                sentryTransaction = HyperskillSentryTransactionBuilder.buildStudyPlanWidgetFetchLearningActivities(true),
+                sentryTransaction = HyperskillSentryTransactionBuilder
+                    .buildStudyPlanWidgetFetchLearningActivities(true),
                 targetPage = SectionPage.MAIN
             )
         )

--- a/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/study_plan/widget/StudyPlanWidgetTest.kt
@@ -23,8 +23,8 @@ import org.hyperskill.app.study_plan.domain.model.StudyPlanSection
 import org.hyperskill.app.study_plan.domain.model.StudyPlanSectionType
 import org.hyperskill.app.study_plan.widget.domain.mapper.LearningActivityToTopicProgressMapper
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature
+import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.ContentStatus
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.SectionContentStatus
-import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetFeature.SectionStatus
 import org.hyperskill.app.study_plan.widget.presentation.StudyPlanWidgetReducer
 import org.hyperskill.app.study_plan.widget.view.mapper.StudyPlanWidgetViewStateMapper
 import org.hyperskill.app.study_plan.widget.view.model.StudyPlanWidgetViewState
@@ -52,7 +52,7 @@ class StudyPlanWidgetTest {
         val initialState = StudyPlanWidgetFeature.State()
         val (state, actions) = reducer.reduce(initialState, StudyPlanWidgetFeature.InternalMessage.Initialize())
         assertContains(actions, StudyPlanWidgetFeature.InternalAction.FetchLearningActivitiesWithSections())
-        assertEquals(state.sectionsStatus, SectionStatus.LOADING)
+        assertEquals(state.sectionsStatus, ContentStatus.LOADING)
     }
 
     @Test
@@ -67,7 +67,7 @@ class StudyPlanWidgetTest {
                 learnedTopicsCount = 0
             )
         )
-        assertEquals(SectionStatus.LOADED, state.sectionsStatus)
+        assertEquals(ContentStatus.LOADED, state.sectionsStatus)
     }
 
     @Test
@@ -174,7 +174,7 @@ class StudyPlanWidgetTest {
     fun `Study plan sections should be empty if loaded sections does not contains current section`() {
         val expectedState = StudyPlanWidgetFeature.State(
             studyPlanSections = emptyMap(),
-            sectionsStatus = SectionStatus.LOADED,
+            sectionsStatus = ContentStatus.LOADED,
             isRefreshing = false
         )
 
@@ -546,7 +546,7 @@ class StudyPlanWidgetTest {
         listOf(collapsedSection, idleSection).forEach { givenSection ->
             val state = StudyPlanWidgetFeature.State(
                 studyPlanSections = mapOf(sectionId to givenSection),
-                sectionsStatus = SectionStatus.LOADED
+                sectionsStatus = ContentStatus.LOADED
             )
 
             val viewState = studyPlanWidgetViewStateMapper.map(state)
@@ -577,7 +577,7 @@ class StudyPlanWidgetTest {
         )
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(sectionId to section),
-            sectionsStatus = SectionStatus.LOADED,
+            sectionsStatus = ContentStatus.LOADED,
             activities = mapOf(activityId to stubLearningActivity(activityId))
         )
 
@@ -618,7 +618,7 @@ class StudyPlanWidgetTest {
         )
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(sectionId to section),
-            sectionsStatus = SectionStatus.LOADED,
+            sectionsStatus = ContentStatus.LOADED,
             activities = mapOf(activityId to stubLearningActivity(activityId))
         )
 
@@ -664,7 +664,7 @@ class StudyPlanWidgetTest {
         )
         val state = StudyPlanWidgetFeature.State(
             studyPlanSections = mapOf(sectionId to section),
-            sectionsStatus = SectionStatus.LOADED
+            sectionsStatus = ContentStatus.LOADED
         )
 
         val (newState, actions) =
@@ -711,7 +711,7 @@ class StudyPlanWidgetTest {
             activities = mapOf(
                 0L to stubLearningActivity(id = 0, title = "Activity 1")
             ),
-            sectionsStatus = SectionStatus.LOADED
+            sectionsStatus = ContentStatus.LOADED
         )
 
         val viewState = studyPlanWidgetViewStateMapper.map(state)
@@ -750,7 +750,7 @@ class StudyPlanWidgetTest {
                 )
             ),
             activities = mapOf(0L to stubLearningActivity(id = 0, title = "")),
-            sectionsStatus = SectionStatus.LOADED
+            sectionsStatus = ContentStatus.LOADED
         )
 
         val viewState = studyPlanWidgetViewStateMapper.map(state)
@@ -796,7 +796,7 @@ class StudyPlanWidgetTest {
                     description = "Work on project. Stage: 1/6"
                 )
             ),
-            sectionsStatus = SectionStatus.LOADED
+            sectionsStatus = ContentStatus.LOADED
         )
 
         val viewState = studyPlanWidgetViewStateMapper.map(state)
@@ -818,7 +818,7 @@ class StudyPlanWidgetTest {
                         sectionContentStatus = SectionContentStatus.IDLE
                     )
                 ),
-                sectionsStatus = SectionStatus.LOADED
+                sectionsStatus = ContentStatus.LOADED
             )
 
         val expectedViewState = StudyPlanWidgetViewState.Content(
@@ -898,7 +898,7 @@ class StudyPlanWidgetTest {
                 0L to stubLearningActivity(id = 0),
                 1L to stubLearningActivity(id = 1)
             ),
-            sectionsStatus = SectionStatus.LOADED
+            sectionsStatus = ContentStatus.LOADED
         )
 
         val viewState = studyPlanWidgetViewStateMapper.map(state)
@@ -1332,7 +1332,7 @@ class StudyPlanWidgetTest {
                 notNextActivityId to stubLearningActivity(notNextActivityId),
                 nextActivityId to stubLearningActivity(nextActivityId)
             ),
-            sectionsStatus = SectionStatus.LOADED
+            sectionsStatus = ContentStatus.LOADED
         )
 
         val viewState = studyPlanWidgetViewStateMapper.map(state)
@@ -1375,7 +1375,7 @@ class StudyPlanWidgetTest {
                 firstActivityId to stubLearningActivity(firstActivityId),
                 secondActivityId to stubLearningActivity(secondActivityId)
             ),
-            sectionsStatus = SectionStatus.LOADED
+            sectionsStatus = ContentStatus.LOADED
         )
 
         val viewState = studyPlanWidgetViewStateMapper.map(state)


### PR DESCRIPTION
**YouTrack Issues**:
[ALTAPPS-1335](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1335)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
- Update `StudyPlanWidgetFeature.State.getNextRootTopicsActivitiesToBeLoaded` so that only activities after last loaded activity are taken;
- Implement `StudyPlanWidgetFeature.State.getActivitiesBeforeCurrentActivityToBeLoaded` to get unloaded activities before current activity;
- Add `StudyPlanWidgetFeature.Message,ExpandCompletedActivitiesClicked` to signal about `Expand completed` button is clicked;
- Replace `StudyPlanWidgetFeature.StudyPlanSectionInfo.sectionContentStatus` with separated content status for the main page, next page and completed page;
- Pass `StudyPlanWidgetFeature.SectionPage` into `StudyPlanWidgetFeature.InternalAction.FetchLearningActivities` to distinct activities loaded for main, next or completed page;
- Add tests for `Expand completed` button;
- Implement Android ui for `Expand completed` button.
