### PR TITLE
GitHub Actions:  Upgrade GitHub Runner Image from ubuntu-22.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/android_beta_deployment.yml
+++ b/.github/workflows/android_beta_deployment.yml
@@ -22,7 +22,7 @@ jobs:
     needs: files-changed
     if: ${{ needs.files-changed.outputs.android == 'true' || needs.files-changed.outputs.shared == 'true' }}
     name: Gradle Wrapper Validation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.1
@@ -41,7 +41,7 @@ jobs:
   google-play-deployment:
     name: Deploy to Google Play
     needs: gradle-wrapper-validation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: android_production
     timeout-minutes: 60
 

--- a/.github/workflows/android_deploy_to_firebase.yml
+++ b/.github/workflows/android_deploy_to_firebase.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: android_production
     timeout-minutes: 30
 

--- a/.github/workflows/android_deploy_to_firebase_manually.yml
+++ b/.github/workflows/android_deploy_to_firebase_manually.yml
@@ -11,7 +11,7 @@ jobs:
   # Run Gradle Wrapper Validation Action to verify the wrapper's checksum
   gradle-wrapper-validation:
     name: Gradle Wrapper Validation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.1

--- a/.github/workflows/android_release_deployment.yml
+++ b/.github/workflows/android_release_deployment.yml
@@ -21,7 +21,7 @@ jobs:
   gradle-wrapper-validation:
     # if: ${{ github.ref == 'refs/heads/main' }}
     name: Gradle Wrapper Validation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.1
@@ -33,7 +33,7 @@ jobs:
   deployment:
     name: Android Release Deployment
     needs: gradle-wrapper-validation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: android_production
     timeout-minutes: 60
 

--- a/.github/workflows/auto_author_assign.yml
+++ b/.github/workflows/auto_author_assign.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   assign-author:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.assignee }}
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.1

--- a/.github/workflows/build_caches.yml
+++ b/.github/workflows/build_caches.yml
@@ -28,7 +28,7 @@ jobs:
     needs: files-changed
     if: ${{ github.event_name == 'workflow_dispatch' || needs.files-changed.outputs.android == 'true' }}
     name: Build Android Caches
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ defaults:
 jobs:
   gradle-wrapper-validation:
     name: Gradle Wrapper Validation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout
@@ -59,7 +59,7 @@ jobs:
     needs: files-changed
     if: ${{ needs.files-changed.outputs.android == 'true' || needs.files-changed.outputs.shared == 'true' }}
     name: Run ktlint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -86,7 +86,7 @@ jobs:
     needs: files-changed
     if: ${{ needs.files-changed.outputs.android == 'true' || needs.files-changed.outputs.shared == 'true' }}
     name: Run detekt
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -146,7 +146,7 @@ jobs:
     needs: [files-changed, ktlint, detekt]
     if: ${{ needs.files-changed.outputs.shared == 'true' }}
     name: Run shared unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
@@ -170,7 +170,7 @@ jobs:
     needs: [files-changed, ktlint, detekt]
     if: ${{ needs.files-changed.outputs.android == 'true' || needs.files-changed.outputs.shared == 'true' }}
     name: Run Android unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/cleanup_pr_caches.yml
+++ b/.github/workflows/cleanup_pr_caches.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/detect_changed_files_reusable_workflow.yml
+++ b/.github/workflows/detect_changed_files_reusable_workflow.yml
@@ -41,7 +41,7 @@ on:
 
 jobs:
   files-changed:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     # Map a step output to a job output
     outputs:

--- a/.github/workflows/gh_pages_analytics.yml
+++ b/.github/workflows/gh_pages_analytics.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     needs: files-changed
     if: ${{ inputs.force_build || needs.files-changed.outputs.analytic == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -59,7 +59,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     environment:

--- a/.github/workflows/gpt_review.yml
+++ b/.github/workflows/gpt_review.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   code-review:
     if: ${{ contains(github.event.*.labels.*.name, 'gpt-review') }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: anc95/ChatGPT-CodeReview@main

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -4,7 +4,7 @@ on: [pull_request_target, issues]
 
 jobs:
   greeting:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/ios_beta_deployment.yml
+++ b/.github/workflows/ios_beta_deployment.yml
@@ -22,7 +22,7 @@ jobs:
     needs: files-changed
     if: ${{ needs.files-changed.outputs.ios == 'true' || needs.files-changed.outputs.shared == 'true' }}
     name: Gradle Wrapper Validation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.1

--- a/.github/workflows/ios_release_deployment.yml
+++ b/.github/workflows/ios_release_deployment.yml
@@ -18,7 +18,7 @@ jobs:
   # Run Gradle Wrapper Validation Action to verify the wrapper's checksum
   gradle-wrapper-validation:
     name: Gradle Wrapper Validation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.1

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   label:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/merge_main_into_develop.yml
+++ b/.github/workflows/merge_main_into_develop.yml
@@ -19,7 +19,7 @@ defaults:
 jobs:
   merge:
     name: Git Merge
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
Resolves #1212 

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

This pull request updates the GitHub Actions workflows to use the latest Ubuntu runner version. The changes ensure that all workflows are running on `ubuntu-latest` instead of the previously specified `ubuntu-22.04`.

Updates to GitHub Actions workflows:

* [`.github/workflows/android_beta_deployment.yml`](diffhunk://#diff-191b109092f50bcc9872a21bacf3e6e51a33b15f3c83ed9861c8b617a3a0345eL25-R25): Updated `runs-on` to `ubuntu-latest` for `Gradle Wrapper Validation` and `Deploy to Google Play` jobs. [[1]](diffhunk://#diff-191b109092f50bcc9872a21bacf3e6e51a33b15f3c83ed9861c8b617a3a0345eL25-R25) [[2]](diffhunk://#diff-191b109092f50bcc9872a21bacf3e6e51a33b15f3c83ed9861c8b617a3a0345eL44-R44)
* [`.github/workflows/android_deploy_to_firebase.yml`](diffhunk://#diff-921dc10318dd27ce10a2e4f99c0248b825a73e0a602efb97a7678d74aa9458a8L8-R8): Updated `runs-on` to `ubuntu-latest` for the `deploy` job.
* [`.github/workflows/android_deploy_to_firebase_manually.yml`](diffhunk://#diff-867cef0020c1fc5c201af434126e7fdea74af4a1b0ba492e7b8ce2ed701d89adL14-R14): Updated `runs-on` to `ubuntu-latest` for `Gradle Wrapper Validation` job.
* [`.github/workflows/android_release_deployment.yml`](diffhunk://#diff-dde87400a43e31d9ba545417aa4aa4baf3fe85d939e79f84e0c21d0db54ae38cL24-R24): Updated `runs-on` to `ubuntu-latest` for `Gradle Wrapper Validation` and `Android Release Deployment` jobs. [[1]](diffhunk://#diff-dde87400a43e31d9ba545417aa4aa4baf3fe85d939e79f84e0c21d0db54ae38cL24-R24) [[2]](diffhunk://#diff-dde87400a43e31d9ba545417aa4aa4baf3fe85d939e79f84e0c21d0db54ae38cL36-R36)
* [`.github/workflows/auto_author_assign.yml`](diffhunk://#diff-5be3b631cfa10c0186109923b656c858d148229a8bec91f28cf5cf19619bafc7L12-R12): Updated `runs-on` to `ubuntu-latest` for the `assign-author` job.
* [`.github/workflows/build_caches.yml`](diffhunk://#diff-eb09b8475445cede97c558be36e635baf9b10b82843e71c69fb2082cded089f2L31-R31): Updated `runs-on` to `ubuntu-latest` for the `Build Android Caches` job.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL40-R40): Updated `runs-on` to `ubuntu-latest` for multiple jobs including `Gradle Wrapper Validation`, `Run ktlint`, `Run detekt`, `Run shared unit tests`, and `Run Android unit tests`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL40-R40) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL62-R62) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL89-R89) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL149-R149) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL173-R173)
* [`.github/workflows/cleanup_pr_caches.yml`](diffhunk://#diff-805e193d0e8d877bfc6b7135f5ec3744dd7bf7d1b745e3e9f366d9c6ea7d8a21L11-R11): Updated `runs-on` to `ubuntu-latest` for the `cleanup` job.
* [`.github/workflows/detect_changed_files_reusable_workflow.yml`](diffhunk://#diff-4f668be81a9c5128d6351c2d19048bc7b070170c72f72ce165ef44cad8211fdcL44-R44): Updated `runs-on` to `ubuntu-latest` for the `files-changed` job.
* [`.github/workflows/gh_pages_analytics.yml`](diffhunk://#diff-c69c80430efa850887ebe4fc1321e1fd5b8ec9ef466910b4579278ea4e3d0bfbL35-R35): Updated `runs-on` to `ubuntu-latest` for `build` and `deploy` jobs. [[1]](diffhunk://#diff-c69c80430efa850887ebe4fc1321e1fd5b8ec9ef466910b4579278ea4e3d0bfbL35-R35) [[2]](diffhunk://#diff-c69c80430efa850887ebe4fc1321e1fd5b8ec9ef466910b4579278ea4e3d0bfbL62-R62)
* [`.github/workflows/gpt_review.yml`](diffhunk://#diff-5876d537b8bb194f867adef79e17bdd9f53a5b187408554370213710ce818131L18-R18): Updated `runs-on` to `ubuntu-latest` for the `code-review` job.
* [`.github/workflows/greetings.yml`](diffhunk://#diff-6318f5fc1ff2829ebbfd7846021a98d807a3b866fcfac669187f49fa22a40702L7-R7): Updated `runs-on` to `ubuntu-latest` for the `greeting` job.
* [`.github/workflows/ios_beta_deployment.yml`](diffhunk://#diff-d6a582d076d812e36427d3ac8ef74b42fa20625d1d7fa8f56cee1752d954735dL25-R25): Updated `runs-on` to `ubuntu-latest` for `Gradle Wrapper Validation` job.
* [`.github/workflows/ios_release_deployment.yml`](diffhunk://#diff-251785566962690238a59f123fccc496eb24ed66823b4f1597185ea2fd2ac346L21-R21): Updated `runs-on` to `ubuntu-latest` for `Gradle Wrapper Validation` job.
* [`.github/workflows/label.yml`](diffhunk://#diff-10c0cd6a4f95e78dd4975968a27901c644f6e36a8a75147e3fb86d08e1c1831bL7-R7): Updated `runs-on` to `ubuntu-latest` for the `label` job.
* [`.github/workflows/merge_main_into_develop.yml`](diffhunk://#diff-af8f47e829de3ac23d33f44fa20d09ce88b420728347984818d1cf84386a7e5bL22-R22): Updated `runs-on` to `ubuntu-latest` for the `merge` job.
* [`.github/workflows/stale.yml`](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894L10-R10): Updated `runs-on` to `ubuntu-latest` for the `stale` job.