### PR TITLE
GitHub Actions: Upload iOS app error log on CI build failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,25 +3,25 @@ name: CI
 on:
   push:
     branches:
-      - '**'
-      - '!main'
-      - '!develop'
-      - '!hotfix/**'
-      - '!release/**'
+      - "**"
+      - "!main"
+      - "!develop"
+      - "!hotfix/**"
+      - "!release/**"
   workflow_dispatch:
     inputs:
       force_android:
-        description: 'Force Android'
+        description: "Force Android"
         required: false
         default: false
         type: boolean
       force_shared:
-        description: 'Force shared'
+        description: "Force shared"
         required: false
         default: false
         type: boolean
       force_ios:
-        description: 'Force iOS'
+        description: "Force iOS"
         required: false
         default: false
         type: boolean
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.1
-        
+
       - name: Gradle Wrapper Validation
         uses: gradle/actions/wrapper-validation@v4
 
@@ -63,24 +63,24 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4.2.1
+      - name: Checkout
+        uses: actions/checkout@v4.2.1
 
-    - name: Setup CI
-      uses: ./.github/actions/setup-android
+      - name: Setup CI
+        uses: ./.github/actions/setup-android
 
-    - name: Run ktlint
-      run: ./gradlew setUserHome ktlintCheck --stacktrace
-      env:
-        GITHUB_USER: ${{ github.actor }}
-        GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run ktlint
+        run: ./gradlew setUserHome ktlintCheck --stacktrace
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v3
-      if: success() || failure()
-      with:
-        sarif_file: shared/build/reports/ktlint
-        category: ktlint
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: success() || failure()
+        with:
+          sarif_file: shared/build/reports/ktlint
+          category: ktlint
 
   detekt:
     needs: files-changed
@@ -90,22 +90,22 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4.2.1
-    
-    - name: Setup CI
-      uses: ./.github/actions/setup-android
+      - name: Checkout
+        uses: actions/checkout@v4.2.1
 
-    - name: Run detekt
-      run: ./gradlew detekt
+      - name: Setup CI
+        uses: ./.github/actions/setup-android
 
-    - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v3
-      if: success() || failure()
-      with:
-        sarif_file: build/reports/detekt/detekt.sarif
-        category: detekt
-  
+      - name: Run detekt
+        run: ./gradlew detekt
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: success() || failure()
+        with:
+          sarif_file: build/reports/detekt/detekt.sarif
+          category: detekt
+
   swiftlint:
     needs: files-changed
     if: ${{ needs.files-changed.outputs.ios == 'true' || needs.files-changed.outputs.shared == 'true' }}
@@ -120,26 +120,26 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1.190.0
         with:
-          ruby-version: '3.3.0'
+          ruby-version: "3.3.0"
           bundler-cache: true
-          working-directory: './iosHyperskillApp'
+          working-directory: "./iosHyperskillApp"
 
       - name: Cache Pods
         uses: actions/cache@v4.1.1
         id: cache-pods
         with:
-          path: './iosHyperskillApp/Pods'
+          path: "./iosHyperskillApp/Pods"
           key: ${{ runner.os }}-pods-${{ hashFiles('iosHyperskillApp/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pods-
 
       - name: Install Pods
         if: steps.cache-pods.outputs.cache-hit != 'true'
-        working-directory: './iosHyperskillApp'
+        working-directory: "./iosHyperskillApp"
         run: bundle exec pod install
 
       - name: Run SwiftLint
-        working-directory: './iosHyperskillApp'
+        working-directory: "./iosHyperskillApp"
         run: ./lint.sh
 
   shared-unit-testing:
@@ -150,21 +150,21 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4.2.1
+      - name: Checkout
+        uses: actions/checkout@v4.2.1
 
-    - name: Setup CI
-      id: setup
-      uses: ./.github/actions/setup-android
-      with:
-        git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
+      - name: Setup CI
+        id: setup
+        uses: ./.github/actions/setup-android
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
 
-    - name: Run unit tests
-      run: ./gradlew shared:testDebugUnitTest
-      env:
-        IS_GIT_CRYPT_UNLOCKED: ${{ steps.setup.outputs.is-git-crypt-unlocked }}
-        GITHUB_USER: ${{ github.actor }}
-        GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run unit tests
+        run: ./gradlew shared:testDebugUnitTest
+        env:
+          IS_GIT_CRYPT_UNLOCKED: ${{ steps.setup.outputs.is-git-crypt-unlocked }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   android-unit-testing:
     needs: [files-changed, ktlint, detekt]
@@ -174,28 +174,28 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4.2.1
+      - name: Checkout
+        uses: actions/checkout@v4.2.1
 
-    - name: Setup CI
-      id: setup
-      uses: ./.github/actions/setup-android
-      with:
-        git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
+      - name: Setup CI
+        id: setup
+        uses: ./.github/actions/setup-android
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
 
-    - name: Run unit tests
-      run: ./gradlew androidHyperskillApp:testDebugUnitTest
-      env:
-        IS_GIT_CRYPT_UNLOCKED: ${{ steps.setup.outputs.is-git-crypt-unlocked }}
-        GITHUB_USER: ${{ github.actor }}
-        GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run unit tests
+        run: ./gradlew androidHyperskillApp:testDebugUnitTest
+        env:
+          IS_GIT_CRYPT_UNLOCKED: ${{ steps.setup.outputs.is-git-crypt-unlocked }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-ios:
     needs: swiftlint
     name: Build iOS
     runs-on: macos-14
     timeout-minutes: 30
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.1
@@ -207,10 +207,17 @@ jobs:
           git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
 
       - name: Build
-        working-directory: './iosHyperskillApp'
+        working-directory: "./iosHyperskillApp"
         run: bundle exec fastlane build install_pods:false
         env:
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
           IS_GIT_CRYPT_UNLOCKED: ${{ steps.setup.outputs.is-git-crypt-unlocked }}
           GITHUB_USER: ${{ github.actor }}
           GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload error log
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: iosHyperskillApp-iosHyperskillApp.log
+          path: /Users/runner/Library/Logs/gym/iosHyperskillApp-iosHyperskillApp.log

--- a/.github/workflows/ios_beta_deployment.yml
+++ b/.github/workflows/ios_beta_deployment.yml
@@ -63,3 +63,10 @@ jobs:
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
           GITHUB_USER: ${{ github.actor }}
           GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload error log
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: iosHyperskillApp-iosHyperskillApp.log
+          path: /Users/runner/Library/Logs/gym/iosHyperskillApp-iosHyperskillApp.log

--- a/.github/workflows/ios_release_deployment.yml
+++ b/.github/workflows/ios_release_deployment.yml
@@ -13,7 +13,7 @@ concurrency:
 defaults:
   run:
     shell: bash
-    
+
 jobs:
   # Run Gradle Wrapper Validation Action to verify the wrapper's checksum
   gradle-wrapper-validation:
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.1
-        
+
       - name: Gradle Wrapper Validation
         uses: gradle/actions/wrapper-validation@v4
 
@@ -35,26 +35,33 @@ jobs:
     timeout-minutes: 60
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4.2.1
+      - name: Checkout
+        uses: actions/checkout@v4.2.1
 
-    - name: Setup CI
-      id: setup
-      uses: ./.github/actions/setup-ios
-      with:
-        git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
-        google-cloud-storage-code-signing-certificates-key: ${{ secrets.GOOGLE_CLOUD_STORAGE_CODE_SIGNING_CERTIFICATES_KEY_CONTENT }}
+      - name: Setup CI
+        id: setup
+        uses: ./.github/actions/setup-ios
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
+          google-cloud-storage-code-signing-certificates-key: ${{ secrets.GOOGLE_CLOUD_STORAGE_CODE_SIGNING_CERTIFICATES_KEY_CONTENT }}
 
-    - name: Submit a new Release Build to App Store Connect
-      working-directory: './iosHyperskillApp'
-      run: bundle exec fastlane release install_pods:false
-      env:
-        FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
-        IS_GIT_CRYPT_UNLOCKED: ${{ steps.setup.outputs.is-git-crypt-unlocked }}
-        KEYCHAIN_NAME: ${{ secrets.KEYCHAIN_NAME }}
-        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-        APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-        APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-        APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
-        GITHUB_USER: ${{ github.actor }}
-        GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Submit a new Release Build to App Store Connect
+        working-directory: "./iosHyperskillApp"
+        run: bundle exec fastlane release install_pods:false
+        env:
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
+          IS_GIT_CRYPT_UNLOCKED: ${{ steps.setup.outputs.is-git-crypt-unlocked }}
+          KEYCHAIN_NAME: ${{ secrets.KEYCHAIN_NAME }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload error log
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: iosHyperskillApp-iosHyperskillApp.log
+          path: /Users/runner/Library/Logs/gym/iosHyperskillApp-iosHyperskillApp.log

--- a/.github/workflows/ios_unit_testing.yml
+++ b/.github/workflows/ios_unit_testing.yml
@@ -22,20 +22,27 @@ jobs:
     timeout-minutes: 60
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4.2.1
-      
-    - name: Setup CI
-      id: setup
-      uses: ./.github/actions/setup-ios
-      with:
-        git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v4.2.1
 
-    - name: Run unit tests
-      working-directory: './iosHyperskillApp'
-      run: bundle exec fastlane run_unit_tests install_pods:false
-      env:
-        FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
-        IS_GIT_CRYPT_UNLOCKED: ${{ steps.setup.outputs.is-git-crypt-unlocked }}
-        GITHUB_USER: ${{ github.actor }}
-        GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup CI
+        id: setup
+        uses: ./.github/actions/setup-ios
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
+
+      - name: Run unit tests
+        working-directory: "./iosHyperskillApp"
+        run: bundle exec fastlane run_unit_tests install_pods:false
+        env:
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
+          IS_GIT_CRYPT_UNLOCKED: ${{ steps.setup.outputs.is-git-crypt-unlocked }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload error log
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: iosHyperskillApp-iosHyperskillApp.log
+          path: /Users/runner/Library/Logs/gym/iosHyperskillApp-iosHyperskillApp.log


### PR DESCRIPTION
Resolves #1214 

**Checklist**

_Before Code Review:_

- [x] Fields "Assignees, Labels, Milestone" are filled in the pull request;
- [x] All checks have been passed;
- [x] Changes have been checked locally.

**Description**

This pull request includes several updates to the CI/CD workflows for the `iosHyperskillApp` project. The changes primarily involve standardizing the use of double quotes for strings and adding steps to upload error logs if a failure occurs.

Standardization and Consistency:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL6-R24): Changed single quotes to double quotes for string values in `on.push.branches`, `workflow_dispatch.inputs`, `jobs.setup-ruby.with`, `jobs.cache-pods.with`, `jobs.install-pods.run`, `jobs.run-swiftlint.run`, and `jobs.build.run` sections. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL6-R24) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL123-R142) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL210-R223)

Error Logging:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL210-R223): Added a step to upload error logs if a failure occurs during the build process.
* [`.github/workflows/ios_beta_deployment.yml`](diffhunk://#diff-d6a582d076d812e36427d3ac8ef74b42fa20625d1d7fa8f56cee1752d954735dR66-R72): Added a step to upload error logs if a failure occurs during the deployment process.
* [`.github/workflows/ios_release_deployment.yml`](diffhunk://#diff-251785566962690238a59f123fccc496eb24ed66823b4f1597185ea2fd2ac346L49-R49): Added a step to upload error logs if a failure occurs during the release process. [[1]](diffhunk://#diff-251785566962690238a59f123fccc496eb24ed66823b4f1597185ea2fd2ac346L49-R49) [[2]](diffhunk://#diff-251785566962690238a59f123fccc496eb24ed66823b4f1597185ea2fd2ac346R61-R67)
* [`.github/workflows/ios_unit_testing.yml`](diffhunk://#diff-72db0ce8a2eb0e7c230f401b2009cc596d163db013dc5dde3cd7426f3054a812L35-R48): Added a step to upload error logs if a failure occurs during unit testing.