### PR TITLE
ALTAPPS-1346: Shared, iOS code blanks support code_blanks_available_conditions

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Extensions/Shared/Model/BlockOptionsExtensions.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Extensions/Shared/Model/BlockOptionsExtensions.swift
@@ -14,6 +14,7 @@ extension Block.Options {
         codeBlanksStrings: [String]? = nil,
         codeBlanksVariables: [String]? = nil,
         codeBlanksOperations: [String]? = nil,
+        codeBlanksAvailableConditions: Set<String>? = nil,
         codeBlanksEnabled: Bool? = nil,
         codeBlanksTemplateString: String? = nil
     ) {
@@ -28,6 +29,7 @@ extension Block.Options {
             codeBlanksStrings: codeBlanksStrings,
             codeBlanksVariables: codeBlanksVariables,
             codeBlanksOperations: codeBlanksOperations,
+            codeBlanksAvailableConditions: codeBlanksAvailableConditions,
             codeBlanksEnabled: codeBlanksEnabled.flatMap(KotlinBoolean.init(value:)),
             codeBlanksTemplateString: codeBlanksTemplateString
         )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step/domain/model/Block.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step/domain/model/Block.kt
@@ -38,12 +38,12 @@ data class Block(
         val codeBlanksVariables: List<String>? = null,
         @SerialName("code_blanks_operations")
         val codeBlanksOperations: List<String>? = null,
+        @SerialName("code_blanks_available_conditions")
+        val codeBlanksAvailableConditions: Set<String>? = null,
         @SerialName("code_blanks_enabled")
         val codeBlanksEnabled: Boolean? = null,
         @SerialName("code_blanks_template")
-        val codeBlanksTemplateString: String? = null,
-        @SerialName("code_blanks_available_conditions")
-        val codeBlanksAvailableConditions: Set<String>? = null
+        val codeBlanksTemplateString: String? = null
     ) {
         val samples: List<Sample>?
             get() = internalSamples?.mapNotNull {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step/domain/model/Block.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step/domain/model/Block.kt
@@ -41,7 +41,9 @@ data class Block(
         @SerialName("code_blanks_enabled")
         val codeBlanksEnabled: Boolean? = null,
         @SerialName("code_blanks_template")
-        val codeBlanksTemplateString: String? = null
+        val codeBlanksTemplateString: String? = null,
+        @SerialName("code_blanks_available_conditions")
+        val codeBlanksAvailableConditions: Set<String>? = null
     ) {
         val samples: List<Sample>?
             get() = internalSamples?.mapNotNull {

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/domain/model/template/CodeBlanksTemplateMapper.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/domain/model/template/CodeBlanksTemplateMapper.kt
@@ -50,7 +50,8 @@ internal object CodeBlanksTemplateMapper {
                     indentLevel = entry.indentLevel,
                     isDeleteForbidden = entry.isDeleteForbidden,
                     suggestions = StepQuizCodeBlanksResolver.getSuggestionsForBlankCodeBlock(
-                        isVariableSuggestionAvailable = StepQuizCodeBlanksResolver.isVariableSuggestionsAvailable(step)
+                        isVariableSuggestionAvailable = StepQuizCodeBlanksResolver.isVariableSuggestionsAvailable(step),
+                        availableConditions = step.block.options.codeBlanksAvailableConditions ?: emptySet()
                     )
                 )
             CodeBlockTemplateEntryType.PRINT ->
@@ -194,7 +195,8 @@ internal object CodeBlanksTemplateMapper {
                 indentLevel = 0,
                 isDeleteForbidden = false,
                 suggestions = StepQuizCodeBlanksResolver.getSuggestionsForBlankCodeBlock(
-                    isVariableSuggestionAvailable = StepQuizCodeBlanksResolver.isVariableSuggestionsAvailable(step)
+                    isVariableSuggestionAvailable = StepQuizCodeBlanksResolver.isVariableSuggestionsAvailable(step),
+                    availableConditions = step.block.options.codeBlanksAvailableConditions ?: emptySet()
                 )
             )
         )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/presentation/StepQuizCodeBlanksReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/presentation/StepQuizCodeBlanksReducer.kt
@@ -200,7 +200,8 @@ class StepQuizCodeBlanksReducer(
                             index = blankInsertIndex,
                             indentLevel = blankIndentLevel,
                             codeBlocks = this,
-                            isVariableSuggestionAvailable = state.isVariableSuggestionsAvailable
+                            isVariableSuggestionAvailable = state.isVariableSuggestionsAvailable,
+                            availableConditions = state.availableConditions
                         )
                     )
                 )
@@ -357,7 +358,8 @@ class StepQuizCodeBlanksReducer(
                             index = activeCodeBlockIndex,
                             indentLevel = activeCodeBlock.indentLevel,
                             codeBlocks = this,
-                            isVariableSuggestionAvailable = state.isVariableSuggestionsAvailable
+                            isVariableSuggestionAvailable = state.isVariableSuggestionsAvailable,
+                            availableConditions = state.availableConditions
                         )
                     )
                 )
@@ -564,7 +566,8 @@ class StepQuizCodeBlanksReducer(
                             index = insertIndex,
                             indentLevel = indentLevel,
                             codeBlocks = this,
-                            isVariableSuggestionAvailable = state.isVariableSuggestionsAvailable
+                            isVariableSuggestionAvailable = state.isVariableSuggestionsAvailable,
+                            availableConditions = state.availableConditions
                         )
                     )
                 )
@@ -699,7 +702,8 @@ class StepQuizCodeBlanksReducer(
                                 index = activeCodeBlockIndex,
                                 indentLevel = newIndentLevel,
                                 codeBlocks = this,
-                                isVariableSuggestionAvailable = state.isVariableSuggestionsAvailable
+                                isVariableSuggestionAvailable = state.isVariableSuggestionsAvailable,
+                                availableConditions = state.availableConditions
                             )
                         )
                         else -> activeCodeBlock.updatedIndentLevel(newIndentLevel)
@@ -749,7 +753,8 @@ class StepQuizCodeBlanksReducer(
                     isActive = true,
                     indentLevel = 0,
                     suggestions = StepQuizCodeBlanksResolver.getSuggestionsForBlankCodeBlock(
-                        isVariableSuggestionAvailable = StepQuizCodeBlanksResolver.isVariableSuggestionsAvailable(step)
+                        isVariableSuggestionAvailable = StepQuizCodeBlanksResolver.isVariableSuggestionsAvailable(step),
+                        availableConditions = step.block.options.codeBlanksAvailableConditions ?: emptySet()
                     )
                 )
             )

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/presentation/StepQuizCodeBlanksResolver.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/presentation/StepQuizCodeBlanksResolver.kt
@@ -15,14 +15,33 @@ internal object StepQuizCodeBlanksResolver {
         index: Int = -1,
         indentLevel: Int = 0,
         codeBlocks: List<CodeBlock> = emptyList(),
-        isVariableSuggestionAvailable: Boolean
+        isVariableSuggestionAvailable: Boolean,
+        availableConditions: Set<String>
     ): List<Suggestion> =
         when {
-            areElifAndElseStatementsSuggestionsAvailable(index, indentLevel, codeBlocks) ->
-                listOf(Suggestion.Print, Suggestion.Variable, Suggestion.ElifStatement, Suggestion.ElseStatement)
+            areElifAndElseStatementsSuggestionsAvailable(index, indentLevel, codeBlocks, availableConditions) ->
+                buildList {
+                    add(Suggestion.Print)
+                    add(Suggestion.Variable)
+
+                    if (availableConditions.contains(Suggestion.ElifStatement.text)) {
+                        add(Suggestion.ElifStatement)
+                    }
+
+                    if (availableConditions.contains(Suggestion.ElseStatement.text)) {
+                        add(Suggestion.ElseStatement)
+                    }
+                }
 
             isVariableSuggestionAvailable ->
-                listOf(Suggestion.Print, Suggestion.Variable, Suggestion.IfStatement)
+                buildList {
+                    add(Suggestion.Print)
+                    add(Suggestion.Variable)
+
+                    if (availableConditions.contains(Suggestion.IfStatement.text)) {
+                        add(Suggestion.IfStatement)
+                    }
+                }
 
             else ->
                 listOf(Suggestion.Print)
@@ -31,9 +50,14 @@ internal object StepQuizCodeBlanksResolver {
     fun areElifAndElseStatementsSuggestionsAvailable(
         index: Int,
         indentLevel: Int,
-        codeBlocks: List<CodeBlock>
+        codeBlocks: List<CodeBlock>,
+        availableConditions: Set<String>
     ): Boolean {
-        if (index < MINIMUM_POSSIBLE_INDEX_FOR_ELIF_AND_ELSE_STATEMENTS || codeBlocks.isEmpty()) {
+        if (
+            index < MINIMUM_POSSIBLE_INDEX_FOR_ELIF_AND_ELSE_STATEMENTS ||
+            codeBlocks.isEmpty() ||
+            availableConditions.isEmpty()
+        ) {
             return false
         }
 

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/presentation/StepQuizCodeBlanksStateExtensions.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz_code_blanks/presentation/StepQuizCodeBlanksStateExtensions.kt
@@ -13,6 +13,9 @@ internal val StepQuizCodeBlanksFeature.State.isVariableSuggestionsAvailable: Boo
         StepQuizCodeBlanksResolver.isVariableSuggestionsAvailable(it)
     } ?: false
 
+internal val StepQuizCodeBlanksFeature.State.Content.availableConditions: Set<String>
+    get() = step.block.options.codeBlanksAvailableConditions ?: emptySet()
+
 fun StepQuizCodeBlanksFeature.State.Content.createReply(): Reply =
     Reply.code(
         code = buildString {

--- a/shared/src/commonTest/kotlin/org/hyperskill/step_quiz_code_blanks/presentation/StepQuizCodeBlanksReducerElifAndElseStatementsSuggestionsAvailabilityTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/step_quiz_code_blanks/presentation/StepQuizCodeBlanksReducerElifAndElseStatementsSuggestionsAvailabilityTest.kt
@@ -7,12 +7,17 @@ import org.hyperskill.app.step_quiz_code_blanks.domain.model.CodeBlock
 import org.hyperskill.app.step_quiz_code_blanks.presentation.StepQuizCodeBlanksResolver
 
 class StepQuizCodeBlanksReducerElifAndElseStatementsSuggestionsAvailabilityTest {
+    companion object {
+        private val availableConditions = setOf("if", "elif", "else")
+    }
+
     @Test
     fun `Should return false if index is less than 2`() {
         val result = StepQuizCodeBlanksResolver.areElifAndElseStatementsSuggestionsAvailable(
             index = 1,
             indentLevel = 0,
-            codeBlocks = emptyList()
+            codeBlocks = emptyList(),
+            availableConditions = availableConditions
         )
         assertFalse(result)
     }
@@ -22,7 +27,23 @@ class StepQuizCodeBlanksReducerElifAndElseStatementsSuggestionsAvailabilityTest 
         val result = StepQuizCodeBlanksResolver.areElifAndElseStatementsSuggestionsAvailable(
             index = 2,
             indentLevel = 0,
-            codeBlocks = emptyList()
+            codeBlocks = emptyList(),
+            availableConditions = availableConditions
+        )
+        assertFalse(result)
+    }
+
+    @Test
+    fun `Should return false if availableConditions is empty`() {
+        val codeBlocks = listOf(
+            CodeBlock.IfStatement(indentLevel = 0, children = emptyList()),
+            CodeBlock.Print(indentLevel = 1, children = emptyList())
+        )
+        val result = StepQuizCodeBlanksResolver.areElifAndElseStatementsSuggestionsAvailable(
+            index = 2,
+            indentLevel = 0,
+            codeBlocks = codeBlocks,
+            availableConditions = emptySet()
         )
         assertFalse(result)
     }
@@ -36,7 +57,8 @@ class StepQuizCodeBlanksReducerElifAndElseStatementsSuggestionsAvailabilityTest 
         val result = StepQuizCodeBlanksResolver.areElifAndElseStatementsSuggestionsAvailable(
             index = 2,
             indentLevel = 1,
-            codeBlocks = codeBlocks
+            codeBlocks = codeBlocks,
+            availableConditions = availableConditions
         )
         assertFalse(result)
     }
@@ -50,7 +72,8 @@ class StepQuizCodeBlanksReducerElifAndElseStatementsSuggestionsAvailabilityTest 
         val result = StepQuizCodeBlanksResolver.areElifAndElseStatementsSuggestionsAvailable(
             index = 2,
             indentLevel = 0,
-            codeBlocks = codeBlocks
+            codeBlocks = codeBlocks,
+            availableConditions = availableConditions
         )
         assertTrue(result)
     }
@@ -66,7 +89,8 @@ class StepQuizCodeBlanksReducerElifAndElseStatementsSuggestionsAvailabilityTest 
         val result = StepQuizCodeBlanksResolver.areElifAndElseStatementsSuggestionsAvailable(
             index = 4,
             indentLevel = 1,
-            codeBlocks = codeBlocks
+            codeBlocks = codeBlocks,
+            availableConditions = availableConditions
         )
         assertTrue(result)
     }
@@ -82,7 +106,8 @@ class StepQuizCodeBlanksReducerElifAndElseStatementsSuggestionsAvailabilityTest 
         val result = StepQuizCodeBlanksResolver.areElifAndElseStatementsSuggestionsAvailable(
             index = 4,
             indentLevel = 0,
-            codeBlocks = codeBlocks
+            codeBlocks = codeBlocks,
+            availableConditions = availableConditions
         )
         assertTrue(result)
     }

--- a/shared/src/commonTest/kotlin/org/hyperskill/step_quiz_code_blanks/presentation/StepQuizCodeBlanksReducerInitializeTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/step_quiz_code_blanks/presentation/StepQuizCodeBlanksReducerInitializeTest.kt
@@ -15,28 +15,42 @@ class StepQuizCodeBlanksReducerInitializeTest {
     private val reducer = StepQuizCodeBlanksReducer.stub()
 
     @Test
-    fun `Initialize should return Content state with active Blank and Print and Variable and If suggestions`() {
-        val step = Step.stub(
-            id = 1,
-            block = Block.stub(options = Block.Options(codeBlanksVariables = listOf("a", "b")))
-        )
-
-        val message = StepQuizCodeBlanksFeature.InternalMessage.Initialize(step)
-        val (state, actions) = reducer.reduce(StepQuizCodeBlanksFeature.State.Idle, message)
-
-        val expectedState = StepQuizCodeBlanksFeature.State.Content(
-            step = step,
-            codeBlocks = listOf(
-                CodeBlock.Blank(
-                    isActive = true,
-                    suggestions = listOf(Suggestion.Print, Suggestion.Variable, Suggestion.IfStatement)
-                )
+    fun `Initialize should return Content state with active Blank and correct suggestions`() {
+        val blockOptions = listOf(
+            Block.Options(codeBlanksVariables = listOf("a", "b")),
+            Block.Options(
+                codeBlanksVariables = listOf("a", "b"),
+                codeBlanksAvailableConditions = setOf("if", "elif", "else")
             )
         )
+        val expectedSuggestions = listOf(
+            listOf(Suggestion.Print, Suggestion.Variable),
+            listOf(Suggestion.Print, Suggestion.Variable, Suggestion.IfStatement)
+        )
 
-        assertTrue(state is StepQuizCodeBlanksFeature.State.Content)
-        assertEquals(expectedState.codeBlocks, state.codeBlocks)
-        assertTrue(actions.isEmpty())
+        blockOptions.forEachIndexed { index, options ->
+            val step = Step.stub(
+                id = 1,
+                block = Block.stub(options = options)
+            )
+
+            val message = StepQuizCodeBlanksFeature.InternalMessage.Initialize(step)
+            val (state, actions) = reducer.reduce(StepQuizCodeBlanksFeature.State.Idle, message)
+
+            val expectedState = StepQuizCodeBlanksFeature.State.Content(
+                step = step,
+                codeBlocks = listOf(
+                    CodeBlock.Blank(
+                        isActive = true,
+                        suggestions = expectedSuggestions[index]
+                    )
+                )
+            )
+
+            assertTrue(state is StepQuizCodeBlanksFeature.State.Content)
+            assertEquals(expectedState.codeBlocks, state.codeBlocks)
+            assertTrue(actions.isEmpty())
+        }
     }
 
     @Test


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1346](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1346)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

- Adds support for `code_blanks_available_conditions` step block option