### PR TITLE
iOS: Fix NSInvalidArgumentException: Required value was nil in CodePlaygroundManager.swift

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/Model/Analyze/CodePlaygroundManager.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/Model/Analyze/CodePlaygroundManager.swift
@@ -384,11 +384,11 @@ final class CodePlaygroundManager {
         }
     }
 
-    func textRangeFrom(position: Int, textView: UITextView) -> UITextRange {
-        let firstCharacterPosition = textView.beginningOfDocument
-        let characterPosition = textView.position(from: firstCharacterPosition, offset: position).require()
-        let characterRange = textView.textRange(from: characterPosition, to: characterPosition).require()
-        return characterRange
+    func textRange(from position: Int, in textView: UITextView) -> UITextRange? {
+        guard let characterPosition = textView.position(from: textView.beginningOfDocument, offset: position) else {
+            return nil
+        }
+        return textView.textRange(from: characterPosition, to: characterPosition)
     }
 
     func insertAtCurrentPosition(symbols: String, textView: UITextView) {
@@ -402,7 +402,7 @@ final class CodePlaygroundManager {
             text.insert(contentsOf: symbols, at: text.index(text.startIndex, offsetBy: cursorPosition))
             textView.text = text
             // Import here to update selectedTextRange before calling textViewDidChange #APPS-2352
-            textView.selectedTextRange = textRangeFrom(position: cursorPosition + symbols.count, textView: textView)
+            textView.selectedTextRange = textRange(from: cursorPosition + symbols.count, in: textView)
         } else {
             textView.replace(selectedRange, withText: symbols)
         }
@@ -440,8 +440,8 @@ final class CodePlaygroundManager {
             textView.delegate?.textViewDidChange?(textView)
         }
 
-        if textView.selectedTextRange != textRangeFrom(position: analyzed.position, textView: textView) {
-            textView.selectedTextRange = textRangeFrom(position: analyzed.position, textView: textView)
+        if textView.selectedTextRange != textRange(from: analyzed.position, in: textView) {
+            textView.selectedTextRange = textRange(from: analyzed.position, in: textView)
         }
 
         if let autocomplete = analyzed.autocomplete {


### PR DESCRIPTION
Resolves #1226 

This pull request includes several changes to the `CodePlaygroundManager` class in the `iosHyperskillApp` project, focusing on improving the method for converting a position to a text range in a `UITextView` and updating the method calls accordingly.

### Method Renaming and Refactoring:

* Renamed and refactored the `textRangeFrom` method to `textRange` to improve readability and return an optional `UITextRange` instead of a required one. (`iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/Model/Analyze/CodePlaygroundManager.swift`)

### Method Call Updates:

* Updated method calls to use the new `textRange` method name and handle the optional return type appropriately. (`iosHyperskillApp/iosHyperskillApp/Sources/Frameworks/CodeEditor/Model/Analyze/CodePlaygroundManager.swift`)
  * Updated the call in `insertAtCurrentPosition` to set the `selectedTextRange`.
  * Updated the call in the conditional check and assignment for `selectedTextRange`.