### PR TITLE
Update privacy policy URLs

### DIFF
--- a/iosHyperskillApp/fastlane/metadata/en-US/privacy_url.txt
+++ b/iosHyperskillApp/fastlane/metadata/en-US/privacy_url.txt
@@ -1,1 +1,1 @@
-https://hi.hyperskill.org/terms
+https://hyperskill.org/terms

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -335,7 +335,7 @@
     <string name="settings_account_deletion_dialog_explanation">Your account on Hyperskill (JetBrains Academy) will be deleted. You will no longer be able to use this account both in the app and on the website.</string>
     <string name="settings_account_deletion_dialog_delete_button_text">Delete</string>
     <string name="settings_terms_of_service_url">https://www.jetbrains.com/legal/terms/jetbrains-academy.html</string>
-    <string name="settings_privacy_policy_url">https://hi.hyperskill.org/terms</string>
+    <string name="settings_privacy_policy_url">https://hyperskill.org/terms</string>
     <string name="settings_report_problem_url">https://support.hyperskill.org/hc/en-us/requests/new</string>
     <string name="settings_rate_in_app_store">Rate us in the App Store</string>
     <string name="settings_rate_in_app_store_url">https://apps.apple.com/app/id1637230833?action=write-review</string>
@@ -711,7 +711,7 @@
     <string name="paywall_pending_purchase">Paid functionality will become available after success payment</string>
     <string name="paywall_subscription_sync_description">The app is updating. Please wait a moment.</string>
     <string name="paywall_tos_and_privacy_bth">Hyperskill Terms of Service and Privacy Policy</string>
-    <string name="paywall_tos_and_privacy_url">https://hi.hyperskill.org/terms</string>
+    <string name="paywall_tos_and_privacy_url">https://hyperskill.org/terms</string>
     <string name="paywall_subscription_duration_monthly">Monthly</string>
     <string name="paywall_subscription_duration_annual">Annual %s</string>
     <string name="paywall_subscription_month_price">%s / month</string>


### PR DESCRIPTION
**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**
Resolves #1206

This pull request includes updates to URLs for the privacy policy across several files to ensure consistency and correctness.

URL updates:

* [`iosHyperskillApp/fastlane/metadata/en-US/privacy_url.txt`](diffhunk://#diff-4cb19512a8760b5a1614269202362da29045ca3b615e25a4f88970ed10dea50eL1-R1): Updated the privacy policy URL to `https://hyperskill.org/terms` from the old URL.
* [`shared/src/commonMain/moko-resources/base/strings.xml`](diffhunk://#diff-a5d29234576a56f04e85e7bf159fdf7a31bb65562c058ff638df3dcf049859f5L338-R338): Updated the `settings_privacy_policy_url` and `paywall_tos_and_privacy_url` to the new URL `https://hyperskill.org/terms` for consistency. [[1]](diffhunk://#diff-a5d29234576a56f04e85e7bf159fdf7a31bb65562c058ff638df3dcf049859f5L338-R338) [[2]](diffhunk://#diff-a5d29234576a56f04e85e7bf159fdf7a31bb65562c058ff638df3dcf049859f5L714-R714)