### PR TITLE
Potential fix for code scanning alert no. 146: Useless comparison test

### DIFF
--- a/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizResolver.kt
+++ b/shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizResolver.kt
@@ -84,7 +84,7 @@ object StepQuizResolver {
             val reply = submissionState.reply ?: return false
             val visibleFilesCount = reply.solution?.count { it.isVisible } ?: 0
 
-            return visibleFilesCount > 1 || (visibleFilesCount <= 1 && reply.checkProfile?.isEmpty() == true)
+            return visibleFilesCount > 1 || reply.checkProfile?.isEmpty() == true
         }
         return false
     }


### PR DESCRIPTION
Potential fix for [https://github.com/hyperskill/mobile-app/security/code-scanning/146](https://github.com/hyperskill/mobile-app/security/code-scanning/146)

To fix the issue, we should simplify the boolean expression on line 87 within the `isIdeRequired` function. The `visibleFilesCount > 1 || (visibleFilesCount <= 1 && reply.checkProfile?.isEmpty() == true)` can be rewritten as `visibleFilesCount > 1 || reply.checkProfile?.isEmpty() == true`. This change preserves the intended logic and removes the always-true comparison. Only the block containing the return statement on line 87 (`return visibleFilesCount > 1 || (visibleFilesCount <= 1 && reply.checkProfile?.isEmpty() == true)`) needs to be modified in the file `shared/src/commonMain/kotlin/org/hyperskill/app/step_quiz/presentation/StepQuizResolver.kt`. No new imports or support code are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
