### PR TITLE
iOS: Specify LSMinimumSystemVersion value of 12.0

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Info.plist
+++ b/iosHyperskillApp/iosHyperskillApp/Info.plist
@@ -41,6 +41,8 @@
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSMinimumSystemVersion</key>
+	<string>12.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

Resolves #1210 

This pull request includes a small but important change to the `Info.plist` file for the iOS Hyperskill app. The change ensures that the app specifies a minimum system version requirement.

* [`iosHyperskillApp/iosHyperskillApp/Info.plist`](diffhunk://#diff-5f27f7839eefb94696173dfe041a93fd756db5bc180f577cd63030e10c334d21R44-R45): Added the `LSMinimumSystemVersion` key with a value of `12.0` to specify the minimum required iOS version for the app.