### PR TITLE
GitHub Actions: Add exempt-pr-labels for stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,4 +22,5 @@ jobs:
           stale-pr-label: 'stale'
           stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity.'
           close-pr-message: 'This PR was closed because it has been inactive for 7 days since being marked as stale.'
+          exempt-pr-labels: 'wip,help wanted,awaiting changes,awaiting review,ready to pull'
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/stale.yml` file to improve the handling of stale pull requests.

Changes to stale pull request handling:

* [`.github/workflows/stale.yml`](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894R25): Added `exempt-pr-labels` to exclude certain labels from being marked as stale.