### PR TITLE
Shared: Fix incorrect share_streak_sharing_url

### DIFF
--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -620,7 +620,7 @@
     <string name="share_streak_modal_share_button_text">Share</string>
     <string name="share_streak_modal_no_thanks_button_text">No, thanks</string>
     <string name="share_streak_sharing_text">Hyperskill – Level up your coding skills!</string>
-    <string name="share_streak_sharing_url">https://hi.hyperskill.org/my-hyperskill-app</string>
+    <string name="share_streak_sharing_url">https://hyperskill.org/my-hyperskill-app</string>
 
     <!-- Challenge widget -->
     <string name="challenge_widget_status_not_started_title">Get ready to push your limits!</string>


### PR DESCRIPTION
**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

Resolves #1208 

This pull request includes a minor update to the `shared/src/commonMain/moko-resources/base/strings.xml` file. The change updates the URL used for sharing a streak in the Hyperskill app.

* [`shared/src/commonMain/moko-resources/base/strings.xml`](diffhunk://#diff-a5d29234576a56f04e85e7bf159fdf7a31bb65562c058ff638df3dcf049859f5L623-R623): Updated the `share_streak_sharing_url` string to use the correct Hyperskill URL.