### PR TITLE
ALTAPPS-1350: iOS clarify reset necessity for users

### DIFF
--- a/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/fragment/DefaultStepQuizFragment.kt
+++ b/androidHyperskillApp/src/main/java/org/hyperskill/app/android/step_quiz/view/fragment/DefaultStepQuizFragment.kt
@@ -342,6 +342,9 @@ abstract class DefaultStepQuizFragment :
             StepQuizFeature.Action.ViewAction.UnhighlightCallToActionButton -> {
                 // no op
             }
+            StepQuizFeature.Action.ViewAction.BounceCallToActionButton -> {
+                // TODO: ALTAPPS-1349 Implement bounce animation
+            }
         }
     }
 

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -10,6 +10,7 @@
     <ID>ComplexCondition:GamificationToolbarReducer.kt$GamificationToolbarReducer$state is State.Idle || (message.forceUpdate &amp;&amp; (state is State.Content || state is State.Error))</ID>
     <ID>ComplexCondition:LeaderboardWidgetReducer.kt$LeaderboardWidgetReducer$state is State.Idle || (message.forceUpdate &amp;&amp; (state is State.Content || state is State.Error))</ID>
     <ID>ComplexCondition:ProfileReducer.kt$ProfileReducer$state is State.Idle || (message.forceUpdate &amp;&amp; (state is State.Content || state is State.Error))</ID>
+    <ID>ComplexCondition:StepQuizReducer.kt$StepQuizReducer$state.stepQuizState is StepQuizState.AttemptLoaded &amp;&amp; !StepQuizResolver.isQuizEnabled(state.stepQuizState) &amp;&amp; state.stepQuizState.submission?.status.isWrongOrRejected &amp;&amp; StepQuizResolver.isNeedRecreateAttemptForNewSubmission(state.stepQuizState.step)</ID>
     <ID>ComplexCondition:TopicsRepetitionsReducer.kt$TopicsRepetitionsReducer$state is State.Idle || (message.forceUpdate &amp;&amp; (state is State.Content || state is State.NetworkError))</ID>
     <ID>ComplexCondition:WelcomeReducer.kt$WelcomeReducer$state is State.Idle || (message.forceUpdate &amp;&amp; (state is State.Content || state is State.NetworkError))</ID>
     <ID>ComposableParamOrder:FindStage.kt$FindStage</ID>

--- a/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
+++ b/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
@@ -171,6 +171,8 @@
 		2C3796122877001700C197E2 /* ProfileHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3796112877001700C197E2 /* ProfileHeaderView.swift */; };
 		2C3B84E82C637AE100FE9D5C /* StepQuizCodeBlanksVariableInstructionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3B84E72C637AE100FE9D5C /* StepQuizCodeBlanksVariableInstructionView.swift */; };
 		2C3B90652CA65AA400FDA6CB /* View+OnTapWhenDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3B90642CA65AA400FDA6CB /* View+OnTapWhenDisabled.swift */; };
+		2C3B90692CA66ABE00FDA6CB /* BounceEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3B90682CA66ABE00FDA6CB /* BounceEffect.swift */; };
+		2C3B906B2CA6861400FDA6CB /* JiggleEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3B906A2CA6861400FDA6CB /* JiggleEffect.swift */; };
 		2C3CE3962C1073990011BECA /* StepToolbarContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3CE3952C1073990011BECA /* StepToolbarContent.swift */; };
 		2C3D92D42C857DAA00D271B7 /* StudyPlanWidgetViewStateSectionContentPageLoadingStateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3D92D32C857DAA00D271B7 /* StudyPlanWidgetViewStateSectionContentPageLoadingStateWrapper.swift */; };
 		2C3E656D2A12722800BC8DC0 /* TrackSelectionListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3E656C2A12722800BC8DC0 /* TrackSelectionListHeaderView.swift */; };
@@ -980,6 +982,8 @@
 		2C3796112877001700C197E2 /* ProfileHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileHeaderView.swift; sourceTree = "<group>"; };
 		2C3B84E72C637AE100FE9D5C /* StepQuizCodeBlanksVariableInstructionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizCodeBlanksVariableInstructionView.swift; sourceTree = "<group>"; };
 		2C3B90642CA65AA400FDA6CB /* View+OnTapWhenDisabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+OnTapWhenDisabled.swift"; sourceTree = "<group>"; };
+		2C3B90682CA66ABE00FDA6CB /* BounceEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BounceEffect.swift; sourceTree = "<group>"; };
+		2C3B906A2CA6861400FDA6CB /* JiggleEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JiggleEffect.swift; sourceTree = "<group>"; };
 		2C3CE3952C1073990011BECA /* StepToolbarContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepToolbarContent.swift; sourceTree = "<group>"; };
 		2C3D92D32C857DAA00D271B7 /* StudyPlanWidgetViewStateSectionContentPageLoadingStateWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyPlanWidgetViewStateSectionContentPageLoadingStateWrapper.swift; sourceTree = "<group>"; };
 		2C3E656C2A12722800BC8DC0 /* TrackSelectionListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSelectionListHeaderView.swift; sourceTree = "<group>"; };
@@ -2466,6 +2470,8 @@
 		2C4677962C75E7D7000EB2EE /* Effects */ = {
 			isa = PBXGroup;
 			children = (
+				2C3B90682CA66ABE00FDA6CB /* BounceEffect.swift */,
+				2C3B906A2CA6861400FDA6CB /* JiggleEffect.swift */,
 				2C4677942C75E7CA000EB2EE /* PulseEffect.swift */,
 				2CAF254B2AB9C2E500595582 /* ShineEffect.swift */,
 			);
@@ -5241,6 +5247,7 @@
 				2CD20ED12B73475400FB5269 /* ApplicationShortcutsService.swift in Sources */,
 				2C5F4A5A2971C71200677530 /* GamificationToolbarContent.swift in Sources */,
 				2C5B2A1F286595AF0097B270 /* CodeCompletionTableViewController.swift in Sources */,
+				2C3B906B2CA6861400FDA6CB /* JiggleEffect.swift in Sources */,
 				2CE0F6EE2BB40B760032C439 /* StepFeedbackViewModel.swift in Sources */,
 				2CCCA3A12862E62F00D98089 /* StepQuizStringViewData.swift in Sources */,
 				2C1061A2285C349400EBD614 /* StepQuizChildQuizAssembly.swift in Sources */,
@@ -5557,6 +5564,7 @@
 				2C0EB9502A151B56006DC84B /* TrackSelectionListViewModel.swift in Sources */,
 				E9ACD3412937342F0005E05B /* ProblemOfDaySolvedModalViewController.swift in Sources */,
 				2C0EB9562A15296D006DC84B /* TrackSelectionListFeatureViewStateContent+Placeholder.swift in Sources */,
+				2C3B90692CA66ABE00FDA6CB /* BounceEffect.swift in Sources */,
 				2CB0AE002B0525020089D557 /* ChallengeWidgetContentStateDescriptionView.swift in Sources */,
 				2CE58C5A2B07662300E5EBBE /* ChallengeWidgetContentStateProgressGridView.swift in Sources */,
 				E9D537D22A71330A00F21828 /* LinearGradientProgressView.swift in Sources */,

--- a/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
+++ b/iosHyperskillApp/iosHyperskillApp.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		2C37960F2876F36F00C197E2 /* ProfileViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C37960E2876F36F00C197E2 /* ProfileViewData.swift */; };
 		2C3796122877001700C197E2 /* ProfileHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3796112877001700C197E2 /* ProfileHeaderView.swift */; };
 		2C3B84E82C637AE100FE9D5C /* StepQuizCodeBlanksVariableInstructionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3B84E72C637AE100FE9D5C /* StepQuizCodeBlanksVariableInstructionView.swift */; };
+		2C3B90652CA65AA400FDA6CB /* View+OnTapWhenDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3B90642CA65AA400FDA6CB /* View+OnTapWhenDisabled.swift */; };
 		2C3CE3962C1073990011BECA /* StepToolbarContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3CE3952C1073990011BECA /* StepToolbarContent.swift */; };
 		2C3D92D42C857DAA00D271B7 /* StudyPlanWidgetViewStateSectionContentPageLoadingStateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3D92D32C857DAA00D271B7 /* StudyPlanWidgetViewStateSectionContentPageLoadingStateWrapper.swift */; };
 		2C3E656D2A12722800BC8DC0 /* TrackSelectionListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3E656C2A12722800BC8DC0 /* TrackSelectionListHeaderView.swift */; };
@@ -978,6 +979,7 @@
 		2C37960E2876F36F00C197E2 /* ProfileViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewData.swift; sourceTree = "<group>"; };
 		2C3796112877001700C197E2 /* ProfileHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileHeaderView.swift; sourceTree = "<group>"; };
 		2C3B84E72C637AE100FE9D5C /* StepQuizCodeBlanksVariableInstructionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepQuizCodeBlanksVariableInstructionView.swift; sourceTree = "<group>"; };
+		2C3B90642CA65AA400FDA6CB /* View+OnTapWhenDisabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+OnTapWhenDisabled.swift"; sourceTree = "<group>"; };
 		2C3CE3952C1073990011BECA /* StepToolbarContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepToolbarContent.swift; sourceTree = "<group>"; };
 		2C3D92D32C857DAA00D271B7 /* StudyPlanWidgetViewStateSectionContentPageLoadingStateWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyPlanWidgetViewStateSectionContentPageLoadingStateWrapper.swift; sourceTree = "<group>"; };
 		2C3E656C2A12722800BC8DC0 /* TrackSelectionListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSelectionListHeaderView.swift; sourceTree = "<group>"; };
@@ -2226,6 +2228,7 @@
 				2C177EC22837B65500D841DB /* View+Frame.swift */,
 				2CF34F9A2C34079C0054477E /* View+ListRowSeparator.swift */,
 				E9FAF38E299F61AE001FC596 /* View+MeasureSize.swift */,
+				2C3B90642CA65AA400FDA6CB /* View+OnTapWhenDisabled.swift */,
 				2CD4EDF82B79D51E0091F0B2 /* View+SafeAreaInset.swift */,
 				2C4605B02ABD75FC003C17E9 /* View+ScrollBounceBehavior.swift */,
 				2C7271232B6B634F005628B0 /* View+Task.swift */,
@@ -5124,6 +5127,7 @@
 				E94D238F280585110003273F /* AuthCredentialsFormView.swift in Sources */,
 				2C5CBBE52948FA7400113007 /* StepQuizSQLAssembly.swift in Sources */,
 				2C54E4222A1F6672003406B9 /* TrackSelectionDetailsFeatureViewStateKsExtensions.swift in Sources */,
+				2C3B90652CA65AA400FDA6CB /* View+OnTapWhenDisabled.swift in Sources */,
 				2CEEE03528916A6800282849 /* ProblemOfDayOutputProtocol.swift in Sources */,
 				2C66720B2A52974A0040EA2F /* ProgressScreenSectionTitleSkeletonView.swift in Sources */,
 				2C0EB9542A151C2B006DC84B /* TrackSelectionListFeatureViewStateKsExtensions.swift in Sources */,

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Extensions/SwiftUI/View/View+OnTapWhenDisabled.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Extensions/SwiftUI/View/View+OnTapWhenDisabled.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func onTapWhenDisabled(isDisabled: Bool, action: @escaping () -> Void) -> some View {
+        if isDisabled {
+            self.overlay(
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: action)
+            )
+        } else {
+            self
+        }
+    }
+}
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+    @Previewable @State var isButtonDisabled = true
+
+    VStack {
+        Button(
+            action: {
+                print("Button tapped!")
+            },
+            label: {
+                Text("Submit")
+                    .padding()
+                    .background(isButtonDisabled ? Color.gray : Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(8)
+            }
+        )
+        .disabled(isButtonDisabled)
+        .onTapWhenDisabled(isDisabled: isButtonDisabled) {
+            print("Button is disabled!")
+        }
+
+        Toggle("Disable View", isOn: $isButtonDisabled)
+            .padding()
+    }
+}
+#endif

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/StepQuizViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/StepQuizViewModel.swift
@@ -134,6 +134,10 @@ final class StepQuizViewModel: FeatureViewModel<
         moduleOutput?.stepQuizDidRequestSkipStep()
     }
 
+    func doChildQuizClickedWhenDisabledAction() {
+        onNewMessage(StepQuizFeatureMessageChildQuizClickedWhenDisabled())
+    }
+
     func doUnsupportedQuizSolveOnTheWebAction() {
         onNewMessage(StepQuizFeatureMessageUnsupportedQuizSolveOnTheWebClicked())
     }

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/Views/StepQuizActionButtons/StepQuizActionButtons.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/Views/StepQuizActionButtons/StepQuizActionButtons.swift
@@ -14,6 +14,7 @@ struct StepQuizActionButtons: View {
                 StepQuizRetryButton(
                     appearance: retryButton.appearance,
                     style: retryButton.style,
+                    isBounceEffectActive: retryButton.isBounceEffectActive,
                     onTap: retryButton.action
                 )
             }
@@ -44,6 +45,8 @@ struct StepQuizActionButtons: View {
         var appearance = StepQuizRetryButton.Appearance()
 
         var style: StepQuizRetryButton.Style = .logoOnly
+
+        var isBounceEffectActive = false
 
         let action: () -> Void
     }
@@ -103,8 +106,17 @@ extension StepQuizActionButtons {
         )
     }
 
-    static func retry(action: @escaping () -> Void) -> StepQuizActionButtons {
-        StepQuizActionButtons(retryButton: .init(style: .roundedRectangle, action: action))
+    static func retry(
+        isBounceEffectActive: Bool,
+        action: @escaping () -> Void
+    ) -> StepQuizActionButtons {
+        StepQuizActionButtons(
+            retryButton: .init(
+                style: .roundedRectangle,
+                isBounceEffectActive: isBounceEffectActive,
+                action: action
+            )
+        )
     }
 
     static func `continue`(isLoading: Bool, action: @escaping () -> Void) -> StepQuizActionButtons {
@@ -168,7 +180,7 @@ struct StepQuizActionButtons_Previews: PreviewProvider {
                 action: {}
             )
 
-            StepQuizActionButtons.retry {}
+            StepQuizActionButtons.retry(isBounceEffectActive: false) {}
 
             StepQuizActionButtons.continue(isLoading: false) {}
             StepQuizActionButtons.continue(isLoading: true) {}

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/Views/StepQuizActionButtons/StepQuizRetryButton.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuiz/Views/StepQuizActionButtons/StepQuizRetryButton.swift
@@ -18,6 +18,8 @@ struct StepQuizRetryButton: View {
 
     var style: Style
 
+    let isBounceEffectActive: Bool
+
     var onTap: () -> Void
 
     @Environment(\.isEnabled) private var isEnabled
@@ -45,6 +47,7 @@ struct StepQuizRetryButton: View {
                 action: onTap
             )
             .buttonStyle(RoundedRectangleButtonStyle(style: .violet))
+            .bounceEffect(isActive: isBounceEffectActive && isEnabled)
         }
     }
 
@@ -58,15 +61,15 @@ struct StepQuizRetryButton_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             HStack {
-                StepQuizRetryButton(style: .logoOnly, onTap: {})
+                StepQuizRetryButton(style: .logoOnly, isBounceEffectActive: false, onTap: {})
 
-                StepQuizRetryButton(style: .logoOnly, onTap: {})
+                StepQuizRetryButton(style: .logoOnly, isBounceEffectActive: true, onTap: {})
                     .disabled(true)
             }
 
-            StepQuizRetryButton(style: .roundedRectangle, onTap: {})
+            StepQuizRetryButton(style: .roundedRectangle, isBounceEffectActive: false, onTap: {})
 
-            StepQuizRetryButton(style: .roundedRectangle, onTap: {})
+            StepQuizRetryButton(style: .roundedRectangle, isBounceEffectActive: true, onTap: {})
                 .disabled(true)
         }
         .previewLayout(.sizeThatFits)

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Views/SwiftUI/Effects/BounceEffect.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Views/SwiftUI/Effects/BounceEffect.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+private struct BounceEffectViewModifier: ViewModifier {
+    @State private var isBouncing = false
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(isBouncing ? 0.95 : 1)
+            .animation(
+                .easeInOut(duration: 0.15)
+                .repeatForever(autoreverses: true)
+                .delay(0.33),
+                value: isBouncing
+            )
+            .onAppear {
+                isBouncing = true
+            }
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func bounceEffect(isActive: Bool = true) -> some View {
+        if isActive {
+            modifier(BounceEffectViewModifier())
+        } else {
+            self
+        }
+    }
+}
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+    @Previewable @State var isBouncing = false
+
+    Button {
+        isBouncing.toggle()
+    } label: {
+        Text("Retry")
+    }
+    .buttonStyle(RoundedRectangleButtonStyle(style: .violet))
+    .bounceEffect(isActive: isBouncing)
+    .padding()
+}
+#endif

--- a/iosHyperskillApp/iosHyperskillApp/Sources/Views/SwiftUI/Effects/JiggleEffect.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Views/SwiftUI/Effects/JiggleEffect.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+private struct JiggleEffectViewModifier: ViewModifier {
+    let amount: Double
+
+    @State private var isJiggling = false
+
+    func body(content: Content) -> some View {
+        content
+            .rotationEffect(.degrees(isJiggling ? amount : 0))
+            .animation(
+                .easeInOut(duration: randomize(interval: 0.14, withVariance: 0.025))
+                .repeatForever(autoreverses: true),
+                value: isJiggling
+            )
+            .animation(
+                .easeInOut(duration: randomize(interval: 0.18, withVariance: 0.025))
+                .repeatForever(autoreverses: true),
+                value: isJiggling
+            )
+            .onAppear {
+                isJiggling.toggle()
+            }
+    }
+
+    private func randomize(interval: TimeInterval, withVariance variance: Double) -> TimeInterval {
+        interval + variance * (Double.random(in: 500...1_000) / 500)
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func jiggleEffect(amount: Double = 2, isActive: Bool = true) -> some View {
+        if isActive {
+            modifier(JiggleEffectViewModifier(amount: amount))
+        } else {
+            self
+        }
+    }
+}
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview {
+    @Previewable @State var isJiggling = false
+
+    Button {
+        isJiggling.toggle()
+    } label: {
+        Text("Retry")
+    }
+    .buttonStyle(RoundedRectangleButtonStyle(style: .violet))
+    .jiggleEffect(amount: 2, isActive: isJiggling)
+    .padding()
+}
+#endif

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizFeature.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizFeature.kt
@@ -119,6 +119,11 @@ object StepQuizFeature {
         data object UnsupportedQuizGoToStudyPlanClicked : Message
 
         /**
+         * Click on child quiz UI when it's disabled
+         */
+        data object ChildQuizClickedWhenDisabled : Message
+
+        /**
          * Analytic
          */
         data object ClickedCodeDetailsEventMessage : Message
@@ -246,6 +251,8 @@ object StepQuizFeature {
              */
             data object HighlightCallToActionButton : ViewAction
             data object UnhighlightCallToActionButton : ViewAction
+
+            data object BounceCallToActionButton : ViewAction
 
             sealed interface ScrollTo : ViewAction {
                 data object Hints : ScrollTo

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizReducer.kt
@@ -686,7 +686,9 @@ internal class StepQuizReducer(
 
     private fun handleChildQuizClickedWhenDisabled(state: State): StepQuizReducerResult? =
         if (state.stepQuizState is StepQuizState.AttemptLoaded &&
-            !StepQuizResolver.isQuizEnabled(state.stepQuizState)
+            !StepQuizResolver.isQuizEnabled(state.stepQuizState) &&
+            state.stepQuizState.submission?.status.isWrongOrRejected &&
+            StepQuizResolver.isNeedRecreateAttemptForNewSubmission(state.stepQuizState.step)
         ) {
             state to setOf(
                 Action.ViewAction.ScrollTo.CallToActionButton,

--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizReducer.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizReducer.kt
@@ -170,6 +170,8 @@ internal class StepQuizReducer(
                 handleReadCommentsClicked(state)
             is Message.SkipClicked ->
                 handleSkipClicked(state)
+            Message.ChildQuizClickedWhenDisabled ->
+                handleChildQuizClickedWhenDisabled(state)
             is Message.ClickedCodeDetailsEventMessage ->
                 if (state.stepQuizState is StepQuizState.AttemptLoaded) {
                     val event = StepQuizClickedCodeDetailsHyperskillAnalyticEvent(stepRoute.analyticRoute)
@@ -681,4 +683,16 @@ internal class StepQuizReducer(
             ),
             Action.ViewAction.RequestSkipStep
         )
+
+    private fun handleChildQuizClickedWhenDisabled(state: State): StepQuizReducerResult? =
+        if (state.stepQuizState is StepQuizState.AttemptLoaded &&
+            !StepQuizResolver.isQuizEnabled(state.stepQuizState)
+        ) {
+            state to setOf(
+                Action.ViewAction.ScrollTo.CallToActionButton,
+                Action.ViewAction.BounceCallToActionButton
+            )
+        } else {
+            null
+        }
 }

--- a/shared/src/commonTest/kotlin/org/hyperskill/step_quiz/StepQuizTest.kt
+++ b/shared/src/commonTest/kotlin/org/hyperskill/step_quiz/StepQuizTest.kt
@@ -11,6 +11,7 @@ import org.hyperskill.app.onboarding.domain.model.ProblemsOnboardingFlags
 import org.hyperskill.app.problems_limit_info.domain.model.ProblemsLimitInfoModalContext
 import org.hyperskill.app.problems_limit_info.domain.model.ProblemsLimitInfoModalLaunchSource
 import org.hyperskill.app.step.domain.model.Block
+import org.hyperskill.app.step.domain.model.BlockName
 import org.hyperskill.app.step.domain.model.Step
 import org.hyperskill.app.step.domain.model.StepRoute
 import org.hyperskill.app.step_quiz.domain.analytic.StepQuizClickedTheoryToolbarItemHyperskillAnalyticEvent
@@ -966,5 +967,72 @@ class StepQuizTest {
                 )
             )
         )
+    }
+
+    @Test
+    fun `handleChildQuizClickedWhenDisabled should scroll and bounce call-to-action button when quiz is disabled`() {
+        val step = Step.stub(id = 1, block = Block.stub(name = BlockName.CHOICE))
+        val stepRoute = StepRoute.Learn.Step(step.id, null)
+
+        val initialState = StepQuizFeature.State(
+            stepQuizState = StepQuizFeature.StepQuizState.AttemptLoaded(
+                step = step,
+                attempt = Attempt.stub(),
+                submissionState = StepQuizFeature.SubmissionState.Loaded(
+                    Submission.stub(status = SubmissionStatus.WRONG)
+                ),
+                isProblemsLimitReached = false,
+                isTheoryAvailable = false
+            ),
+            stepQuizHintsState = StepQuizHintsFeature.State.Idle,
+            stepQuizToolbarState = StepQuizToolbarFeature.initialState(stepRoute),
+            stepQuizCodeBlanksState = StepQuizCodeBlanksFeature.initialState()
+        )
+
+        val reducer = StepQuizReducer(
+            stepRoute = stepRoute,
+            stepQuizChildFeatureReducer = StepQuizChildFeatureReducer.stub(stepRoute)
+        )
+
+        val (_, actions) = reducer.reduce(initialState, StepQuizFeature.Message.ChildQuizClickedWhenDisabled)
+
+        assertContains(
+            actions,
+            StepQuizFeature.Action.ViewAction.ScrollTo.CallToActionButton
+        )
+        assertContains(
+            actions,
+            StepQuizFeature.Action.ViewAction.BounceCallToActionButton
+        )
+    }
+
+    /* ktlint-disable */
+    @Test
+    fun `handleChildQuizClickedWhenDisabled should not scroll and bounce call-to-action button when quiz is disabled`() {
+        val step = Step.stub(id = 1, block = Block.stub(name = BlockName.CODE))
+        val stepRoute = StepRoute.Learn.Step(step.id, null)
+
+        val initialState = StepQuizFeature.State(
+            stepQuizState = StepQuizFeature.StepQuizState.AttemptLoaded(
+                step = step,
+                attempt = Attempt.stub(),
+                submissionState = StepQuizFeature.SubmissionState.Loaded(
+                    Submission.stub(status = SubmissionStatus.WRONG)
+                ),
+                isProblemsLimitReached = false,
+                isTheoryAvailable = false
+            ),
+            stepQuizHintsState = StepQuizHintsFeature.State.Idle,
+            stepQuizToolbarState = StepQuizToolbarFeature.initialState(stepRoute),
+            stepQuizCodeBlanksState = StepQuizCodeBlanksFeature.initialState()
+        )
+
+        val reducer = StepQuizReducer(
+            stepRoute = stepRoute,
+            stepQuizChildFeatureReducer = StepQuizChildFeatureReducer.stub(stepRoute)
+        )
+
+        val (_, actions) = reducer.reduce(initialState, StepQuizFeature.Message.ChildQuizClickedWhenDisabled)
+        assertTrue(actions.isEmpty())
     }
 }


### PR DESCRIPTION
**YouTrack Issues**:
[#ALTAPPS-1350](https://vyahhi.myjetbrains.com/youtrack/issue/ALTAPPS-1350)

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

- Adds a bouncing animation to the retry button when the user taps on the quiz UI while it is disabled