### PR TITLE
Fix YAML keys for issue and PR messages

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          issue-message: |
+          issue_message: |
             ## 👋 Welcome to Hyperskill Mobile App!
 
             Thank you for submitting your first issue! We really appreciate your interest in improving the Hyperskill mobile learning experience.
@@ -36,7 +36,7 @@ jobs:
             - 📱 Download the app: [Android](https://play.google.com/store/apps/details?id=org.hyperskill.app.android) | [iOS](https://apps.apple.com/app/my-hyperskill/id1637230833)
 
             Thanks for helping make coding education more accessible! 🚀
-          pr-message: |
+          pr_message: |
             ## 🎉 Welcome to Hyperskill Mobile App!
 
             Thank you for your first contribution! We really appreciate your effort to improve the mobile learning experience for thousands of developers worldwide.


### PR DESCRIPTION
This pull request updates the `.github/workflows/greetings.yml` workflow file to fix the configuration keys for the first interaction GitHub Action. The changes ensure the correct keys are used for specifying custom messages for issues and pull requests.

**Workflow configuration fixes:**

* Changed the `first-interaction` action input keys from `issue-message` and `pr-message` to `issue_message` and `pr_message` to match the expected configuration format. [[1]](diffhunk://#diff-6318f5fc1ff2829ebbfd7846021a98d807a3b866fcfac669187f49fa22a40702L23-R23) [[2]](diffhunk://#diff-6318f5fc1ff2829ebbfd7846021a98d807a3b866fcfac669187f49fa22a40702L39-R39)