### PR TITLE
iOS: Fix Array Index Out of Range Exception in StepQuizMatchingViewModel.swift

### DIFF
--- a/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizMatching/StepQuizMatchingViewModel.swift
+++ b/iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizMatching/StepQuizMatchingViewModel.swift
@@ -30,8 +30,8 @@ final class StepQuizMatchingViewModel: ObservableObject, StepQuizChildQuizInputP
 
         let items = pairs.enumerated().map { index, _ in
             StepQuizMatchingViewData.MatchItem(
-                title: .init(id: index, text: pairs[index].first ?? ""),
-                option: options.first { $0.id == replyOrdering?[index] }
+                title: .init(id: index, text: pairs[safe: index]?.first ?? ""),
+                option: options.first { $0.id == replyOrdering?[safe: index] }
             )
         }
 


### PR DESCRIPTION
Resolves #1228 

This pull request includes a small but important change to the `StepQuizMatchingViewModel.swift` file. The change ensures safer access to array elements by using a custom subscript that prevents out-of-bounds errors.

* [`iosHyperskillApp/iosHyperskillApp/Sources/Modules/StepQuizSubmodules/StepQuizMatching/StepQuizMatchingViewModel.swift`](diffhunk://#diff-47d2ea53321d29e6c3d529b1db03fa2ee8855def2725d37f894a33b37e695d32L33-R34): Modified the `pairs` and `replyOrdering` array accesses to use a safe subscript, preventing potential out-of-bounds errors.